### PR TITLE
Configurable BE API URL so that stream-chat library can be used with any BE

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -212,7 +212,10 @@ export class StreamChat<
 
     this.axiosInstance = axios.create(this.options);
 
-    this.setBaseURL('https://chat-us-east-1.stream-io-api.com');
+    // Making BE url configurable so that library can be used against any BE
+    this.setBaseURL(
+      process?.env?.STREAM_BE_BASE_URL || 'https://chat-us-east-1.stream-io-api.com',
+    );
 
     if (typeof process !== 'undefined' && process.env.STREAM_LOCAL_TEST_RUN) {
       this.setBaseURL('http://localhost:3030');


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
Currently stream-chat client library uses stream api as BE. In this PR i have added the ability to set the  BE API url dynamically from an environment variable `STREAM_BE_BASE_URL` Having this functionality would make stream-chat client library to work with any backend API.