### PR TITLE
[CHAT-1172] Ban by IP feature

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -137,6 +137,7 @@ export class StreamChat<
   secret?: string;
   setUserPromise: ConnectAPIResponse<ChannelType, CommandType, UserType> | null;
   state: ClientState<UserType>;
+  testIPOverride?: string;
   tokenManager: TokenManager<UserType>;
   user?: UserResponse<UserType>;
   userAgent?: string;
@@ -1077,6 +1078,7 @@ export class StreamChat<
       wsBaseURL: client.wsBaseURL,
       clientID: client.clientID,
       userID: client.userID,
+      testIPOverride: client.testIPOverride,
       tokenManager: client.tokenManager,
       user: this._user,
       authType: this.getAuthType(),

--- a/src/client.ts
+++ b/src/client.ts
@@ -137,7 +137,6 @@ export class StreamChat<
   secret?: string;
   setUserPromise: ConnectAPIResponse<ChannelType, CommandType, UserType> | null;
   state: ClientState<UserType>;
-  testIPOverride?: string;
   tokenManager: TokenManager<UserType>;
   user?: UserResponse<UserType>;
   userAgent?: string;
@@ -1078,11 +1077,10 @@ export class StreamChat<
       wsBaseURL: client.wsBaseURL,
       clientID: client.clientID,
       userID: client.userID,
-      testIPOverride: client.testIPOverride,
       tokenManager: client.tokenManager,
       user: this._user,
       authType: this.getAuthType(),
-      userAgent: this._userAgent(),
+      userAgent: this.getUserAgent(),
       apiKey: this.key,
       recoverCallback: this.recoverState,
       messageCallback: this.handleEvent,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,6 +39,7 @@ type Constructor<
   userAgent: string;
   userID: string;
   wsBaseURL: string;
+  testIPOverride?: string;
 };
 
 /**
@@ -95,6 +96,7 @@ export class StableWSConnection<
     },
   ) => void;
   resolvePromise?: (value?: WebSocket.MessageEvent) => void;
+  testIPOverride?: string;
   totalFailures: number;
   ws?: WebSocket;
   wsID: number;
@@ -107,6 +109,7 @@ export class StableWSConnection<
     logger,
     messageCallback,
     recoverCallback,
+    testIPOverride,
     tokenManager,
     user,
     userAgent,
@@ -120,6 +123,7 @@ export class StableWSConnection<
     this.authType = authType;
     this.userAgent = userAgent;
     this.apiKey = apiKey;
+    this.testIPOverride = testIPOverride;
     this.tokenManager = tokenManager;
     /** consecutive failures influence the duration of the timeout */
     this.consecutiveFailures = 0;
@@ -211,7 +215,11 @@ export class StableWSConnection<
     };
     const qs = encodeURIComponent(JSON.stringify(params));
     const token = this.tokenManager.getToken();
-    return `${this.wsBaseURL}/connect?json=${qs}&api_key=${this.apiKey}&authorization=${token}&stream-auth-type=${this.authType}&x-stream-client=${this.userAgent}`;
+    let url = `${this.wsBaseURL}/connect?json=${qs}&api_key=${this.apiKey}&authorization=${token}&stream-auth-type=${this.authType}&x-stream-client=${this.userAgent}`;
+    if (this.testIPOverride !== null && this.testIPOverride !== undefined) {
+      url += `&X-Forwarded-For=${this.testIPOverride}&X-Forwarded-Port=80`;
+    }
+    return url;
   };
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -39,7 +39,6 @@ type Constructor<
   userAgent: string;
   userID: string;
   wsBaseURL: string;
-  testIPOverride?: string;
 };
 
 /**
@@ -96,7 +95,6 @@ export class StableWSConnection<
     },
   ) => void;
   resolvePromise?: (value?: WebSocket.MessageEvent) => void;
-  testIPOverride?: string;
   totalFailures: number;
   ws?: WebSocket;
   wsID: number;
@@ -109,7 +107,6 @@ export class StableWSConnection<
     logger,
     messageCallback,
     recoverCallback,
-    testIPOverride,
     tokenManager,
     user,
     userAgent,
@@ -123,7 +120,6 @@ export class StableWSConnection<
     this.authType = authType;
     this.userAgent = userAgent;
     this.apiKey = apiKey;
-    this.testIPOverride = testIPOverride;
     this.tokenManager = tokenManager;
     /** consecutive failures influence the duration of the timeout */
     this.consecutiveFailures = 0;
@@ -215,11 +211,7 @@ export class StableWSConnection<
     };
     const qs = encodeURIComponent(JSON.stringify(params));
     const token = this.tokenManager.getToken();
