### PR TITLE
Fix type check for readable stream

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -24,9 +24,10 @@ import pkg from '../package.json';
 
 function isReadableStream(obj) {
 	return (
+		obj !== null &&
 		typeof obj === 'object' &&
-		typeof (obj._read === 'function') &&
-		typeof (obj._readableState === 'object')
+		typeof obj._read === 'function' &&
+		typeof obj._readableState === 'object'
 	);
 }
 

--- a/test/query_users.js
+++ b/test/query_users.js
@@ -146,6 +146,6 @@ describe('Query Users', function() {
 
 		expect(mute1.user.id).eq(userID);
 		expect(mute2.user.id).eq(userID);
-		expect([mute1.target.id,mute2.target.id]).to.have.members([userID2, userID3])
+		expect([mute1.target.id, mute2.target.id]).to.have.members([userID2, userID3]);
 	});
 });


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Check was always true due to expression is evaluated first then `typeof` was returning `boolean` which true for the main boolean expression.

Added a guard for null check too. Since `typeof null === object` will return true which would break on property checks.

Other change is irrelevant - comes from prettier. 

I didn't add a test since it wasn't exported, if you guide me how to test it in terms of code layout, I'm happy to add more confidence.