### PR TITLE
Fix Message interface so it accepts array of userIds (i.e. strings) i…

### DIFF
--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -33,7 +33,7 @@ export interface Attachment {
 export interface Message {
   text: string;
   attachments?: Attachment[];
-  mentioned_users?: User[];
+  mentioned_users?: string[];
   parent_id?: string;
   [propName: string]: any;
 }
@@ -218,7 +218,7 @@ export class StreamChat {
   errorFromResponse(response: APIResponse): Error;
 
   sendFile(
-    url: string | Buffer,
+    url: string | Buffer | File,
     uri: string,
     name?: string,
     contentType?: string,
@@ -362,13 +362,13 @@ export class Channel {
   };
   sendMessage(message: Message): Promise<SendMessageAPIResponse>;
   sendFile(
-    uri: string | Buffer,
+    uri: string | Buffer | File,
     name?: string,
     contentType?: string,
     user?: User,
   ): Promise<FileUploadAPIResponse>;
   sendImage(
-    uri: string | Buffer,
+    uri: string | Buffer | File,
     name?: string,
     contentType?: string,
     user?: User,

--- a/types/stream-chat/tsconfig.json
+++ b/types/stream-chat/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "module": "commonjs",
     "noEmit": true,
     "noImplicitAny": true,


### PR DESCRIPTION
…nstead of User objects, allow sending File objects in sendFile/sendImage (as happens in the browser already), add dom to tsconfig so we can use browser types in type definitions

# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
