### PR TITLE
fix test when members have same created_at and may be in different order

### DIFF
--- a/test/channels.js
+++ b/test/channels.js
@@ -396,9 +396,8 @@ describe('Channels - Members are update correctly', function() {
 		expect(resp.members.length).to.be.equal(3);
 		const channelState = await channel.watch();
 		expect(channelState.members.length).to.be.equal(3);
-		expect(channelState.members[0].user.id).to.be.equal(members[0].id);
-		expect(channelState.members[1].user.id).to.be.equal(members[1].id);
-		expect(channelState.members[2].user.id).to.be.equal(members[2].id);
+		const memberIDs = channelState.members.map(m => m.user.id);
+		expect(memberIDs).to.deep.members(members.map(m => m.id));
 	});
 
 	it('channel state must be updated after removing multiple members', async function() {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Sometimes members may be in different order if created_at is the same, so test is failed