### PR TITLE
add test for deleteUser

### DIFF
--- a/test/gdpr.js
+++ b/test/gdpr.js
@@ -398,7 +398,7 @@ describe('GDPR endpoints', function() {
 			expect(state.messages[0].text).to.equal('hi');
 		});
 
-		it('hard delete a user without specifying mark_messages_deleted shoud fail', async function() {
+		it('hard delete a user without specifying mark_messages_deleted should fail', async function() {
 			// setup
 			const userID = uuidv4();
 			const creatorID = uuidv4();

--- a/test/gdpr.js
+++ b/test/gdpr.js
@@ -415,7 +415,7 @@ describe('GDPR endpoints', function() {
 					mark_messages_deleted: false,
 					hard_delete: true,
 				}),
-				'StreamChat error code 4: DeleteUser failed with error: "mark_messages_deleted must be specified with hard_delete"',
+				'StreamChat error code 4: DeleteUser failed with error: "mark_messages_deleted must be set together with hard_delete"',
 			);
 		});
 


### PR DESCRIPTION
Validation error is missing; we should also have validate tags for those fields

Sentry Issue: CHAT-FS

Stacktrace (most recent call first):

  File "github.com/GetStream/chat/state/pg_redis_state.go", line 1043, in (*PGRedisState).DeleteUser
    return nil, stack.Error("Can't do a hard delete without specifying mark_messages_deleted")
  File "github.com/GetStream/chat/controllers/delete_user.go", line 60, in (*DeleteUser).Handle
    removed, err := state.DeleteUser(r.Context(), chat.Auth().App(), userToRemove, request.MarkMessagesDeleted, request.HardDelete)
  File "github.com/GetStream/chat/server/server.go", line 474, in (*Server).MakeHandler.func1
    response, err := handler.Handle(ctx, w, r.WithContext(handleCtx))
  File "github.com/GetStream/chat/server/cors.go", line 42, in CorsPreFlightMiddleware.func1
    })
  File "github.com/GetStream/chat/utils/panic_recovery.go", line 23, in PanicRecoverHandler.func1
    }
  File "github.com/GetStream/chat/server/wrapper.go", line 28, in (*netHTTPResponseWriter).StatusCode
    if w.statusCode == 0 {
  File "github.com/GetStream/chat/server/server.go", line 994, in (*Server).serveConn
    atomic.AddUint32(&s.httpConns, ^uint32(0))
  File "github.com/GetStream/chat/server/server.go", line 1027, in (*Server).serveHTTP
    s.httpServer.ServeConn(conn)
...
(11 additional frame(s) were not displayed)

Can't do a hard delete without specifying mark_messages_deleted

