### PR TITLE
Forcefully closing the ws connection, if close frame gets delayed

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -178,17 +178,26 @@ export class StableWSConnection {
 		const { ws } = this;
 		if (ws && ws.close && ws.readyState === ws.OPEN) {
 			isClosedPromise = new Promise(resolve => {
-				ws.onclose = () => {
+				const onclose = event => {
 					this.logger(
 						'info',
-						`connection:disconnect() - resolving isClosedPromise`,
+						`connection:disconnect() - resolving isClosedPromise ${
+							event ? 'with' : 'without'
+						} close frame`,
 						{
 							tags: ['connection'],
+							event,
 						},
 					);
 					resolve();
 				};
+
+				ws.onclose = onclose;
+				// In case we don't receive close frame websocket server in time,
+				// lets not wait for more than 2 seconds.
+				setTimeout(onclose, 2000);
 			});
+
 			this.logger(
 				'info',
 				`connection:disconnect() - Manually closed connection by calling client.disconnect()`,

--- a/src/connection.js
+++ b/src/connection.js
@@ -194,8 +194,8 @@ export class StableWSConnection {
 
 				ws.onclose = onclose;
 				// In case we don't receive close frame websocket server in time,
-				// lets not wait for more than 2 seconds.
-				setTimeout(onclose, 2000);
+				// lets not wait for more than 1 seconds.
+				setTimeout(onclose, 1000);
 			});
 
 			this.logger(


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

Feeld is facing some issue where ws just keeps waiting for close frame after manually disconnecting the ws. Its something we definitely need to fix on backend (as discussed with @thesyncim ). But we should not infinitely wait for it, in case there are delays. 

So forcefully resolving disconnection promise, if we don't receive close frame from backend within 2 seconds!