### PR TITLE
Added mute expiration timeout to client

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1168,7 +1168,7 @@ export class StreamChat {
 	 * @param options
 	 * @returns {Promise<*>}
 	 */
-	async muteUser(targetID, userID = null, options = {}) {
+	async muteUser(targetID, userID = null, options) {
 		const timeout = options ? options.timeout : undefined;
 		return await this.post(this.baseURL + '/moderation/mute', {
 			target_id: targetID,

--- a/src/client.js
+++ b/src/client.js
@@ -1164,12 +1164,11 @@ export class StreamChat {
 	/** muteUser - mutes a user
 	 *
 	 * @param targetID
+	 * @param [userID] Only used with serverside auth
 	 * @param options
 	 * @returns {Promise<*>}
 	 */
-	async muteUser(targetID, options) {
-		// WARNING: this is a backwards incompatible change
-		const userID = options ? options.userID : undefined;
+	async muteUser(targetID, userID = null, options = {}) {
 		const timeout = options ? options.timeout : undefined;
 		return await this.post(this.baseURL + '/moderation/mute', {
 			target_id: targetID,

--- a/src/client.js
+++ b/src/client.js
@@ -1164,13 +1164,17 @@ export class StreamChat {
 	/** muteUser - mutes a user
 	 *
 	 * @param targetID
-	 * @param [userID] Only used with serverside auth
+	 * @param options
 	 * @returns {Promise<*>}
 	 */
-	async muteUser(targetID, userID = null) {
+	async muteUser(targetID, options) {
+		// WARNING: this is a backwards incompatible change
+		const userID = options ? options.userID : undefined;
+		const timeout = options ? options.timeout : undefined;
 		return await this.post(this.baseURL + '/moderation/mute', {
 			target_id: targetID,
 			...(userID ? { user_id: userID } : {}),
+			...(timeout ? { timeout } : {}),
 		});
 	}
 

--- a/test/moderation.js
+++ b/test/moderation.js
@@ -69,7 +69,7 @@ describe('Moderation', function() {
 				resolve();
 			});
 		});
-		const response = await client1.muteUser(user2, { timeout: 10 });
+		const response = await client1.muteUser(user2, null, { timeout: 10 });
 		expect(response.mute.created_at).to.not.be.undefined;
 		expect(response.mute.updated_at).to.not.be.undefined;
 		expect(response.mute.expires).to.not.be.undefined;

--- a/test/moderation.js
+++ b/test/moderation.js
@@ -56,6 +56,36 @@ describe('Moderation', function() {
 		await eventPromise;
 	});
 
+	it('Mute with expiration', async function() {
+		const user1 = uuidv4();
+		const user2 = uuidv4();
+		await createUsers([user1, user2]);
+		const client1 = await getTestClientForUser(user1);
+
+		const eventPromise = new Promise(resolve => {
+			// verify that the notification is sent
+			client1.on('notification.mutes_updated', e => {
+				expect(e.me.mutes.length).to.equal(1);
+				resolve();
+			});
+		});
+		const response = await client1.muteUser(user2, { timeout: 10 });
+		expect(response.mute.created_at).to.not.be.undefined;
+		expect(response.mute.updated_at).to.not.be.undefined;
+		expect(response.mute.expires).to.not.be.undefined;
+		expect(response.mute.user.id).to.equal(user1);
+		expect(response.mute.target.id).to.equal(user2);
+		// verify we return the right user mute upon connect
+		const client = getTestClient(false);
+		const connectResponse = await client.setUser(
+			{ id: user1 },
+			createUserToken(user1),
+		);
+		expect(connectResponse.me.mutes.length).to.equal(1);
+		expect(connectResponse.me.mutes[0].target.id).to.equal(user2);
+		await eventPromise;
+	});
+
 	it('Mute after sendMessage', async function() {
 		const user1 = uuidv4();
 		const user2 = uuidv4();

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -295,7 +295,7 @@ export class StreamChat {
   banUser(targetUserID: string, options: object): Promise<BanUserAPIResponse>;
   unbanUser(targetUserID: string, options: object): Promise<UnbanUserAPIResponse>;
 
-  muteUser(targetUserID: string): Promise<MuteAPIResponse>;
+  muteUser(targetUserID: string, options?: object): Promise<MuteAPIResponse>;
   unmuteUser(targetUserID: string): Promise<UnmuteAPIResponse>;
 
   flagUser(userID: string, options?: object): Promise<FlagAPIResponse>;


### PR DESCRIPTION
These changes add [expiration to user mutes](https://stream-io.atlassian.net/browse/CHAT-1006) to the api client. Backend implementation is described in [this pr](https://github.com/GetStream/chat/pull/1211).