### PR TITLE
fixed error message and security warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
     "react/prop-types": 0,
     "no-var": 2,
     "linebreak-style": [2, "unix"],
-    "semi": [1, "always"]
+    "semi": [1, "always"],
+    "no-buffer-constructor": "error"
   },
   "env": {
     "es6": true,

--- a/src/client.js
+++ b/src/client.js
@@ -1046,14 +1046,14 @@ export class StreamChat {
 	}
 
 	_getToken() {
-		if (!this.secret && !this.userToken && !this.anonymous) {
+		if (this.secret == null && this.userToken == null && !this.anonymous) {
 			throw new Error(
 				`Both secret and user tokens are not set. Either client.setUser wasn't called or client.disconnect was called`,
 			);
 		}
 		let token = '';
 		if (!this.anonymous) {
-			token = this.userToken ? this.userToken : JWTServerToken(this.secret);
+			token = this.userToken != null ? this.userToken : JWTServerToken(this.secret);
 		}
 		return token;
 	}

--- a/src/client.js
+++ b/src/client.js
@@ -234,11 +234,17 @@ export class StreamChat {
 		// remove the user specific fields
 		delete this.user;
 		delete this._user;
-
-		delete this.anonymous;
 		delete this.userID;
-		delete this.userToken;
+
+		this.anonymous = false;
+		this.userToken = null;
+
 		this.connectionEstablishedCount = 0;
+
+		for (const channel of Object.values(this.activeChannels)) {
+			channel._disconnect();
+		}
+
 		// close the WS connection
 		if (this.wsConnection) {
 			return this.wsConnection.disconnect();

--- a/src/client.js
+++ b/src/client.js
@@ -570,12 +570,7 @@ export class StreamChat {
 			throw Error('User object is too large');
 		}
 
-		let token = '';
-
-		if (this.anonymous === false) {
-			token =
-				this.userToken !== null ? this.userToken : JWTServerToken(this.secret);
-		}
+		const token = this._getToken();
 
 		const authType = this.getAuthType();
 		client.wsURL = `${client.wsBaseURL}/connect?json=${qs}&api_key=${
@@ -1032,17 +1027,7 @@ export class StreamChat {
 	};
 
 	_addClientParams(params = {}) {
-		let token = '';
-		if (this.secret === null && this.userToken === null && this.anonymous === false) {
-			throw new Error(
-				'Both secret and user tokens are not set, did you forget to call client.setUser?',
-			);
-		}
-
-		if (this.anonymous === false) {
-			token =
-				this.userToken !== null ? this.userToken : JWTServerToken(this.secret);
-		}
+		const token = this._getToken();
 
 		return {
 			...this.options,
@@ -1058,6 +1043,19 @@ export class StreamChat {
 				'x-stream-client': this._userAgent(),
 			},
 		};
+	}
+
+	_getToken() {
+		if (!this.secret && !this.userToken && !this.anonymous) {
+			throw new Error(
+				`Both secret and user tokens are not set. Either client.setUser wasn't called or client.disconnect was called`,
+			);
+		}
+		let token = '';
+		if (!this.anonymous) {
+			token = this.userToken ? this.userToken : JWTServerToken(this.secret);
+		}
+		return token;
 	}
 
 	_startCleaning() {

--- a/src/signing.js
+++ b/src/signing.js
@@ -104,7 +104,7 @@ export function DevToken(userId) {
  * @return {boolean}
  */
 export function CheckSignature(body, secret, signature) {
-	const key = new Buffer(secret, 'ascii');
+	const key = Buffer.from(secret, 'ascii');
 	const hash = crypto
 		.createHmac('sha256', key)
 		.update(body)

--- a/test/test.js
+++ b/test/test.js
@@ -260,8 +260,7 @@ describe('Chat', function() {
 
 		describe('User is not set', function() {
 			it('device management does not work', async function() {
-				const errorMsg =
-					'Both secret and user tokens are not set, did you forget to call client.setUser?';
+				const errorMsg = `Both secret and user tokens are not set. Either client.setUser wasn't called or client.disconnect was called`;
 				await expect(client.addDevice(deviceId, 'apn')).to.be.rejectedWith(
 					errorMsg,
 				);
@@ -536,6 +535,21 @@ describe('Chat', function() {
 					name: 'Mother of dragons',
 				}),
 			);
+		});
+
+		it('Calling a method after disconnect should raise a clear error', async function() {
+			const client2 = await getTestClientForUser('bob');
+			const chan = client2.channel('messaging', uuidv4());
+			await chan.watch();
+			await client2.disconnect();
+
+			const errorMsg = `Both secret and user tokens are not set. Either client.setUser wasn't called or client.disconnect was called`;
+
+			let p = client2.addDevice('deviceID', 'apn');
+			await expect(p).to.be.rejectedWith(errorMsg);
+
+			p = chan.stopWatching();
+			await expect(p).to.be.rejectedWith(errorMsg);
 		});
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -549,7 +549,9 @@ describe('Chat', function() {
 			await expect(p).to.be.rejectedWith(errorMsg);
 
 			p = chan.stopWatching();
-			await expect(p).to.be.rejectedWith(errorMsg);
+			await expect(p).to.be.rejectedWith(
+				`You can't use a channel after client.disconnect() was called`,
+			);
 
 			const anonClient = getTestClient(false);
 			await anonClient.setAnonymousUser();

--- a/test/test.js
+++ b/test/test.js
@@ -550,6 +550,13 @@ describe('Chat', function() {
 
 			p = chan.stopWatching();
 			await expect(p).to.be.rejectedWith(errorMsg);
+
+			const anonClient = getTestClient(false);
+			await anonClient.setAnonymousUser();
+			await anonClient.disconnect();
+
+			p = anonClient.addDevice('deviceID', 'apn');
+			await expect(p).to.be.rejectedWith(errorMsg);
 		});
 	});
 


### PR DESCRIPTION
 - The behaviour in `disconnect` was causing empty tokens to be sent to the API and crytpic error messages being generated.
 - `Buffer()` is [deprecated due to security reasons](https://nodejs.org/de/docs/guides/buffer-constructor-deprecation/), so replace it accordingly and add eslint rule to prevent it from happening again 