### PR TITLE
Removing reaction_counts from message since its a reserved field

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -988,6 +988,7 @@ export class StreamChat {
 			'latest_reactions',
 			'own_reactions',
 			'reply_count',
+			'reaction_counts',
 			'created_at',
 			'updated_at',
 			'html',


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Adding the missing field - `reaction_counts` to reserved fields list to be removed from message while updating.