### PR TITLE
add strict tests and correct message/null types

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "types": "tsc --emitDeclarationOnly true",
     "prettier": "prettier --check '**/*.{js,ts,md,css,scss,json}' .eslintrc.json .prettierrc .babelrc",
     "prettier-fix": "npx prettier --write '**/*.{js,ts,md,css,scss,json}' .eslintrc.json .prettierrc .babelrc",
-    "test-types": "node ts-test/index.js && tsc --esModuleInterop true --noEmit true ts-test/*.ts",
+    "test-types": "node ts-test/index.js && tsc --esModuleInterop true --noEmit true --strictNullChecks true --noImplicitAny true --strict true ts-test/*.ts",
     "eslint": "eslint '**/*.{js,md,ts}' --max-warnings 0 --ignore-path ./.eslintignore",
     "eslint-fix": "npx eslint --fix '**/*.{js,md,ts}' --max-warnings 0 --ignore-path ./.eslintignore",
     "test": "NODE_ENV=test mocha --exit --bail --timeout 15000 --require ./babel-register test/*.js --async-stack-traces",

--- a/src/client.ts
+++ b/src/client.ts
@@ -76,6 +76,7 @@ import {
   PartialUserUpdate,
   UpdateMessageAPIResponse,
   LiteralStringForUnion,
+  Message,
 } from './types';
 
 function isReadableStream(
@@ -1792,14 +1793,7 @@ export class StreamChat<
    * @return {APIResponse & { message: MessageResponse<MessageType, AttachmentType, ChannelType, ReactionType, UserType, CommandType> }} Response that includes the message
    */
   async updateMessage(
-    message: MessageResponse<
-      MessageType,
-      AttachmentType,
-      ChannelType,
-      ReactionType,
-      UserType,
-      CommandType
-    >,
+    message: Message<MessageType, AttachmentType, UserType>,
     userId?: string | { id: string },
   ) {
     if (!message.id) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,7 +107,7 @@ export type ChannelResponse<
   type: string;
   config?: ChannelConfigWithInfo<CommandType>;
   created_at?: string;
-  created_by?: UserResponse<UserType>;
+  created_by?: UserResponse<UserType> | null;
   created_by_id?: string;
   deleted_at?: string;
   invites?: string[];
@@ -139,7 +139,7 @@ export type ChannelAPIResponse<
     CommandType
   >[];
   hidden?: boolean;
-  membership?: ChannelMembership<UserType>;
+  membership?: ChannelMembership<UserType> | null;
   read?: ReadResponse<UserType>[];
   watcher_count?: number;
   watchers?: UserResponse<UserType>[];
@@ -381,7 +381,7 @@ export type MessageResponse<
   ReactionType = UnknownType,
   UserType = UnknownType,
   CommandType extends string = LiteralStringForUnion
-> = MessageBase<MessageType, AttachmentType> & {
+> = MessageBase<MessageType, AttachmentType, UserType> & {
   args?: string;
   channel?: ChannelResponse<ChannelType, UserType, CommandType>;
   command?: string;
@@ -390,15 +390,14 @@ export type MessageResponse<
   deleted_at?: string;
   latest_reactions?: ReactionResponse<ReactionType, UserType>[];
   mentioned_users?: UserResponse<UserType>[];
-  own_reactions?: ReactionResponse<ReactionType, UserType>[];
-  reaction_counts?: { [key: string]: number };
-  reaction_scores?: { [key: string]: number };
+  own_reactions?: ReactionResponse<ReactionType, UserType>[] | null;
+  reaction_counts?: { [key: string]: number } | null;
+  reaction_scores?: { [key: string]: number } | null;
   reply_count?: number;
   silent?: boolean;
   status?: string;
   type?: string;
   updated_at?: string;
-  user?: UserResponse<UserType>;
 };
 
 export type MuteResponse<UserType = UnknownType> = {
@@ -1319,14 +1318,14 @@ export type Message<
   MessageType = UnknownType,
   AttachmentType = UnknownType,
   UserType = UnknownType
-> = MessageBase<MessageType, AttachmentType> & {
+> = MessageBase<MessageType, AttachmentType, UserType> & {
   mentioned_users?: string[];
-  user?: UserResponse<UserType>;
 };
 
 export type MessageBase<
   MessageType = UnknownType,
-  AttachmentType = UnknownType
+  AttachmentType = UnknownType,
+  UserType = UnknownType
 > = MessageType & {
   attachments?: Attachment<AttachmentType>[];
   html?: string;
@@ -1334,6 +1333,7 @@ export type MessageBase<
   parent_id?: string;
   show_in_channel?: boolean;
   text?: string;
+  user?: UserResponse<UserType> | null;
   user_id?: string;
 };
 
@@ -1385,7 +1385,7 @@ export type Reaction<
   type: string;
   message_id?: string;
   score?: number;
-  user?: UserResponse<UserType>;
+  user?: UserResponse<UserType> | null;
   user_id?: string;
 };
 

--- a/ts-test/index.js
+++ b/ts-test/index.js
@@ -236,7 +236,7 @@ const executables = [
 		f: rg.lastMessage,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Omit<ReturnType<Immutable<Unpacked<ReturnType<Channel<{}, { description?: string }, {}, {}, {}, {}>['lastMessage']>>['asMutable']>>, 'created_at' | 'updated_at'> & { created_at?: string; updated_at?: string }",
+			"Omit<ReturnType<ImmutableObject<Unpacked<ReturnType<Channel<{}, { description?: string }, {}, {}, {}, {}>['lastMessage']>>>['asMutable']>, 'created_at' | 'updated_at'> & { created_at?: string; updated_at?: string }",
 	},
 	{
 		f: rg.listChannelTypes,
@@ -528,7 +528,7 @@ executables.forEach(i => {
 const uniqueTypes = types.filter((value, index, self) => self.indexOf(value) === index);
 imports = uniqueTypes.join(', ');
 
-imports = `import { Immutable } from 'seamless-immutable';\n\nimport { ${imports} } from '..';`;
+imports = `import { ImmutableObject } from 'seamless-immutable';\n\nimport { ${imports} } from '..';`;
 const tsFileName = `${__dirname}/data.ts`;
 fs.writeFile(tsFileName, `${imports} \n\n`, function(err) {
 	if (err) {

--- a/ts-test/response-generators/channel.js
+++ b/ts-test/response-generators/channel.js
@@ -107,6 +107,7 @@ async function lastMessage() {
 	const channel = await utils.createTestChannelForUser(uuidv4(), johnID);
 	await channel.watch();
 	await channel.sendMessage({ text: 'Hello World' });
+	await channel.sendMessage({ text: 'Hello World...again' });
 
 	return await channel.lastMessage();
 }

--- a/ts-test/response-generators/channel.js
+++ b/ts-test/response-generators/channel.js
@@ -105,7 +105,9 @@ async function inviteMembers() {
 
 async function lastMessage() {
 	const channel = await utils.createTestChannelForUser(uuidv4(), johnID);
+	await channel.watch();
 	await channel.sendMessage({ text: 'Hello World' });
+
 	return await channel.lastMessage();
 }
 

--- a/ts-test/response-generators/message.js
+++ b/ts-test/response-generators/message.js
@@ -9,7 +9,7 @@ async function deleteMessage() {
 	await channel.watch();
 	const { message } = await channel.sendMessage({ text: `Test message` });
 
-	await authClient.deleteMessage(message.id);
+	return await authClient.deleteMessage(message.id);
 }
 
 async function getMessage() {
@@ -94,12 +94,17 @@ async function translateMessage() {
 
 async function updateMessage() {
 	const authClient = await utils.getTestClientForUser(johnID, {});
-	const channel = authClient.channel('messaging', `poppins-${uuidv4()}`);
+	const userID = 'tommaso-' + uuidv4();
+	await utils.getTestClient(true).updateUser({ id: userID });
+	const channel = authClient.channel('messaging', `poppins-${uuidv4()}`, {
+		members: [userID],
+	});
 	await channel.watch();
 	const { message } = await channel.sendMessage({ text: `Test message` });
-	await authClient.updateMessage({
+	return await authClient.updateMessage({
 		id: message.id,
 		text: 'I mean, awesome chat',
+		mentioned_users: [userID],
 	});
 }
 

--- a/ts-test/tsconfig.json
+++ b/ts-test/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "noImplicitAny": true,
+    "strict": true,
+    "strictNullChecks": true
+  }
+}

--- a/ts-test/unit-test.ts
+++ b/ts-test/unit-test.ts
@@ -59,9 +59,9 @@ const client: StreamChat<
   AttachmentType,
   ReactionType,
   EventType
->(apiKey, null, {
+>(apiKey, undefined, {
   timeout: 3000,
-  logger: (logLevel: string, msg: string, extraData: {}) => {},
+  logger: (logLevel: string, msg: string, extraData?: Record<string, unknown>) => {},
 });
 
 const clientWithoutSecret: StreamChat<ChannelType, UserType> = new StreamChat<
@@ -69,7 +69,7 @@ const clientWithoutSecret: StreamChat<ChannelType, UserType> = new StreamChat<
   UserType
 >(apiKey, {
   timeout: 3000,
-  logger: (logLevel: string, msg: string, extraData: {}) => {},
+  logger: (logLevel: string, msg: string, extraData?: Record<string, unknown>) => {},
 });
 
 const devToken: string = client.devToken('joshua');
@@ -250,7 +250,7 @@ const permissions = [
 ];
 
 client.updateChannelType('messaging', { permissions }).then(response => {
-  const permissions: PermissionObject[] = response.permissions;
-  const permissionName: string = permissions[0].name;
-  const permissionRoles: string[] = permissions[0].roles;
+  const permissions: PermissionObject[] = response.permissions || [];
+  const permissionName: string = permissions[0].name || '';
+  const permissionRoles: string[] = permissions[0].roles || [];
 });


### PR DESCRIPTION
# Make type checks on tests strict

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
I have added strict null checks to the tests to catch a few minor testing errors. Additionally I have corrected updateMessage input type. The backend will soon update to allow user objects to be used in mentioned users array, when this is done MessageBase can be changed to just Message and current Message type can be removed. The only field of messageResponse that is currently not an extension of Message is mentioned_users Message uses a string array, response a user array. Having these overlap 100% will also remove the need to map message response to message when updating a message.
