### PR TITLE
[CHAT-733] Fix non-default order in muting

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1125,30 +1125,46 @@ export class StreamChat {
 		});
 	}
 
+	// old: string, string?
+	// new: {user_id?, target_id}
+	getMuteParams(users, userID) {
+		if (typeof users === 'object') {
+			return users;
+		}
+		return {
+			target_id: users,
+			...(userID ? { user_id: userID } : {}),
+		};
+	}
+
 	/** muteUser - mutes a user
 	 *
-	 * @param targetID
-	 * @param [userID] Only used with serverside auth
+	 * @param {object} Object A pair of ids: muter and muted. Muter is only needed server side
+	 * example: {user_id: "A", target_id: "B"} - user A mutes user B - server side
+	 * example: {target_id: "B"} - user B is muted by the current user
+	 *
 	 * @returns {Promise<*>}
 	 */
-	async muteUser(targetID, userID = null) {
-		return await this.post(this.baseURL + '/moderation/mute', {
-			target_id: targetID,
-			...(userID ? { user_id: userID } : {}),
-		});
+	async muteUser(users, userID = null) {
+		return await this.post(
+			this.baseURL + '/moderation/mute',
+			this.getMuteParams(users, userID),
+		);
 	}
 
 	/** unmuteUser - unmutes a user
 	 *
-	 * @param targetID
-	 * @param [userID] Only used with serverside auth
+	 * @param {object} Object A pair of ids: unmuter and unmuted. Unmuter is only needed server side
+	 * example: {user_id: "A", target_id: "B"} - user A unmutes user B - server side
+	 * example: {target_id: "B"} - user B is unmuted by the current user
+	 *
 	 * @returns {Promise<*>}
 	 */
-	async unmuteUser(targetID, userID = null) {
-		return await this.post(this.baseURL + '/moderation/unmute', {
-			target_id: targetID,
-			...(userID ? { user_id: userID } : {}),
-		});
+	async unmuteUser(users, userID = null) {
+		return await this.post(
+			this.baseURL + '/moderation/unmute',
+			this.getMuteParams(users, userID),
+		);
 	}
 
 	async flagMessage(messageID) {

--- a/test/moderation.js
+++ b/test/moderation.js
@@ -38,7 +38,7 @@ describe('Moderation', function() {
 				resolve();
 			});
 		});
-		const response = await client1.muteUser(user2);
+		const response = await client1.muteUser({ target_id: user2 });
 		expect(response.mute.created_at).to.not.be.undefined;
 		expect(response.mute.updated_at).to.not.be.undefined;
 		expect(response.mute.user.id).to.equal(user1);
@@ -59,7 +59,7 @@ describe('Moderation', function() {
 		const user2 = uuidv4();
 		await createUsers([user1, user2]);
 		const client1 = await getTestClientForUser(user1);
-		const response = await client1.muteUser(user2);
+		const response = await client1.muteUser({ target_id: user2 });
 		expect(response.mute.created_at).to.not.be.undefined;
 		expect(response.mute.updated_at).to.not.be.undefined;
 		expect(response.mute.user.id).to.equal(user1);
@@ -83,7 +83,7 @@ describe('Moderation', function() {
 		const user2 = uuidv4();
 		await createUsers([user1, user2]);
 		const client1 = await getTestClientForUser(user1);
-		await client1.muteUser(user2);
+		await client1.muteUser({ target_id: user2 });
 
 		const eventPromise = new Promise(resolve => {
 			// verify that the notification is sent
@@ -94,7 +94,7 @@ describe('Moderation', function() {
 			});
 		});
 
-		await client1.unmuteUser(user2);
+		await client1.unmuteUser({ target_id: user2 });
 
 		// wait notification
 		await eventPromise;

--- a/test/query_users.js
+++ b/test/query_users.js
@@ -131,8 +131,8 @@ describe('Query Users', function() {
 			},
 		]);
 
-		await client.muteUser(userID2, userID);
-		await client.muteUser(userID3, userID);
+		await client.muteUser({ user_id: userID, target_id: userID2 });
+		await client.muteUser({ user_id: userID, target_id: userID3 });
 
 		const response = await client.queryUsers({
 			id: { $eq: userID },

--- a/test/serverside.js
+++ b/test/serverside.js
@@ -1827,10 +1827,13 @@ describe('Moderation', function() {
 
 	describe('Mutes', function() {
 		it('source user not set', async function() {
-			await expectHTTPErrorCode(400, srvClient.muteUser(targetUser));
+			await expectHTTPErrorCode(400, srvClient.muteUser({ target_id: targetUser }));
 		});
 		it('source user set', async function() {
-			const data = await srvClient.muteUser(targetUser, srcUser);
+			const data = await srvClient.muteUser({
+				user_id: srcUSer,
+				target_id: targetUser,
+			});
 			expect(data.mute.user.id).to.equal(srcUser);
 			expect(data.mute.target.id).to.equal(targetUser);
 
@@ -1846,10 +1849,13 @@ describe('Moderation', function() {
 
 	describe('Unmutes', function() {
 		it('source user not set', async function() {
-			await expectHTTPErrorCode(400, srvClient.unmuteUser(targetUser));
+			await expectHTTPErrorCode(
+				400,
+				srvClient.unmuteUser({ target_id: targetUser }),
+			);
 		});
 		it('source user set', async function() {
-			await srvClient.unmuteUser(targetUser, srcUser);
+			await srvClient.unmuteUser({ user_id: srcUser, target_id: targetUser });
 
 			const client = getTestClient(false);
 			const connectResponse = await client.setUser(

--- a/test/test.js
+++ b/test/test.js
@@ -2490,12 +2490,12 @@ describe('Chat', function() {
 			});
 		});
 		it('Mute', async function() {
-			const data = await authClient.muteUser('eviluser');
+			const data = await authClient.muteUser({ target_id: 'eviluser' });
 			expect(data.mute.user.id).to.equal('thierry2');
 			expect(data.mute.target.id).to.equal('eviluser');
 		});
 		it('Unmute', async function() {
-			const data = await authClient.unmuteUser('eviluser');
+			const data = await authClient.unmuteUser({ target_id: 'eviluser' });
 			expect(data).to.not.be.null;
 		});
 		it('Flag and Unflag a message ', async function() {

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -421,7 +421,7 @@ describe('Webhooks', function() {
 	it('moderation mute', async function() {
 		const [events] = await Promise.all([
 			promises.waitForEvents('user.muted'),
-			client.muteUser(tommasoID, jaapID),
+			client.muteUser({ user_id: jaapID, target_id: tommasoID }),
 		]);
 		const event = events[0];
 		expect(event).to.not.be.null;
@@ -450,7 +450,7 @@ describe('Webhooks', function() {
 	it('moderation unmute', async function() {
 		const [events] = await Promise.all([
 			promises.waitForEvents('user.unmuted'),
-			client.unmuteUser(tommasoID, jaapID),
+			client.unmuteUser({ user_id: jaapID, target_id: tommasoID }),
 		]);
 		const event = events[0];
 		expect(event).to.not.be.null;

--- a/types/stream-chat/api-response-tests/response-generators/client.js
+++ b/types/stream-chat/api-response-tests/response-generators/client.js
@@ -9,7 +9,7 @@ async function setUser() {
 	await utils.createUsers([user1, user2]);
 	const client1 = await utils.getTestClientForUser(user1);
 
-	await client1.muteUser(user2);
+	await client1.muteUser({ target_id: user2 });
 
 	const authClient = await utils.getTestClient(false);
 	return authClient.setUser({ id: user1 }, utils.createUserToken(user1));

--- a/types/stream-chat/api-response-tests/response-generators/moderation.js
+++ b/types/stream-chat/api-response-tests/response-generators/moderation.js
@@ -36,7 +36,7 @@ async function muteUser() {
 	await utils.createUsers([user1, user2]);
 	const client1 = await utils.getTestClientForUser(user1);
 
-	return await client1.muteUser(user2);
+	return await client1.muteUser({ target_id: user2 });
 }
 
 async function unmuteUser() {
@@ -45,8 +45,8 @@ async function unmuteUser() {
 	await utils.createUsers([user1, user2]);
 	const client1 = await utils.getTestClientForUser(user1);
 
-	await client1.muteUser(user2);
-	return await client1.unmuteUser(user2);
+	await client1.muteUser({ target_id: user2 });
+	return await client1.unmuteUser({ target_id: user2 });
 }
 async function flagUser() {
 	//flag the user

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -116,6 +116,11 @@ export interface ReactionResponse extends Reaction {
   created_at: string;
   updated_at: string;
 }
+
+export interface MuteParams {
+  user_id?: string;
+  target_id: string;
+}
 export interface StreamChatOptions {
   /**
    * extraData contains tags array attached to log message. Tags can have one/many of following values:
@@ -229,8 +234,8 @@ export class StreamChat {
   banUser(targetUserID: string, options: object): Promise<BanUserAPIResponse>;
   unbanUser(targetUserID: string, options: object): Promise<UnbanUserAPIResponse>;
 
-  muteUser(targetUserID: string): Promise<MuteAPIResponse>;
-  unmuteUser(targetUserID: string): Promise<UnmuteAPIResponse>;
+  muteUser(users: MuteParams): Promise<MuteAPIResponse>;
+  unmuteUser(users: MuteParams): Promise<UnmuteAPIResponse>;
 
   flagUser(userID: string): Promise<FlagAPIResponse>;
   unflagUser(userID: string): Promise<UnflagAPIResponse>;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
Order in muting was against default/convenience. (`target_id, user_id`)
Changed it to an object (`{user_id?, target_id}`)