### PR TITLE
Handling token expiration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -93,6 +93,14 @@ export class StreamChat {
 		this.configs = {};
 		this.anonymous = false;
 
+		// If its a server-side client, then lets initialize the tokenManager, since token will be
+		// generated from secret.
+		if (this.secret) {
+			this.tokenManager = new TokenManager({
+				secret: this.secret,
+			});
+		}
+
 		/**
 		 * logger function should accept 3 parameters:
 		 * @param logLevel string
@@ -375,6 +383,7 @@ export class StreamChat {
 		if (exp != null) {
 			extra.exp = exp;
 		}
+
 		return JWTUserToken(this.secret, userID, extra, {});
 	}
 

--- a/src/client.js
+++ b/src/client.js
@@ -313,6 +313,8 @@ export class StreamChat {
 		this.activeChannels = {};
 		// reset client state
 		this.state = new ClientState();
+		// reset token manager
+		this.tokenManager = new TokenManager({ secret: this.secret });
 
 		// close the WS connection
 		if (this.wsConnection) {

--- a/src/client.js
+++ b/src/client.js
@@ -202,12 +202,7 @@ export class StreamChat {
 	};
 
 	_setToken = async (user, userTokenOrProvider) => {
-		this.tokenManager = new TokenManager({
-			tokenOrProvider: userTokenOrProvider,
-			secret: this.secret,
-			user,
-		});
-		await this.tokenManager.loadToken();
+		await this.tokenManager.setTokenOrProvider(userTokenOrProvider, user);
 	};
 
 	_setUser(user) {
@@ -314,7 +309,7 @@ export class StreamChat {
 		// reset client state
 		this.state = new ClientState();
 		// reset token manager
-		this.tokenManager = new TokenManager({ secret: this.secret });
+		this.tokenManager.expire();
 
 		// close the WS connection
 		if (this.wsConnection) {

--- a/src/client.js
+++ b/src/client.js
@@ -165,13 +165,13 @@ export class StreamChat {
 		this.wsBaseURL = this.baseURL.replace('http', 'ws');
 	}
 
-	_setupConnection() {
+	_setupConnection = () => {
 		this.UUID = uuidv4();
 		this.clientID = `${this.userID}--${this.UUID}`;
 		this.wsPromise = this.connect();
 		this._startCleaning();
 		return this.wsPromise;
-	}
+	};
 
 	_hasConnectionID = () => Boolean(this.connectionID);
 
@@ -209,7 +209,6 @@ export class StreamChat {
 			secret: this.secret,
 			user,
 		});
-
 		await this.tokenManager.loadToken();
 	};
 
@@ -325,7 +324,7 @@ export class StreamChat {
 		return Promise.resolve();
 	}
 
-	setAnonymousUser() {
+	setAnonymousUser = async () => {
 		this.anonymous = true;
 		this.userID = uuidv4();
 		const anonymousUser = {
@@ -333,11 +332,11 @@ export class StreamChat {
 			anon: true,
 		};
 
-		this._setToken(anonymousUser, '');
+		await this._setToken(anonymousUser, '');
 		this._setUser(anonymousUser);
 
 		return this._setupConnection();
-	}
+	};
 
 	/**
 	 * setGuestUser - Setup a temporary guest user
@@ -346,7 +345,7 @@ export class StreamChat {
 	 *
 	 * @return {promise} Returns a promise that resolves when the connection is setup
 	 */
-	async setGuestUser(user) {
+	setGuestUser = async user => {
 		let response;
 		this.anonymous = true;
 		try {
@@ -364,7 +363,7 @@ export class StreamChat {
 			...guestUser
 		} = response.user;
 		return await this.setUser(guestUser, response.access_token);
-	}
+	};
 
 	/**
 	 * createToken - Creates a token to authenticate this user. This function is used server side.
@@ -1356,6 +1355,8 @@ export class StreamChat {
 	}
 
 	_getToken() {
+		if (!this.tokenManager) return null;
+
 		return this.tokenManager.getToken();
 	}
 

--- a/src/client.js
+++ b/src/client.js
@@ -95,11 +95,9 @@ export class StreamChat {
 
 		// If its a server-side client, then lets initialize the tokenManager, since token will be
 		// generated from secret.
-		if (this.secret) {
-			this.tokenManager = new TokenManager({
-				secret: this.secret,
-			});
-		}
+		this.tokenManager = new TokenManager({
+			secret: this.secret,
+		});
 
 		/**
 		 * logger function should accept 3 parameters:
@@ -801,7 +799,7 @@ export class StreamChat {
 		this.wsConnection = new StableWSConnection({
 			wsBaseURL: client.wsBaseURL,
 			tokenManager: client.tokenManager,
-			user: this.user,
+			user: this._user,
 			authType: this.getAuthType(),
 			userAgent: this._userAgent(),
 			apiKey: this.key,

--- a/src/connection.js
+++ b/src/connection.js
@@ -102,7 +102,11 @@ export class StableWSConnection {
 			this.isConnecting = false;
 			this.isHealthy = false;
 			this.consecutiveFailures += 1;
-			if (error.code === chatCodes.TOKEN_EXPIRED && !this.tokenManager.isStatic()) {
+			const _error = JSON.parse(error.message);
+			if (
+				_error.code === chatCodes.TOKEN_EXPIRED &&
+				!this.tokenManager.isStatic()
+			) {
 				this.logger(
 					'info',
 					'connection:connect() - WS failure due to expired token, so going to try to reload token and reconnect',

--- a/src/connection.js
+++ b/src/connection.js
@@ -116,10 +116,10 @@ export class StableWSConnection {
 				return false;
 			}
 
-			// if (!error.isWSFailure) {
-			// 	// This is a permanent failure, throw the error...
-			// 	throw error;
-			// }
+			if (!error.isWSFailure) {
+				// This is a permanent failure, throw the error...
+				throw error;
+			}
 		}
 	}
 
@@ -132,7 +132,6 @@ export class StableWSConnection {
 		};
 		const qs = encodeURIComponent(JSON.stringify(params));
 		const token = this.tokenManager.getToken();
-
 		return `${this.wsBaseURL}/connect?json=${qs}&api_key=${this.apiKey}&authorization=${token}&stream-auth-type=${this.authType}&x-stream-client=${this.userAgent}`;
 	};
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,5 +1,5 @@
 import isoWS from 'isomorphic-ws';
-import { sleep } from './utils';
+import { sleep, chatCodes } from './utils';
 /**
  * StableWSConnection - A WS connection that reconnects upon failure.
  * - the browser will sometimes report that you're online or offline
@@ -102,7 +102,7 @@ export class StableWSConnection {
 			this.isConnecting = false;
 			this.isHealthy = false;
 			this.consecutiveFailures += 1;
-			if (error.code === 40 && !this.tokenManager.isStatic()) {
+			if (error.code === chatCodes.TOKEN_EXPIRED && !this.tokenManager.isStatic()) {
 				this.logger(
 					'info',
 					'connection:connect() - WS failure due to expired token, so going to try to reload token and reconnect',
@@ -194,7 +194,10 @@ export class StableWSConnection {
 				},
 			);
 
-			ws.close(1000, 'Manually closed connection by calling client.disconnect()');
+			ws.close(
+				chatCodes.WS_CLOSED_SUCCESS,
+				'Manually closed connection by calling client.disconnect()',
+			);
 		} else {
 			this.logger(
 				'info',
@@ -320,7 +323,7 @@ export class StableWSConnection {
 			this.isHealthy = false;
 			this.consecutiveFailures += 1;
 
-			if (error.code === 40 && !this.tokenManager.isStatic()) {
+			if (error.code === chatCodes.TOKEN_EXPIRED && !this.tokenManager.isStatic()) {
 				this.logger(
 					'info',
 					'connection:_reconnect() - WS failure due to expired token, so going to try to reload token and reconnect',
@@ -427,7 +430,7 @@ export class StableWSConnection {
 
 		if (this.wsID !== wsID) return;
 
-		if (event.code === 1000) {
+		if (event.code === chatCodes.WS_CLOSED_SUCCESS) {
 			// this is a permanent error raised by stream..
 			// usually caused by invalid auth details
 			const error = new Error(`WS connection reject with error ${event.reason}`);

--- a/src/connection.js
+++ b/src/connection.js
@@ -604,7 +604,7 @@ export class StableWSConnection {
 		}).then(e => {
 			const data = JSON.parse(e.data);
 			if (data.error != null) {
-				throw data.error;
+				throw new Error(JSON.stringify(data.error));
 			}
 			return data;
 		});

--- a/src/connection.js
+++ b/src/connection.js
@@ -223,6 +223,7 @@ export class StableWSConnection {
 	 * @return {promise} Promise that completes once the first health check message is received
 	 */
 	async _connect() {
+		await this.tokenManager.tokenReady();
 		this._setupConnectionPromise();
 		const wsURL = this._buildUrl();
 		this.ws = new isoWS(wsURL);

--- a/src/token_manager.js
+++ b/src/token_manager.js
@@ -1,0 +1,59 @@
+import { UserFromToken, JWTServerToken } from './signing';
+import { isFunction } from './utils';
+
+export class TokenManager {
+	constructor({ tokenOrProvider, user, secret }) {
+		this.secret = secret;
+		this.user = user;
+
+		if (tokenOrProvider == null && this.secret === null) {
+			throw new Error('both userToken and api secret are not provided');
+		}
+
+		if (tokenOrProvider == null && this.secret != null) {
+			this.token = this.createToken(this.userID);
+		} else if (isFunction(tokenOrProvider)) {
+			this.tokenProvider = tokenOrProvider;
+			this.type = 'provider';
+		} else if (typeof tokenOrProvider === 'string') {
+			this.token = tokenOrProvider;
+			this.type = 'static';
+
+			const tokenUserId = UserFromToken(this.token);
+			if (
+				this.token != null &&
+				(tokenUserId == null || tokenUserId === '' || tokenUserId !== user.id)
+			) {
+				throw new Error(
+					'userToken does not have a user_id or is not matching with user.id',
+				);
+			}
+		} else {
+			throw new Error('user token is invalid');
+		}
+	}
+
+	loadToken = async () => {
+		if (this.type === 'static') {
+			return Promise.resolve();
+		}
+
+		this.token = await this.tokenProvider();
+	};
+
+	getToken = () => {
+		if (this.secret == null && this.token == null) {
+			throw new Error(
+				`Both secret and user tokens are not set. Either client.setUser wasn't called or client.disconnect was called`,
+			);
+		}
+
+		if (this.token !== null) {
+			return this.token;
+		}
+
+		return JWTServerToken(this.secret);
+	};
+
+	isStatic = () => this.type === 'static';
+}

--- a/src/token_manager.js
+++ b/src/token_manager.js
@@ -42,7 +42,17 @@ export class TokenManager {
 	}
 
 	// Validates the user token.
-	validateToken = (tokenOrProvider, user, secret) => {
+	validateToken = (tokenOrProvider, user) => {
+		if (user && user.anon && tokenOrProvider === '') return;
+
+		if (
+			tokenOrProvider &&
+			typeof tokenOrProvider !== 'string' &&
+			!isFunction(tokenOrProvider)
+		) {
+			throw new Error('user token should either be a string or a function');
+		}
+
 		if (typeof tokenOrProvider === 'string') {
 			// Allow empty token for anonymous users
 			if (user.anon && tokenOrProvider === '') return;
@@ -56,23 +66,7 @@ export class TokenManager {
 					'userToken does not have a user_id or is not matching with user.id',
 				);
 			}
-
-			return;
 		}
-
-		if (isFunction(tokenOrProvider)) {
-			return;
-		}
-
-		if (!tokenOrProvider) {
-			if (!secret) {
-				throw new Error('both userToken and api secret are not provided');
-			}
-
-			return;
-		}
-
-		throw new Error('user token should either be a string or a function');
 	};
 
 	loadToken = async () => {

--- a/src/token_manager.js
+++ b/src/token_manager.js
@@ -20,9 +20,19 @@ export class TokenManager {
 	 * - user {object}
 	 * - secret {string}
 	 */
-	constructor({ tokenOrProvider, user, secret }) {
-		this.validateToken(tokenOrProvider, user, secret);
-		this.secret = secret;
+	constructor(options) {
+		if (options && options.secret) {
+			this.secret = options.secret;
+		}
+		this.type = 'static';
+
+		if (this.secret) {
+			this.token = JWTServerToken(this.secret);
+		}
+	}
+
+	setTokenOrProvider = async (tokenOrProvider, user) => {
+		this.validateToken(tokenOrProvider, user);
 		this.user = user;
 
 		if (isFunction(tokenOrProvider)) {
@@ -39,7 +49,14 @@ export class TokenManager {
 			this.token = JWTUserToken(this.secret, user.id, {}, {});
 			this.type = 'static';
 		}
-	}
+
+		await this.loadToken();
+	};
+
+	expire = () => {
+		this.token = null;
+		this.user = null;
+	};
 
 	// Validates the user token.
 	validateToken = (tokenOrProvider, user) => {

--- a/src/token_manager.js
+++ b/src/token_manager.js
@@ -75,6 +75,8 @@ export class TokenManager {
 		}
 
 		this.token = await this.tokenProvider();
+
+		return this.token;
 	};
 
 	getToken = () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,3 +27,8 @@ export function isFunction(value) {
 			value instanceof Function)
 	);
 }
+
+export const chatCodes = {
+	TOKEN_EXPIRED: 40,
+	WS_CLOSED_SUCCESS: 1000,
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,3 +18,12 @@ export function logChatPromiseExecution(promise, name) {
 }
 
 export const sleep = m => new Promise(r => setTimeout(r, m));
+
+export function isFunction(value) {
+	return (
+		value &&
+		(Object.prototype.toString.call(value) === '[object Function]' ||
+			'function' === typeof value ||
+			value instanceof Function)
+	);
+}

--- a/test/connection.js
+++ b/test/connection.js
@@ -6,30 +6,52 @@ import uuidv4 from 'uuid/v4';
 import chai from 'chai';
 const expect = chai.expect;
 import sinon from 'sinon';
+import { TokenManager } from '../src/token_manager';
 
 const wsBaseURL = process.env.STREAM_LOCAL_TEST_RUN
 	? 'ws://localhost:3030'
 	: 'wss://chat-us-east-1.stream-io-api.com';
 
-// const validURL = `${wsBaseURL}/connect?json=%7B%22client_id%22%3A%22thierry--b853403e-1f7c-4425-bd43-be8e4dda41ae%22%2C%22user_id%22%3A%22thierry%22%2C%22user_details%22%3A%7B%22id%22%3A%22thierry%22%7D%2C%22user_token%22%3A%22eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.EJ6poZ2UbnJJvbCi6ZiImeEPeIoXVEBSdZN_-2YC3t0%22%7D&api_key=qk4nn7rpcn75&authorization=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9./eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.EJ6poZ2UbnJJvbCi6ZiImeEPeIoXVEBSdZN_-2YC3t0&stream-auth-type=jwt`;
-const validURL = `${wsBaseURL}/connect?json=%7B%22client_id%22%3A%22thierry--b853403e-1f7c-4425-bd43-be8e4dda41ae%22%2C%22user_id%22%3A%22thierry%22%2C%22user_details%22%3A%7B%22id%22%3A%22thierry%22%7D%2C%22user_token%22%3A%22eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.EJ6poZ2UbnJJvbCi6ZiImeEPeIoXVEBSdZN_-2YC3t0%22%2C%22server_determines_connection_id%22%3Atrue%7D&api_key=qk4nn7rpcn75&authorization=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.EJ6poZ2UbnJJvbCi6ZiImeEPeIoXVEBSdZN_-2YC3t0&stream-auth-type=jwt`;
+const tokenManagerWithProvider = new TokenManager({
+	tokenOrProvider: () =>
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSIsImV4cCI6MTU4ODc5MzQ4MH0.At-JGwdxIvz6ItYBSetljYCZBCMRRtuNd6KPPkwSxHk',
+	user: { id: 'thierry' },
+});
 
-const emptyAuthURL = `${wsBaseURL}/connect?json=%7B%22client_id%22%3A%22thierry--b853403e-1f7c-4425-bd43-be8e4dda41ae%22%2C%22user_id%22%3A%22thierry%22%2C%22user_details%22%3A%7B%22id%22%3A%22thierry%22%7D%2C%22user_token%22%3A%22eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.EJ6poZ2UbnJJvbCi6ZiImeEPeIoXVEBSdZN_-2YC3t0%22%2C%22server_determines_connection_id%22%3Atrue%7D&api_key=qk4nn7rpcn75&authorization=&stream-auth-type=`;
+const tokenManagerStatic_validToken = new TokenManager({
+	tokenOrProvider:
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSIsImV4cCI6MjQwMDE1ODg3OTk2MzF9.vJsAQxuV4OABR2VTLc2NIUFzVIazAnnB31FajUxf-ws',
+	user: { id: 'thierry' },
+});
 
-function createTestWSConnection(wsURL) {
+const tokenManagerStatic_expiredToken = new TokenManager({
+	tokenOrProvider:
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSIsImV4cCI6MTU4ODgzOTg2NH0.RHfcNuX-FkitL3ne-KS2whFGbU7lJFkMpgiF_g8DhHI',
+	user: { id: 'thierry' },
+});
+
+function createTestWSConnection(options) {
 	const conn = new StableWSConnection({
-		wsURL,
-		clientID: 'thierry--b853403e-1f7c-4425-bd43-be8e4dda41ae',
+		wsBaseURL,
 		userID: 'thierry',
+		user: { id: 'thierry' },
+		tokenManager: tokenManagerStatic_validToken,
+		apiKey: '892s22ypvt6m',
+		authType: 'jwt',
+		userAgent: '',
 		messageCallback: sinon.fake(),
 		recoverCallback: sinon.fake(),
 		eventCallback: sinon.fake(),
-		logger: () => {},
+		logger: (type, msg) => {
+			// console.log(msg);
+		},
+		...options,
 	});
 	// disable the retry interval to speedup tests
 	conn._retryInterval = function() {
 		return 10;
 	};
+
 	return conn;
 }
 
@@ -75,7 +97,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Connect', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		const result = healthCheck;
 		expect(result.type).to.equal('health.check');
@@ -85,7 +107,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Connect twice should fail', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		try {
 			const healthCheck2 = await conn.connect();
@@ -96,7 +118,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Reconnect', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		conn.isHealthy = false;
 		const open2 = await conn._reconnect();
@@ -110,7 +132,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Reconnect with a code bug should not trigger infinite loop', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		const original = conn._retryInterval;
 		conn._retryInterval = function() {
@@ -127,7 +149,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Reconnect with a code bug should not trigger infinite loop part 2', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		conn._connect = function() {
 			throw new Error('stuff is broken in the connect');
@@ -141,7 +163,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Connection closed', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		expect(conn.isConnecting).to.equal(false);
 		// fake a connection closed... should trigger a reconnect...
@@ -157,14 +179,13 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Connection error', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		expect(conn.isConnecting).to.equal(false);
 		// fake a connection error... should trigger a reconnect
 		conn.onerror(conn.wsID, { text: 'a test error' });
 
 		await sleep(1000);
-
 		expect(conn.consecutiveFailures).to.equal(0);
 		expect(conn.totalFailures).to.equal(1);
 		expect(conn.wsID).to.equal(2);
@@ -174,7 +195,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Health check failure', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		expect(conn.isConnecting).to.equal(false);
 		// fake a health check failure...
@@ -189,7 +210,7 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Browser offline', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		const healthCheck = await conn.connect();
 		expect(conn.isConnecting).to.equal(false);
 		conn.onlineStatusChanged({ type: 'offline' });
@@ -206,15 +227,21 @@ describe('Connection and reconnect behaviour', function() {
 	});
 
 	it('Connect auth error', function(done) {
-		const conn = createTestWSConnection(emptyAuthURL);
-		// this should fail since auth details are invalid
-		conn.connect().catch(e => {
+		try {
+			const conn = createTestWSConnection({
+				tokenManager: new TokenManager({
+					tokenOrProvider: '',
+					user: { id: 'thierry' },
+				}),
+				authType: '',
+			});
+		} catch (e) {
 			done();
-		});
+		}
 	});
 
 	it('Disconnect', async function() {
-		const conn = createTestWSConnection(validURL);
+		const conn = createTestWSConnection();
 		await conn.connect();
 		expect(conn.isConnecting).to.equal(false);
 		const wsID = conn.wsID;
@@ -222,5 +249,27 @@ describe('Connection and reconnect behaviour', function() {
 		expect(conn.isHealthy).to.equal(false);
 		expect(conn.wsID).to.equal(wsID + 1);
 		expect(conn.ws).to.equal(undefined);
+	});
+
+	it('Expired static tokens should fail', done => {
+		const conn = createTestWSConnection({
+			tokenManager: tokenManagerStatic_expiredToken,
+		});
+
+		// this should fail since auth details are invalid
+		conn.connect().catch(e => {
+			done();
+		});
+	});
+
+	it('Provider based expired tokens should should invoke loadToken and reconnect', async () => {
+		const conn = createTestWSConnection({ tokenManager: tokenManagerWithProvider });
+		await conn.tokenManager.loadToken();
+
+		conn._reconnect = sinon.fake();
+		conn.connect();
+
+		await sleep(1000);
+		expect(conn._reconnect.calledWith({ refreshToken: true })).to.equal(true);
 	});
 });

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,6 +1,6 @@
 import { StableWSConnection } from '../src/connection';
 import { sleep } from '../src/utils';
-import { getTestClientForUser } from './utils';
+import { getTestClientForUser, getTestClient, createUserToken } from './utils';
 import uuidv4 from 'uuid/v4';
 
 import chai from 'chai';
@@ -14,7 +14,7 @@ const wsBaseURL = process.env.STREAM_LOCAL_TEST_RUN
 
 const tokenManagerWithProvider = new TokenManager({
 	tokenOrProvider: () =>
-		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSIsImV4cCI6MTU4ODc5MzQ4MH0.At-JGwdxIvz6ItYBSetljYCZBCMRRtuNd6KPPkwSxHk',
+		'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSIsImV4cCI6MTU4ODkzMzY5OX0.4v5WiQDBtkM3dNQXewRf5or6seuSj0XT5v21yZqgCAU',
 	user: { id: 'thierry' },
 });
 
@@ -271,5 +271,17 @@ describe('Connection and reconnect behaviour', function() {
 
 		await sleep(1000);
 		expect(conn._reconnect.calledWith({ refreshToken: true })).to.equal(true);
+	});
+
+	it.only('Http request with expired token should reload token', async () => {
+		const client = getTestClient(false);
+		await client.setUser({ id: 'thierry' }, () => createUserToken('thierry', 1));
+
+		await sleep(2000);
+		const channel = client.channel('messaging', 'fjsdbfjsbdjfsbhjdbfhjdf');
+		channel.create();
+		client.tokenManager.loadToken = sinon.fake();
+		await sleep(2000);
+		expect(client.tokenManager.loadToken.called).to.equal(true);
 	});
 });

--- a/test/token_manager.js
+++ b/test/token_manager.js
@@ -1,0 +1,83 @@
+/* eslint no-unused-vars: "off" */
+
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import chaiLike from 'chai-like';
+
+import assertArrays from 'chai-arrays';
+
+import uuidv4 from 'uuid/v4';
+import { TokenManager } from '../src/token_manager';
+import sinon from 'sinon';
+
+const expect = chai.expect;
+chai.use(assertArrays);
+chai.use(chaiAsPromised);
+chai.use(chaiLike);
+
+describe('token_manager', function() {
+	it('allows empty token for server side client', () => {
+		const tm = new TokenManager({ secret: uuidv4() });
+		tm.getToken();
+	});
+
+	it('allows empty token for anonymous user', async () => {
+		const tm = new TokenManager();
+
+		await tm.setTokenOrProvider(null, { id: 'vishal', anon: true });
+		tm.getToken();
+	});
+
+	it('fails for empty token for non-server side client', async () => {
+		const tm = new TokenManager();
+		try {
+			await tm.setTokenOrProvider(null, { id: 'vishal' });
+		} catch (e) {
+			// nothing
+			return;
+		}
+
+		throw Error('setTokenOrProvider should have failed');
+	});
+
+	it('fails for non-string and non-function token', async () => {
+		const tm = new TokenManager();
+		try {
+			await tm.setTokenOrProvider(true, { id: 'vishal' });
+		} catch (e) {
+			// nothing
+			return;
+		}
+
+		throw Error('setTokenOrProvider should have failed');
+	});
+
+	it('should call `tokenProvider` upon `loadToken`', async () => {
+		const tm = new TokenManager();
+		const tokenPrvider = sinon.fake();
+		await tm.setTokenOrProvider(tokenPrvider, { id: 'vishal' });
+
+		tm.loadToken();
+		expect(tokenPrvider.called).to.equal(true);
+	});
+
+	it('`tokenReady()` should resolve when `loadToken()` is finished', async () => {
+		const tm = new TokenManager();
+		let didLoadTokenResolve;
+		const tokenPrvider = () =>
+			new Promise(resolve => {
+				setTimeout(() => {
+					didLoadTokenResolve = true;
+					resolve('demo_token');
+				}, 300);
+			});
+
+		await tm.setTokenOrProvider(tokenPrvider, { id: 'vishal' });
+
+		didLoadTokenResolve = false;
+		tm.loadToken();
+		expect(didLoadTokenResolve).to.equal(false);
+		await tm.tokenReady();
+		expect(didLoadTokenResolve).to.equal(true);
+	});
+});


### PR DESCRIPTION
# Submit a pull request

## Usage

### Static token

```js
client.setUser({id: 'vishal'}, 'token');
```

### Token provider

```js
client.setUser({id: 'vishal'}, async () => {
    // const token = await api.fetchToken();
    return token;
});
```

## Description

- New class - `TokenManager`, which will be a common place to access token from for client and connection class.
- When ws connection fails with error code `40`, the token will be refreshed using tokenProvider function (given to `setUser` function) and connection request will be retried.
- When http request fails with error code `40`, the token will be refreshed using tokenProvider function (given to `setUser` function) and connection request will be retried.

## TODO

- [x] Handle error from ws connection about expired token
- [x] Handle error from http request about expired token
- [x] Handle the case of guest users
- [x] Handle the case of anonymous users
- [x] tests
- [ ] docs

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
