### PR TITLE
Fix TypeScript definition for Channel.update()

### DIFF
--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -391,7 +391,7 @@ export class Channel {
 
   update(
     channelData: ChannelData,
-    updateMessage: Message,
+    updateMessage?: Message,
   ): Promise<UpdateChannelAPIResponse>;
   delete(): Promise<DeleteChannelAPIResponse>;
   search(query: string | object, options: object): Promise<SearchAPIResponse>;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

`Channel.update()` defines the `updateMessage` parameter as optional, and the underlying REST API allows it to be omitted as well. Fixed the TypeScript definition to allow the message to be omitted.