### PR TITLE
Fix Message interface type definition

### DIFF
--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -33,7 +33,7 @@ export interface Attachment {
 export interface Message {
   text: string;
   attachments?: Attachment[];
-  mentioned_users?: User[];
+  mentioned_users?: string[];
   parent_id?: string;
   [propName: string]: any;
 }


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
This fixes the type definition for the Message interface, so that it no longer expects an array of User objects, but instead an array of strings (i.e. user IDs). This matches the APIs, e.g. https://getstream.io/chat/docs/send_message/?language=js
