### PR TITLE
Avoid duplicate reactions

### DIFF
--- a/src/channel_state.js
+++ b/src/channel_state.js
@@ -109,6 +109,11 @@ export class ChannelState {
 	}
 
 	addReaction(reaction, message) {
+		// Don't do anything if reaction already exist.
+		if (this.hasReaction(reaction, message)) {
+			return;
+		}
+
 		const { messages } = this;
 		if (!message) return;
 		const { parent_id, show_in_channel } = message;
@@ -138,6 +143,16 @@ export class ChannelState {
 				break;
 			}
 		}
+	}
+
+	hasReaction(reaction, message) {
+		if (!message.latest_reactions) return;
+
+		const index = message.latest_reactions.findIndex(
+			r => r.type === reaction.type && r.user.id === reaction.user.id,
+		);
+
+		return index > -1;
 	}
 
 	_addReactionToMessage(message, reaction) {


### PR DESCRIPTION
# Submit a pull request

## Purpose

Avoid duplication of reaction, if it already exists in channel state

## Context

This is regarding optimistic updates to UI for reactions in our react sdks. We manually add reaction to channel state 
before sending it to server ([PR](https://github.com/GetStream/stream-chat-react/pull/180)). So when we receive `reaction.new` event for that new reaction, reaction is already present in the state. With this change, we will avoid the duplication of reaction.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
