### PR TITLE
Fix/autocomplete test order

### DIFF
--- a/test/query_users.js
+++ b/test/query_users.js
@@ -60,8 +60,8 @@ describe('Query Users', function() {
 			id: { $in: [userID, userID2] },
 			name: { $autocomplete: 'ro' },
 		});
-		expect(response.users[0].name).to.equal('Roxanne');
-		expect(response.users[1].name).to.equal('Curiosity Rover');
+		expect(response.users[0].name).to.equal('Curiosity Rover');
+		expect(response.users[1].name).to.equal('Roxanne');
 	});
 
 	it('autocomplete users by username', async function() {

--- a/test/serverside.js
+++ b/test/serverside.js
@@ -1021,6 +1021,7 @@ describe('Channel types', function() {
 			const data = await client.channel(channelTypeName, 'test').watch();
 			const expectedData = {
 				automod: 'AI',
+				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[@username] [text]',

--- a/test/serverside.js
+++ b/test/serverside.js
@@ -895,6 +895,7 @@ describe('Channel types', function() {
 		it('should have the right defaults and name', function() {
 			const expectedData = {
 				automod: 'AI',
+				automod_behavior: 'flag',
 				commands: ['giphy', 'flag', 'ban', 'unban', 'mute', 'unmute'],
 				connect_events: true,
 				max_message_length: 5000,
@@ -939,6 +940,7 @@ describe('Channel types', function() {
 
 			const expectedData = {
 				automod: 'AI',
+				automod_behavior: 'flag',
 				commands: ['giphy', 'flag', 'ban', 'unban', 'mute', 'unmute'],
 				connect_events: true,
 				max_message_length: 5000,
@@ -986,6 +988,7 @@ describe('Channel types', function() {
 			const data = await client.channel(channelTypeName, 'test').watch();
 			const expectedData = {
 				automod: 'AI',
+				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[@username] [text]',
@@ -1156,6 +1159,7 @@ describe('Channel types', function() {
 		it('should return configs correctly', function() {
 			const expectedData = {
 				automod: 'disabled',
+				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[text]',
@@ -1230,6 +1234,7 @@ describe('Channel types', function() {
 		it('should return configs correctly for channel type messaging', function() {
 			const expectedData = {
 				automod: 'disabled',
+				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[text]',

--- a/test/serverside.js
+++ b/test/serverside.js
@@ -895,7 +895,6 @@ describe('Channel types', function() {
 		it('should have the right defaults and name', function() {
 			const expectedData = {
 				automod: 'AI',
-				automod_behavior: 'flag',
 				commands: ['giphy', 'flag', 'ban', 'unban', 'mute', 'unmute'],
 				connect_events: true,
 				max_message_length: 5000,
@@ -940,7 +939,6 @@ describe('Channel types', function() {
 
 			const expectedData = {
 				automod: 'AI',
-				automod_behavior: 'flag',
 				commands: ['giphy', 'flag', 'ban', 'unban', 'mute', 'unmute'],
 				connect_events: true,
 				max_message_length: 5000,
@@ -988,7 +986,6 @@ describe('Channel types', function() {
 			const data = await client.channel(channelTypeName, 'test').watch();
 			const expectedData = {
 				automod: 'AI',
-				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[@username] [text]',
@@ -1024,7 +1021,6 @@ describe('Channel types', function() {
 			const data = await client.channel(channelTypeName, 'test').watch();
 			const expectedData = {
 				automod: 'AI',
-				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[@username] [text]',
@@ -1159,7 +1155,6 @@ describe('Channel types', function() {
 		it('should return configs correctly', function() {
 			const expectedData = {
 				automod: 'disabled',
-				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[text]',
@@ -1234,7 +1229,6 @@ describe('Channel types', function() {
 		it('should return configs correctly for channel type messaging', function() {
 			const expectedData = {
 				automod: 'disabled',
-				automod_behavior: 'flag',
 				commands: [
 					{
 						args: '[text]',


### PR DESCRIPTION
Fixes failing QA tests due to checking response in reverse order