### PR TITLE
Add test for channel.truncated webhook

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "prettier-fix": "npx prettier --write '**/*.{js,ts,md,css,scss,json}' .eslintrc.json .prettierrc .babelrc",
     "test-api-dts": "node types/stream-chat/api-response-tests/index.js && npx prettier --write 'types/stream-chat/api-response-tests/data.ts' .eslintrc.json .prettierrc .babelrc && tsc types/stream-chat/api-response-tests/data.ts && rm types/stream-chat/api-response-tests/data.js && dtslint types/stream-chat",
     "eslint": "npx eslint '**/*.{js,md}' --max-warnings 0",
-    "test": "NODE_ENV=test mocha --exit --bail --timeout 15000 --require @babel/register test/*.js -- --async-stack-traces",
+    "test": "NODE_ENV=test mocha --exit --bail --timeout 15000 --require @babel/register test/*.js --async-stack-traces",
     "testall": "NODE_ENV=test mocha --exit --timeout 3000 --require @babel/register test/*.js -- --async-stack-traces",
     "testwatch": "NODE_ENV=test nodemon ./node_modules/.bin/mocha --timeout 15000 --require test-entry.js test/test.js",
     "lint": "npx prettier --list-different '**/*.{js,ts,css,scss,json}' .eslintrc.json .prettierrc .babelrc && npx eslint 'src/*.js' --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "test-api-dts": "node types/stream-chat/api-response-tests/index.js && npx prettier --write 'types/stream-chat/api-response-tests/data.ts' .eslintrc.json .prettierrc .babelrc && tsc types/stream-chat/api-response-tests/data.ts && rm types/stream-chat/api-response-tests/data.js && dtslint types/stream-chat",
     "eslint": "npx eslint '**/*.{js,md}' --max-warnings 0",
     "test": "NODE_ENV=test mocha --exit --bail --timeout 15000 --require @babel/register test/*.js --async-stack-traces",
-    "testall": "NODE_ENV=test mocha --exit --timeout 3000 --require @babel/register test/*.js -- --async-stack-traces",
+    "testall": "NODE_ENV=test mocha --exit --timeout 3000 --require @babel/register test/*.js --async-stack-traces",
     "testwatch": "NODE_ENV=test nodemon ./node_modules/.bin/mocha --timeout 15000 --require test-entry.js test/test.js",
     "lint": "npx prettier --list-different '**/*.{js,ts,css,scss,json}' .eslintrc.json .prettierrc .babelrc && npx eslint 'src/*.js' --max-warnings 0",
     "lint-fix": "npx prettier --write '**/*.{js,ts,css,scss,json}' .eslintrc.json .prettierrc .babelrc && npx eslint --fix 'src/*.js' --max-warnings 0",

--- a/test/webhook.js
+++ b/test/webhook.js
@@ -375,10 +375,14 @@ describe('Webhooks', function() {
 	});
 
 	it('member.added', async function() {
-		await Promise.all([
+		const [events] = await Promise.all([
 			promises.waitForEvents('member.added'),
 			chan.addMembers([jaapID]),
 		]);
+		const event = events[0];
+		expect(event).to.not.be.null;
+		expect(event.type).to.eq('member.added');
+		expect(event.user.id).to.eq(jaapID);
 	});
 
 	it('member.updated', async function() {
@@ -545,6 +549,17 @@ describe('Webhooks', function() {
 		expect(event.user.id).to.eq(jaapID);
 		expect(event.target_user).to.be.an('object');
 		expect(event.target_user.id).to.eq(thierryID);
+	});
+
+	it('channel.truncate webhook fires', async function() {
+		const [events] = await Promise.all([
+			promises.waitForEvents('channel.truncated'),
+			chan.truncate(),
+		]);
+		const event = events[0];
+		expect(event).to.not.be.null;
+		expect(event.type).to.eq('channel.truncated');
+		expect(event.channel).to.be.an('object');
 	});
 
 	it('channel.deleted', async function() {


### PR DESCRIPTION
Currently `channel.truncated` doesn't fire a webhook. I'm adding it and this is the related test.