### PR TITLE
Modify return type of setUser to be consistent with the vanilla js

### DIFF
--- a/types/stream-chat/api-response-tests/data.ts
+++ b/types/stream-chat/api-response-tests/data.ts
@@ -1,5 +1,5 @@
 import {
-  ConnectAPIReponse,
+  ConnectAPIResponse,
   SearchAPIResponse,
   UpdateUsersAPIResponse,
   BanUserAPIResponse,
@@ -1036,7 +1036,7 @@ export const removeMembersResponse: RemoveMembersAPIResponse = {
   members: [],
   duration: '14.56ms',
 };
-export const setUserResponse: ConnectAPIReponse = {
+export const setUserResponse: ConnectAPIResponse = {
   connection_id: '26a33f44-a679-43e9-8e71-c90014f9866e',
   cid: '*',
   type: 'health.check',

--- a/types/stream-chat/api-response-tests/index.js
+++ b/types/stream-chat/api-response-tests/index.js
@@ -7,7 +7,7 @@ const rg = require('./response-generators/index');
 let countExecutables = 0;
 
 const executables = [
-	{ f: rg.setUser, type: 'ConnectAPIReponse' },
+	{ f: rg.setUser, type: 'ConnectAPIResponse' },
 	{ f: rg.channelSearch, type: 'SearchAPIResponse' },
 	{ f: rg.updateUsers, type: 'UpdateUsersAPIResponse' },
 	{ f: rg.banUsers, type: 'BanUserAPIResponse' },

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -170,7 +170,7 @@ export class StreamChat {
   getAuthType(): string;
 
   setBaseURL(baseURL: string): void;
-  setUser(user: User, userToken: string): Promise<void>;
+  setUser(user: User, userToken: string): Promise<ConnectAPIResponse>;
 
   updateAppSettings(options: object): Promise<object>;
   getAppSettings(): Promise<object>;
@@ -617,7 +617,7 @@ export interface DeleteMessageAPIResponse extends APIResponse {
   message: MessageResponse;
 }
 
-export interface ConnectAPIReponse extends Event<HealthCheckEvent> {}
+export interface ConnectAPIResponse extends Event<HealthCheckEvent> {}
 
 export interface ChannelMemberResponse {
   user_id?: string;


### PR DESCRIPTION
Modify return type of setUser to be consistent with the vanilla js and documentation.

Unless this is the way forward considering it's a setter, the setUser function is inconsistent with the vanilla js one. 