### PR TITLE
reduce member type to in/nin

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -910,7 +910,7 @@ export type ChannelFilters<
   UserType = UnknownType
 > = QueryFilters<
   ContainsOperator<ChannelType> & {
-    members?: QueryFilter<string>;
+    members?: RequireOnlyOne<Pick<QueryFilter<string>, '$in' | '$nin'>>;
   } & {
     name?:
       | RequireOnlyOne<


### PR DESCRIPTION
Members is a special filter that only accepts $in / $nin commands, both take string[].