### PR TITLE
[CHAT-275]ip based ban

### DIFF
--- a/test/serverside.js
+++ b/test/serverside.js
@@ -67,6 +67,10 @@ describe('Managing users', function() {
 	const user = {
 		id: uuidv4(),
 	};
+	const evilUser = 'evil-user' + uuidv4();
+	before(async () => {
+		await createUsers([evilUser, user.id]);
+	});
 
 	it('edit user inserts if missing', async function() {
 		await client.updateUser(user);
@@ -105,7 +109,9 @@ describe('Managing users', function() {
 	});
 
 	it('ban user', async function() {
-		await client.banUser(user.id);
+		await client.banUser(evilUser, {
+			user_id: user.id,
+		});
 	});
 
 	it('remove ban', async function() {

--- a/test/test.js
+++ b/test/test.js
@@ -824,7 +824,7 @@ describe('Chat', function() {
 				expect(channels[0].data.id).to.equal(channelID);
 			});
 
-			it.skip('Channel Filtering equal Members', async function() {
+			it('Channel Filtering equal Members', async function() {
 				const uuid = uuidv4();
 
 				const uniqueMember = `jackjones-${uuid}`;
@@ -867,7 +867,7 @@ describe('Chat', function() {
 				]);
 			});
 
-			it.skip('Channel Filtering equal Members short mode', async function() {
+			it('Channel Filtering equal Members short mode', async function() {
 				const uuid = uuidv4();
 
 				const uniqueMember = `jackjones-${uuid}`;
@@ -898,7 +898,7 @@ describe('Chat', function() {
 				]);
 			});
 
-			it.skip('Channel Filtering equal array custom field', async function() {
+			it('Channel Filtering equal array custom field', async function() {
 				const uuid = uuidv4();
 
 				const uniqueMember = `jackjones-${uuid}`;
@@ -922,7 +922,7 @@ describe('Chat', function() {
 				expect(channels2[0].data.id).to.equal(channelID);
 			});
 
-			it.skip('Channel Filtering equal Members and custom field', async function() {
+			it('Channel Filtering equal Members and custom field', async function() {
 				const uuid = uuidv4();
 
 				const uniqueMember = `jackjones-${uuid}`;
@@ -2025,6 +2025,18 @@ describe('Chat', function() {
 			role: 'user',
 		};
 
+		const moderator = {
+			id: 'eviluser-mod',
+			name: 'moderator',
+			status: 'busy',
+			image: 'myimageurl',
+			role: 'user',
+		};
+
+		before(async () => {
+			await createUsers([moderator.id]);
+		});
+
 		serverAuthClient.updateUser(evil);
 
 		it('Ban', async function() {
@@ -2032,6 +2044,7 @@ describe('Chat', function() {
 			await serverAuthClient.banUser('eviluser', {
 				timeout: 60,
 				reason: 'Stop spamming your YouTube channel',
+				user_id: moderator.id,
 			});
 		});
 		it('Mute', async function() {


### PR DESCRIPTION
- [x]  restore array match query tests
- [x]  ensure user_id is present when banning server side
- [x] add basic test to ensure that we don't ban our own IP