### PR TITLE
Skip some events for the stopWatching test

### DIFF
--- a/test/presence.js
+++ b/test/presence.js
@@ -97,6 +97,13 @@ describe('Presence', function() {
 			const results = [];
 			const eventPromise = new Promise(resolve => {
 				b.on('all', e => {
+					// We sometimes get other events which don't have a watcher_count or
+					// user. In which case this crashes. Ignore these events, and just
+					// filter down to relevant ones.
+					if (!e.watcher_count || !e.user) {
+						return;
+					}
+
 					expect(e.watcher_count).to.equal(b.state.watcher_count);
 					results.push([e.watcher_count, e.user.id]);
 					// expect to see thierry join, james join and james leave

--- a/test/presence.js
+++ b/test/presence.js
@@ -96,14 +96,7 @@ describe('Presence', function() {
 			await b.create();
 			const results = [];
 			const eventPromise = new Promise(resolve => {
-				b.on('all', e => {
-					// We sometimes get other events which don't have a watcher_count or
-					// user. In which case this crashes. Ignore these events, and just
-					// filter down to relevant ones.
-					if (!e.watcher_count || !e.user) {
-						return;
-					}
-
+				const handler = e => {
 					expect(e.watcher_count).to.equal(b.state.watcher_count);
 					results.push([e.watcher_count, e.user.id]);
 					// expect to see thierry join, james join and james leave
@@ -116,7 +109,10 @@ describe('Presence', function() {
 						expect(results).to.deep.equal(expected);
 						resolve();
 					}
-				});
+				};
+
+				b.on('user.watching.start', handler);
+				b.on('user.watching.stop', handler);
 			});
 
 			// user1 starts watching


### PR DESCRIPTION
So this test works by creating an event handler. Then on each event we append that we got the event. After we get three events we then do the checking to make sure everything is what we expect.

The specific order we get events in changes as is expected for a concurrent program. Additionally we sometimes get extra events such as `notification.added_to_channel`. These events may have keys such as `channel`, but not have keys like `user`. If these events show up early enough, then we crash. By skipping these events we can increase the pass rate of tests.

This was debugged and fixed with the assistance of @gumuz and @vishalnarkhede.