### PR TITLE
Fix types for channel, member, and user values in Event interface

### DIFF
--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -56,7 +56,7 @@ export interface Event<T = string> {
   message?: MessageResponse;
   reaction?: ReactionResponse;
   channel?: ChannelResponse;
-  member?: UserResponse;
+  member?: ChannelMemberResponse;
   user?: UserResponse;
   user_id?: string;
   me?: OwnUserResponse;

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -55,9 +55,9 @@ export interface Event<T = string> {
   type: T;
   message?: MessageResponse;
   reaction?: ReactionResponse;
-  channel?: Channel;
-  member?: User;
-  user?: User;
+  channel?: ChannelResponse;
+  member?: UserResponse;
+  user?: UserResponse;
   user_id?: string;
   me?: OwnUserResponse;
   watcher_count?: number;

--- a/types/stream-chat/test-stream-chat.ts
+++ b/types/stream-chat/test-stream-chat.ts
@@ -77,8 +77,8 @@ const event = {
     updated_at: '',
     score: 10,
   },
-  member: { id: 'john' },
-  user: { id: 'john' },
+  member: { id: 'john', online: false },
+  user: { id: 'john', online: true },
   unread_count: 3,
   online: true,
 };

--- a/types/stream-chat/test-stream-chat.ts
+++ b/types/stream-chat/test-stream-chat.ts
@@ -77,7 +77,7 @@ const event = {
     updated_at: '',
     score: 10,
   },
-  member: { id: 'john', online: false },
+  member: { user_id: 'john' },
   user: { id: 'john', online: true },
   unread_count: 3,
   online: true,


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fixed TypeScript interface definition for Event to reflect actual types of `ChannelResponse` and `UserResponse` API response objects instead of the `Channel` and `User` classes.