### PR TITLE
Add old helper types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "@types/uuid": "^3.4.5",
+    "@types/ws": "^6.0.3",
     "axios": "^0.18.1",
     "base64-js": "^1.3.1",
     "form-data": "^2.3.3",
@@ -78,8 +80,6 @@
     "@types/rollup-plugin-url": "^2.2.0",
     "@types/seamless-immutable": "7.1.13",
     "@types/sinon": "^7.5.1",
-    "@types/uuid": "^3.4.5",
-    "@types/ws": "^6.0.3",
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
     "babel-eslint": "^10.0.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -363,6 +363,10 @@ export type ListChannelResponse<
   >;
 };
 
+export type ListChannelTypesAPIResponse<
+  CommandType extends string = LiteralStringForUnion
+> = ListChannelResponse<CommandType>;
+
 export type MuteChannelAPIResponse<
   ChannelType extends UnknownType = UnknownType,
   CommandType extends string = LiteralStringForUnion,
@@ -542,6 +546,22 @@ export type UpdateChannelAPIResponse<
   >;
 };
 
+export type UpdateChannelResponse<
+  CommandType extends string = LiteralStringForUnion
+> = APIResponse &
+  Omit<CreateChannelOptions<CommandType>, 'client_id' | 'connection_id'> & {
+    created_at: string;
+    updated_at: string;
+  };
+
+export type UsersAPIResponse<UserType = UnknownType> = APIResponse & {
+  users: Array<UserResponse<UserType>>;
+};
+
+export type UpdateUsersAPIResponse<UserType = UnknownType> = APIResponse & {
+  users: { [key: string]: UserResponse<UserType> };
+};
+
 export type UserResponse<T = UnknownType> = User<T> & {
   banned?: boolean;
   created_at?: string;
@@ -551,14 +571,6 @@ export type UserResponse<T = UnknownType> = User<T> & {
   online?: boolean;
   updated_at?: string;
 };
-
-export type UpdateChannelResponse<
-  CommandType extends string = LiteralStringForUnion
-> = APIResponse &
-  Omit<CreateChannelOptions<CommandType>, 'client_id' | 'connection_id'> & {
-    created_at: string;
-    updated_at: string;
-  };
 
 /**
  * Option Types

--- a/ts-test/index.js
+++ b/ts-test/index.js
@@ -71,7 +71,7 @@ const executables = [
 		f: rg.createCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two', {}, {}, {}, {} >['createCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | '', {}, {}, {}, {} >['createCommand']>>",
 	},
 	{
 		f: rg.createPermission,
@@ -103,7 +103,7 @@ const executables = [
 		f: rg.deleteCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two', {}, {}, {}, {}>['deleteCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | '', {}, {}, {}, {}>['deleteCommand']>>",
 	},
 	{
 		f: rg.deleteFile,
@@ -187,7 +187,7 @@ const executables = [
 		f: rg.getCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two', {}, {}, {}, {}>['getCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | '', {}, {}, {}, {}>['getCommand']>>",
 	},
 	{
 		f: rg.getConfig,
@@ -259,7 +259,7 @@ const executables = [
 		f: rg.listCommands,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two', {}, {}, {}, {}>['listCommands']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | '', {}, {}, {}, {}>['listCommands']>>",
 	},
 	{
 		f: rg.listPermissions,
@@ -482,7 +482,7 @@ const executables = [
 		f: rg.updateCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two', {}, {}, {}, {}>['updateCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | '', {}, {}, {}, {}>['updateCommand']>>",
 	},
 	{
 		f: rg.updateMessage,


### PR DESCRIPTION
# Submit a pull request
Add old types for backward compatibility

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Add old types as helpers for backward compatibility and move production @types into non dev dependencies. 
