### PR TITLE
adding type key-value pair to FormData creation to fix React Native Android image upload failures

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -72,6 +72,7 @@ export function addFileToFormData(
       uri,
       name: name || (uri as string).split('/').reverse()[0],
       contentType: contentType || undefined,
+      type: contentType || undefined,
     });
   }
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request

- Needed based on https://github.com/facebook/react-native/blob/0d02c60bae3025dee41874a88765dc872f401f45/Libraries/Network/FormData.js#L82