### PR TITLE
[CHAT-976] queryMembers

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -161,7 +161,7 @@ export class Channel {
 	/**
 	 * search - Query Members
 	 *
-	 * @param {object|string}  filterConditions object MongoDB style filters
+	 * @param {object}  filterConditions object MongoDB style filters
 	 * @param {object} sort             Sort options, for instance {created_at: -1}
 	 * @param {object} options        Option object, {limit: 10, offset:10}
 	 *

--- a/src/channel.js
+++ b/src/channel.js
@@ -159,6 +159,18 @@ export class Channel {
 	}
 
 	/**
+	 * search - Query Members
+	 *
+	 * @param {object|string}  member search query or object MongoDB style filters
+	 * @param {object} options       Option object, {limit: 10}
+	 *
+	 * @return {object} search messages response
+	 */
+	async queryMembers(query, options = {}) {
+		return await this.getClient().queryMembers(this.cid, query, options);
+	}
+
+	/**
 	 * sendReaction - Send a reaction about a message
 	 *
 	 * @param {string} messageID the message id

--- a/src/channel.js
+++ b/src/channel.js
@@ -162,13 +162,15 @@ export class Channel {
 	 * search - Query Members
 	 *
 	 * @param {object|string}  filterConditions object MongoDB style filters
+	 * @param {object} sort             Sort options, for instance {created_at: -1}
 	 * @param {object} options        Option object, {limit: 10, offset:10}
 	 *
 	 * @return {object} search members response
 	 */
-	async queryMembers(filterConditions, options = {}) {
-		if (!options) {
-			options = {};
+	async queryMembers(filterConditions, sort = {}, options = {}) {
+		const sortFields = [];
+		for (const [k, v] of Object.entries(sort)) {
+			sortFields.push({ field: k, direction: v });
 		}
 		let id;
 		const type = this.type;
@@ -184,6 +186,7 @@ export class Channel {
 				type,
 				id,
 				members,
+				sort: sortFields,
 				filter_conditions: filterConditions,
 				...options,
 			},

--- a/src/channel.js
+++ b/src/channel.js
@@ -161,13 +161,33 @@ export class Channel {
 	/**
 	 * search - Query Members
 	 *
-	 * @param {object|string}  member search query or object MongoDB style filters
-	 * @param {object} options       Option object, {limit: 10}
+	 * @param {object|string}  filterConditions object MongoDB style filters
+	 * @param {object} options        Option object, {limit: 10, offset:10}
 	 *
-	 * @return {object} search messages response
+	 * @return {object} search members response
 	 */
-	async queryMembers(query, options = {}) {
-		return await this.getClient().queryMembers(this.cid, query, options);
+	async queryMembers(filterConditions, options = {}) {
+		if (!options) {
+			options = {};
+		}
+		let id;
+		const type = this.type;
+		let members;
+		if (this.id) {
+			id = this.id;
+		} else if (this.data && Array.isArray(this.data.members)) {
+			members = this.data.members;
+		}
+		// Return a list of members
+		return await this.getClient().get(this.getClient().baseURL + '/members', {
+			payload: {
+				type,
+				id,
+				members,
+				filter_conditions: filterConditions,
+				...options,
+			},
+		});
 	}
 
 	/**

--- a/src/client.js
+++ b/src/client.js
@@ -877,30 +877,6 @@ export class StreamChat {
 		return data;
 	}
 
-	/**
-	 * queryUsers - Query Members
-	 *
-	 * @param {string} cid channel to search members
-	 * @param {object} filterConditions MongoDB style filter conditions
-	 * @param {object} options          Option object, {limit: 10}
-	 *
-	 * @return {object} Member Query Response
-	 */
-	async queryMembers(cid, filterConditions, options) {
-		if (!options) {
-			options = {};
-		}
-
-		// Return a list of users
-		return await this.get(this.baseURL + '/members', {
-			payload: {
-				cid,
-				filter_conditions: filterConditions,
-				...options,
-			},
-		});
-	}
-
 	async queryChannels(filterConditions, sort = {}, options = {}) {
 		const sortFields = [];
 

--- a/src/client.js
+++ b/src/client.js
@@ -877,6 +877,30 @@ export class StreamChat {
 		return data;
 	}
 
+	/**
+	 * queryUsers - Query Members
+	 *
+	 * @param {string} cid channel to search members
+	 * @param {object} filterConditions MongoDB style filter conditions
+	 * @param {object} options          Option object, {limit: 10}
+	 *
+	 * @return {object} Member Query Response
+	 */
+	async queryMembers(cid, filterConditions, options) {
+		if (!options) {
+			options = {};
+		}
+
+		// Return a list of users
+		return await this.get(this.baseURL + '/members', {
+			payload: {
+				cid,
+				filter_conditions: filterConditions,
+				...options,
+			},
+		});
+	}
+
 	async queryChannels(filterConditions, sort = {}, options = {}) {
 		const sortFields = [];
 

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -51,11 +51,15 @@ describe.only('Query Members', function() {
 
 		csClient = await getTestClientForUser(rob);
 		channel = ssClient.channel('messaging', uuidv4(), {
-			members: [mod, rob, rob2, adam, banned],
 			created_by_id: mod,
 		});
 		await channel.create();
 		await channel.addModerators([mod]);
+		await channel.addMembers([rob]);
+		await channel.addMembers([rob2]);
+		await channel.addMembers([adam]);
+		await channel.addMembers([banned]);
+
 		await channel.inviteMembers([invited, pending, rejected]);
 
 		// mod bans user banned

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -1,0 +1,64 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { getServerTestClient, createUsers } from './utils';
+import uuidv4 from 'uuid/v4';
+
+const expect = chai.expect;
+
+chai.use(chaiAsPromised);
+
+if (process.env.NODE_ENV !== 'production') {
+	require('longjohn');
+}
+
+const Promise = require('bluebird');
+Promise.config({
+	longStackTraces: true,
+	warnings: {
+		wForgottenReturn: false,
+	},
+});
+
+describe.only('Query Members', function() {
+	let tom = 'tom-' + uuidv4();
+	let rob = 'rob-' + uuidv4();
+	let adam = 'adam-' + uuidv4();
+	let invited = 'invited-' + uuidv4();
+	let channel;
+	let ssClient;
+	before(async function() {
+		ssClient = await getServerTestClient();
+		await ssClient.updateUser({ id: rob, name: 'Robert' });
+		await ssClient.updateUser({ id: tom, name: 'Tomas' });
+		await ssClient.updateUser({ id: adam, name: 'Adame' });
+		await ssClient.updateUser({ id: invited, name: 'Mary' });
+		await createUsers([tom, rob, adam]);
+		channel = ssClient.channel('messaging', uuidv4(), {
+			members: [tom, rob, adam],
+			created_by_id: tom,
+		});
+		await channel.create();
+		await channel.inviteMembers([invited]);
+	});
+
+	it('query member with name Robert', async function() {
+		let results = await channel.queryMembers({ name: 'Robert' });
+		expect(results.members.length).to.be.equal(1);
+		expect(results.members[0].user.id).to.be.equal(rob);
+	});
+
+	it('query members by id', async function() {
+		let results = await channel.queryMembers({ id: tom });
+		expect(results.members.length).to.be.equal(1);
+		expect(results.members[0].user.id).to.be.equal(tom);
+	});
+
+	it('query multiple users by id', async function() {
+		let results = await channel.queryMembers({ id: { $in: [tom, rob, adam] } });
+		expect(results.members.length).to.be.equal(3);
+		expect(results.members[0].user.id).to.be.equal(tom);
+		expect(results.members[1].user.id).to.be.equal(rob);
+		expect(results.members[2].user.id).to.be.equal(adam);
+	});
+});

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -25,7 +25,7 @@ Promise.config({
 	},
 });
 
-describe.only('Query Members', function() {
+describe('Query Members', function() {
 	let mod = 'mod-' + uuidv4();
 	let rob = 'rob-' + uuidv4();
 	let rob2 = 'rob2-' + uuidv4();

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -97,7 +97,7 @@ describe('Query Members', function() {
 		expect(results.members.length).to.be.equal(8);
 		const members = results.members;
 		for (let i = 0; i < results.length; i++) {
-			const result = channel.queryMembers({}, { limit: 1, offset: i });
+			const result = channel.queryMembers({}, {}, { limit: 1, offset: i });
 			expect(result.members.length).to.be.equal(1);
 			expect(members[i].user.id).to.be.equal(result.members[0].user.id);
 		}

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -25,7 +25,7 @@ Promise.config({
 	},
 });
 
-describe('Query Members', function() {
+describe.only('Query Members', function() {
 	let mod = 'mod-' + uuidv4();
 	let rob = 'rob-' + uuidv4();
 	let rob2 = 'rob2-' + uuidv4();

--- a/test/query_members.js
+++ b/test/query_members.js
@@ -80,6 +80,13 @@ describe('Query Members', function() {
 		expect(results.members[1].user.id).to.be.equal(rob2);
 	});
 
+	it('member with name containing Robert', async function() {
+		let results = await channel.queryMembers({ name: { $q: 'Rob' } });
+		expect(results.members.length).to.be.equal(2);
+		expect(results.members[0].user.id).to.be.equal(rob);
+		expect(results.members[1].user.id).to.be.equal(rob2);
+	});
+
 	it('query members by id', async function() {
 		let results = await channel.queryMembers({ id: mod });
 		expect(results.members.length).to.be.equal(1);
@@ -143,6 +150,15 @@ describe('Query Members', function() {
 			400,
 			results,
 			'StreamChat error code 4: QueryMembers failed with error: "unrecognized field "invalid""',
+		);
+	});
+
+	it('invalid operator for field', async function() {
+		let results = channel.queryMembers({ id: { $q: 's' } });
+		await expectHTTPErrorCode(
+			400,
+			results,
+			'StreamChat error code 4: QueryMembers failed with error: "operator "$q" is not allowed for field "id""',
 		);
 	});
 });

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -678,7 +678,7 @@ export interface UsersAPIResponse extends APIResponse {
 }
 
 export interface MembersAPIResponse extends APIResponse {
-  members: Member[];
+  members: ChannelMemberResponse[];
 }
 
 export interface DeleteUserAPIResponse extends APIResponse {

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -427,6 +427,12 @@ export class Channel {
   delete(): Promise<DeleteChannelAPIResponse>;
   search(query: string | object, options: object): Promise<SearchAPIResponse>;
 
+  queryMembers(
+    filterConditions: object,
+    sort: object,
+    options: object,
+  ): Promise<MembersAPIResponse>;
+
   acceptInvite(options: object): Promise<AcceptInviteAPIResponse>;
   rejectInvite(options: object): Promise<RejectInviteAPIResponse>;
 
@@ -669,6 +675,10 @@ export interface UpdateUsersAPIResponse extends APIResponse {
 
 export interface UsersAPIResponse extends APIResponse {
   users: UserResponse[];
+}
+
+export interface MembersAPIResponse extends APIResponse {
+  members: Member[];
 }
 
 export interface DeleteUserAPIResponse extends APIResponse {

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -429,8 +429,8 @@ export class Channel {
 
   queryMembers(
     filterConditions: object,
-    sort: object,
-    options: object,
+    sort?: object,
+    options?: object,
   ): Promise<MembersAPIResponse>;
 
   acceptInvite(options: object): Promise<AcceptInviteAPIResponse>;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

**introduce a new endpoint that allows clients to filter and search channel members**

example queries:

query all the members for the current channel where user.name='tommaso'
```js
channel.queryMembers({'name':'tommaso'})
```
filter member by id
```js
channel.queryMembers({'id':'tommaso'})
```
query all the members for the current channel where user.name contains
```js
channel.queryMembers({'name':{"$q":'tomm'}})
```
query channel moderators
```js
channel.queryMembers({'is_moderator:true'})
```
query for banned members in channel
```js
channel.queryMembers({'banned:true'})
```
