### PR TITLE
remove unnecessary _initializeState call in watch()

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1003,7 +1003,6 @@ export class Channel<
     const combined = { ...defaultOptions, ...options };
     const state = await this.query(combined);
     this.initialized = true;
-    this._initializeState(state);
     this.data = state.channel;
 
     this._client.logger(


### PR DESCRIPTION
`this._initializeState(state)` is already called in `channel.query` 
https://github.com/GetStream/stream-chat-js/blob/bug/duplicate-channel-initializeState/src/channel.ts#L1246