-    let url = `${this.wsBaseURL}/connect?json=${qs}&api_key=${this.apiKey}&authorization=${token}&stream-auth-type=${this.authType}&x-stream-client=${this.userAgent}`;
-    if (this.testIPOverride !== null && this.testIPOverride !== undefined) {
-      url += `&X-Forwarded-For=${this.testIPOverride}&X-Forwarded-Port=80`;
-    }
-    return url;
+    return `${this.wsBaseURL}/connect?json=${qs}&api_key=${this.apiKey}&authorization=${token}&stream-auth-type=${this.authType}&x-stream-client=${this.userAgent}`;
   };
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -589,6 +589,7 @@ export type UserResponse<UserType = UnknownType> = User<UserType> & {
  */
 
 export type BanUserOptions<UserType = UnknownType> = UnBanUserOptions & {
+  ip_ban?: boolean;
   reason?: string;
   timeout?: number;
   user?: UserResponse<UserType>;

--- a/test/integration/ban_by_ip.js
+++ b/test/integration/ban_by_ip.js
@@ -23,11 +23,22 @@ function randomIP() {
 	);
 }
 
+// mockIP appends X-Forwarded-For to the user agent string
+function mockIP(client, ip) {
+	client.setUserAgent(
+		client.getUserAgent() + `&X-Forwarded-For=${ip}&X-Forwarded-Port=80`,
+	);
+}
+
 describe('ban user by ip', () => {
 	const serverClient = getTestClient(true);
 	const adminUser = {
 		id: uuidv4(),
 	};
+
+	const ip1 = randomIP();
+	const ip2 = randomIP();
+	const ip3 = randomIP();
 
 	const tommasoID = `tommaso-${uuidv4()}`;
 	const thierryID = `thierry-${uuidv4()}`;
@@ -36,13 +47,13 @@ describe('ban user by ip', () => {
 	const tommasoToken = createUserToken(tommasoID);
 	const thierryToken = createUserToken(thierryID);
 	const tommasoClient1 = getTestClient();
-	tommasoClient1.testIPOverride = randomIP();
+	mockIP(tommasoClient1, ip1);
 	const tommasoClient2 = getTestClient();
-	tommasoClient2.testIPOverride = randomIP();
+	mockIP(tommasoClient2, ip2);
 	const thierryClient1 = getTestClient();
-	thierryClient1.testIPOverride = tommasoClient1.testIPOverride;
+	mockIP(thierryClient1, ip1);
 	const thierryClient2 = getTestClient();
-	thierryClient2.testIPOverride = randomIP();
+	mockIP(thierryClient2, ip3);
 
 	before(async () => {
 		await createUsers([adminUser.id]);

--- a/test/integration/ban_by_ip.js
+++ b/test/integration/ban_by_ip.js
@@ -1,0 +1,129 @@
+import {
+	createUsers,
+	createUserToken,
+	expectHTTPErrorCode,
+	getTestClient,
+} from './utils';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { v4 as uuidv4 } from 'uuid';
+
+chai.use(chaiAsPromised);
+
+function randomIP() {
+	return (
+		Math.floor(Math.random() * 255) +
+		1 +
+		'.' +
+		Math.floor(Math.random() * 255) +
+		'.' +
+		Math.floor(Math.random() * 255) +
+		'.' +
+		Math.floor(Math.random() * 255)
+	);
+}
+
+describe('ban user by ip', () => {
+	const serverClient = getTestClient(true);
+	const adminUser = {
+		id: uuidv4(),
+	};
+
+	const tommasoID = `tommaso-${uuidv4()}`;
+	const thierryID = `thierry-${uuidv4()}`;
+	const tommasoChannelId = `test-channels-${uuidv4()}`;
+	const thierryChannelId = `test-channels-${uuidv4()}`;
+	const tommasoToken = createUserToken(tommasoID);
+	const thierryToken = createUserToken(thierryID);
+	const tommasoClient1 = getTestClient();
+	tommasoClient1.testIPOverride = randomIP();
+	const tommasoClient2 = getTestClient();
+	tommasoClient2.testIPOverride = randomIP();
+	const thierryClient1 = getTestClient();
+	thierryClient1.testIPOverride = tommasoClient1.testIPOverride;
+	const thierryClient2 = getTestClient();
+	thierryClient2.testIPOverride = randomIP();
+
+	before(async () => {
+		await createUsers([adminUser.id]);
+		await tommasoClient1.setUser({ id: tommasoID }, tommasoToken);
+		await thierryClient1.setUser({ id: thierryID }, thierryToken);
+	});
+
+	it('tommaso and thierry create channels', async () => {
+		await tommasoClient1.channel('messaging', tommasoChannelId).watch();
+		await thierryClient1.channel('messaging', thierryChannelId).watch();
+	});
+
+	it('tommasso1 is not banned yet', async () => {
+		await tommasoClient1
+			.channel('messaging', tommasoChannelId)
+			.sendMessage({ text: 'I am not banned yet' });
+	});
+
+	it('ban tommaso by IP', async () => {
+		await serverClient.banUser(tommasoID, {
+			user_id: adminUser.id,
+			ip_ban: true,
+		});
+	});
+
+	it('tommasso1 is banned', async () => {
+		await expectHTTPErrorCode(
+			403,
+			tommasoClient1
+				.channel('messaging', tommasoChannelId)
+				.sendMessage({ text: 'I am banned' }),
+		);
+	});
+
+	it('thierry1 is banned because he has same ip', async () => {
+		await expectHTTPErrorCode(
+			403,
+			thierryClient1
+				.channel('messaging', thierryChannelId)
+				.sendMessage({ text: 'I am banned' }),
+		);
+	});
+
+	it('tommaso and thierry switch IP addresses', async () => {
+		await tommasoClient2.setUser({ id: tommasoID }, tommasoToken);
+		await thierryClient2.setUser({ id: thierryID }, thierryToken);
+		await tommasoClient2.channel('messaging', tommasoChannelId).watch();
+		await thierryClient2.channel('messaging', thierryChannelId).watch();
+	});
+
+	it('tommasso2 is banned', async () => {
+		await expectHTTPErrorCode(
+			403,
+			tommasoClient2
+				.channel('messaging', tommasoChannelId)
+				.sendMessage({ text: 'I am banned' }),
+		);
+	});
+
+	it('thierry2 is not banned', async () => {
+		await thierryClient2
+			.channel('messaging', thierryChannelId)
+			.sendMessage({ text: 'I am not banned' });
+	});
+
+	it('unban tommaso', async () => {
+		await serverClient.unbanUser(tommasoID);
+	});
+
+	it('no one is banned', async () => {
+		await tommasoClient1
+			.channel('messaging', tommasoChannelId)
+			.sendMessage({ text: 'I am not banned' });
+		await tommasoClient2
+			.channel('messaging', tommasoChannelId)
+			.sendMessage({ text: 'I am not banned' });
+		await thierryClient1
+			.channel('messaging', thierryChannelId)
+			.sendMessage({ text: 'I am not banned' });
+		await thierryClient2
+			.channel('messaging', thierryChannelId)
+			.sendMessage({ text: 'I am not banned' });
+	});
+});

--- a/test/integration/channels.js
+++ b/test/integration/channels.js
@@ -462,7 +462,10 @@ describe('Channels - members', function () {
 					{ state: true },
 				);
 				expect(channels.length).to.be.equal(2);
-				expect(channels[0].data.last_message_at).to.be.equal(last_message);
+				// parse date to avoid precision issues
+				expect(Date.parse(channels[0].data.last_message_at)).to.be.equal(
+					Date.parse(last_message),
+				);
 			}
 			channel1Messages.push(results[0].message);
 			channel2Messages.push(msg2.message);

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -21,11 +21,10 @@ export function getTestClientForUser2(userID, status, options) {
 
 export async function getTestClientForUser(userID, status, options) {
 	const client = getTestClient(false);
-	const health = await client.setUser(
+	client.health = await client.setUser(
 		{ id: userID, status, ...options },
 		createUserToken(userID),
 	);
-	client.health = health;
 	return client;
 }
 
@@ -93,7 +92,7 @@ export async function createUsers(userIDs) {
 	for (const userID of userIDs) {
 		users.push({ id: userID });
 	}
-	return await serverClient.updateUsers(users);
+	return await serverClient.upsertUsers(users);
 }
 
 export function createEventWaiter(clientOrChannel, eventTypes) {


### PR DESCRIPTION
This PR contains Ban by IP feature implementation.

I had to add some `X-Forwarded-For` trickery for IP manipulation, I would love to hear the feedback about this approach.

Also fixed a couple of warnings in `utils.js`

**Proposed Ban By IP API (Server-Side only):**

To ban user account and it's last known IP address you should provide `ip_ban: true` option to the `banUser` call:
```js
client.banUser(userToBan.id, {
  user_id: adminUser.id,
  ip_ban: true,
});
```

The unban procedure is unchanged:
```js
client.unbanUser(userToUnban.id);
```

When unbanning user who was banned by IP, IP will be unbanned even if there's another account who was using the same IP address.