### PR TITLE
Adding jsonwebtoken to external package in browser module

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,6 +23,7 @@ const externalPackages = [
 	'lodash',
 	'seamless-immutable',
 	'uuid/v4',
+	'jsonwebtoken',
 	'@babel/runtime/regenerator',
 	'@babel/runtime/helpers/asyncToGenerator',
 	'@babel/runtime/helpers/objectWithoutProperties',
@@ -71,7 +72,7 @@ const normalBundle = {
 			sourcemap: true,
 		},
 	],
-	external: externalPackages.concat(['http', 'https', 'jsonwebtoken', 'crypto']),
+	external: externalPackages.concat(['http', 'https', 'crypto']),
 	plugins: [
 		replace({
 			'process.env.NODE_ENV': JSON.stringify('production'),


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

When user tries to create userToken from client side, it fails with error `TypeError: Cannot read property 'sign' of null` at this [line](https://github.com/GetStream/stream-chat-js/blob/master/src/signing.js#L26). I guess ideally tokens are supposed to generated on server side, but this is the 2nd time I have received this error from user

1 - https://github.com/GetStream/stream-chat-react-native/issues/53
2 - Ticket [#1288](https://getstream.zendesk.com/agent/tickets/1288) on zendesk.

Following change will fix this error.
