### PR TITLE
Allow no data in channel update

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -256,10 +256,17 @@ export class Channel {
 	 * @return {type} The server response
 	 */
 	async update(channelData, updateMessage) {
-		const data = await this.getClient().post(this._channelURL(), {
-			message: updateMessage,
-			data: channelData,
-		});
+		let data;
+		if (channelData) {
+			data = await this.getClient().post(this._channelURL(), {
+				message: updateMessage,
+				data: channelData,
+			});
+		} else {
+			data = await this.getClient().post(this._channelURL(), {
+				message: updateMessage,
+			});
+		}
 		this.data = data.channel;
 		return data;
 	}


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

... or something along these lines. It is currently impossible to just send a system message without an update to the channel's data. If I set an empty object, all my old custom data is overwritten. I thought I managed to work around this by setting `channelData=undefined` but it turns out that just magically ignores the attached message. The only way to do it, it seems, it by not setting the `data` field altogether. Just like the `addMembers` method does.

Please consider this functionality. It's a bit crippling.
