### PR TITLE
Fix typo in types: verifyWebHook -> verifyWebhook

### DIFF
--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -254,7 +254,7 @@ export class StreamChat {
     messageID: string,
     hardDelete?: boolean,
   ): Promise<DeleteMessageAPIResponse>;
-  verifyWebHook(requestBody: object, xSignature: string): boolean;
+  verifyWebhook(requestBody: object, xSignature: string): boolean;
 }
 
 export class ClientState {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

There was a small typo in the Typescript type definitions. `verifyWebHook` should be `verifyWebhook`, which is the actual exported method in the client. 
