### PR TITLE
use raw date (string value) when comparing js dates

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -559,7 +559,7 @@ export class Channel {
 	lastRead() {
 		this._checkInitialized();
 		return this.state.read[this.getClient().userID]
-			? this.state.read[this.getClient().userID].last_read
+			? this.state.read[this.getClient().userID].raw_last_read
 			: null;
 	}
 
@@ -583,7 +583,7 @@ export class Channel {
 				count++;
 				continue;
 			}
-			if (m.created_at > lastRead) {
+			if (m.raw_created_at > lastRead) {
 				count++;
 			}
 		}
@@ -606,7 +606,7 @@ export class Channel {
 				count++;
 				continue;
 			}
-			if (m.created_at > lastRead) {
+			if (m.raw_created_at > lastRead) {
 				const userID = this.getClient().userID;
 				if (m.mentioned_users.findIndex(u => u.id === userID) !== -1) {
 					count++;
@@ -809,7 +809,11 @@ export class Channel {
 			case 'message.read':
 				s.read = s.read.set(
 					event.user.id,
-					Immutable({ user: { ...event.user }, last_read: event.received_at }),
+					Immutable({
+						user: { ...event.user },
+						last_read: event.created_at,
+						raw_last_read: event.created_at,
+					}),
 				);
 				break;
 			case 'user.watching.start':
@@ -931,6 +935,7 @@ export class Channel {
 			for (const read of state.read) {
 				const parsedRead = Object.assign({ ...read });
 				parsedRead.last_read = new Date(read.last_read);
+				parsedRead.raw_last_read = read.last_read;
 				this.state.read = this.state.read.set(read.user.id, parsedRead);
 			}
 		}

--- a/src/channel.js
+++ b/src/channel.js
@@ -396,7 +396,7 @@ export class Channel {
 		const messageSlice = this.state.messages.slice(min, max).asMutable();
 
 		// sort by pk desc
-		messageSlice.sort((a, b) => b.created_at - a.created_at);
+		messageSlice.sort((a, b) => b.raw_created_at - a.raw_created_at);
 
 		let lastMessage;
 		if (messageSlice.length > 0) {

--- a/src/channel_state.js
+++ b/src/channel_state.js
@@ -44,9 +44,13 @@ export class ChannelState {
 	messageToImmutable(message) {
 		message.__html = message.html;
 		// parse the date..
-		message.raw_created_at = message.created_at;
+
+		message.raw_created_at =
+			message.raw_created_at != null ? message.raw_created_at : message.created_at;
 		message.created_at = new Date(message.created_at);
 		message.updated_at = new Date(message.updated_at);
+		console.log('message to imutable', message.raw_created_at);
+
 		if (!message.status) {
 			message.status = 'received';
 		}

--- a/src/channel_state.js
+++ b/src/channel_state.js
@@ -44,6 +44,7 @@ export class ChannelState {
 	messageToImmutable(message) {
 		message.__html = message.html;
 		// parse the date..
+		message.raw_created_at = message.created_at;
 		message.created_at = new Date(message.created_at);
 		message.updated_at = new Date(message.updated_at);
 		if (!message.status) {

--- a/src/channel_state.js
+++ b/src/channel_state.js
@@ -49,7 +49,6 @@ export class ChannelState {
 			message.raw_created_at != null ? message.raw_created_at : message.created_at;
 		message.created_at = new Date(message.created_at);
 		message.updated_at = new Date(message.updated_at);
-		console.log('message to imutable', message.raw_created_at);
 
 		if (!message.status) {
 			message.status = 'received';

--- a/test/notifications.js
+++ b/test/notifications.js
@@ -482,7 +482,7 @@ describe('Unread on connect', function() {
 		expect(chan.state.read).to.be.an('object');
 		expect(chan.state.read[thierryID]).to.be.an('object');
 		expect(chan.state.read[thierryID].user).to.be.an('object');
-		const previousLastRead = chan.state.read[thierryID].last_read;
+		const previousLastRead = chan.state.read[thierryID].raw_last_read;
 		let resp = chan.countUnread();
 		expect(resp).to.eq(1);
 		await chan.markRead();
@@ -491,7 +491,7 @@ describe('Unread on connect', function() {
 		expect(chan.state.read).to.be.an('object');
 		expect(chan.state.read[thierryID]).to.be.an('object');
 		expect(chan.state.read[thierryID].user).to.be.an('object');
-		expect(chan.state.read[thierryID].last_read).to.be.greaterThan(previousLastRead);
+		expect(chan.state.read[thierryID].raw_last_read > previousLastRead).to.be.true;
 	});
 
 	it('thierry re-connects and receive unread_count=4', async function() {


### PR DESCRIPTION
js drops datetime precision to millisecond 