### PR TITLE
Prevent travis test auto run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - 12
   - 13
 
-install:
+script:
   - yarn
   - yarn lint
   - yarn test-api-dts


### PR DESCRIPTION
Change install to script so that travis does only what we want.
