### PR TITLE
only start cleanup timer when connection is up

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -140,7 +140,6 @@ export class StreamChat {
 		 * }
 		 */
 		this.logger = isFunction(options.logger) ? options.logger : () => {};
-		this._startCleaning();
 	}
 
 	devToken(userID) {
@@ -160,6 +159,7 @@ export class StreamChat {
 		this.UUID = uuidv4();
 		this.clientID = `${this.userID}--${this.UUID}`;
 		this.wsPromise = this.connect();
+		this._startCleaning();
 		return this.wsPromise;
 	}
 
@@ -291,6 +291,11 @@ export class StreamChat {
 		delete this.user;
 		delete this._user;
 		delete this.userID;
+
+		if (this.cleaningIntervalRef != null) {
+			clearInterval(this.cleaningIntervalRef);
+			this.cleaningIntervalRef = null;
+		}
 
 		this.anonymous = false;
 		this.userToken = null;
@@ -1234,6 +1239,9 @@ export class StreamChat {
 
 	_startCleaning() {
 		const that = this;
+		if (this.cleaningIntervalRef != null) {
+			return;
+		}
 		this.cleaningIntervalRef = setInterval(() => {
 			// call clean on the channel, used for calling the stop.typing event etc.
 			for (const channel of Object.values(that.activeChannels)) {


### PR DESCRIPTION
Start cleaner timer only after a connection is created and clear it when `disconnect` is called
