### PR TITLE
Changed muteUser client method to include expiration timeout

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -1163,17 +1163,16 @@ export class StreamChat {
 
 	/** muteUser - mutes a user
 	 *
-	 * @param targetID
+	 * @param targetUserID
 	 * @param [userID] Only used with serverside auth
 	 * @param options
 	 * @returns {Promise<*>}
 	 */
-	async muteUser(targetID, userID = null, options) {
-		const timeout = options ? options.timeout : undefined;
+	async muteUser(targetUserID, userID = null, options = {}) {
 		return await this.post(this.baseURL + '/moderation/mute', {
-			target_id: targetID,
+			target_id: targetUserID,
 			...(userID ? { user_id: userID } : {}),
-			...(timeout ? { timeout } : {}),
+			...options,
 		});
 	}
 

--- a/types/stream-chat/index.d.ts
+++ b/types/stream-chat/index.d.ts
@@ -295,7 +295,11 @@ export class StreamChat {
   banUser(targetUserID: string, options: object): Promise<BanUserAPIResponse>;
   unbanUser(targetUserID: string, options: object): Promise<UnbanUserAPIResponse>;
 
-  muteUser(targetUserID: string, options?: object): Promise<MuteAPIResponse>;
+  muteUser(
+    targetUserID: string,
+    UserID?: string,
+    options?: object,
+  ): Promise<MuteAPIResponse>;
   unmuteUser(targetUserID: string): Promise<UnmuteAPIResponse>;
 
   flagUser(userID: string, options?: object): Promise<FlagAPIResponse>;


### PR DESCRIPTION
To support expiration of user mutes, the api accepts an optional `timeout` parameter, defining the _expiration time in minutes_.

**note**: The signature of muteUser changed from: 

`muteUser(targetUserID, userID = null)`

to:

`muteUser(targetUserID, userID = null, options = {})`

In order to stay backwards compatible, the `options` parameter was added after the optional `userID`. 

This has the unfortunate effect that a call without a userID, but with a timeout  looks like this: `muteUser(1234, null, { timeout: 10 })`. I don't see a way around that.
