### PR TITLE
Allow .off() on uninitialized channels

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -769,7 +769,6 @@ export class Channel {
 	 *
 	 */
 	off(callbackOrString, callbackOrNothing) {
-		this._checkInitialized();
 		const key = callbackOrNothing ? callbackOrString : 'all';
 		const valid = isValidEventType(key);
 		if (!valid) {

--- a/test/test.js
+++ b/test/test.js
@@ -1933,6 +1933,23 @@ describe('Chat', function() {
 				);
 			}
 		});
+
+		it('should allow .off() on unwatched channels', () => {
+			const client = getTestClient(false);
+			const userID = uuidv4();
+
+			client.setUser({ id: userID }, createUserToken(userID));
+			const channel = client.channel('messaging', uuidv4());
+			let result;
+			try {
+				channel.off('message.new');
+				result = true;
+			} catch (e) {
+				result = false;
+			}
+
+			expect(result).to.be.ok;
+		});
 	});
 
 	describe('Channel State', function() {


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Currently we throw error, if someone calls .off  on uninitialized channel. I think we should just allow it!!

Its simply a cleanup. E.g., in websocket … if you call .close  on closed connection, it still allows it. It does nothing, but doesn’t throw error as well.

In components (react or RN), if the component gets unmounted before .watch() , then it results into error because of this. We can handle it on component level as well, but I think it should not throw error on client level itself 