### PR TITLE
fix #487: form data file name in browser

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import FormData, { AppendOptions } from 'form-data';
+import FormData from 'form-data';
 
 /**
  * logChatPromiseExecution - utility function for logging the execution of a promise..
@@ -61,12 +61,9 @@ export function addFileToFormData(
 ) {
   const data = new FormData();
 
-  const appendOptions: AppendOptions = {};
-  if (name) appendOptions.filename = name;
-  if (contentType) appendOptions.contentType = contentType;
-
   if (isReadableStream(uri) || isBuffer(uri) || isFileWebAPI(uri)) {
-    data.append('file', uri, appendOptions);
+    if (name) data.append('file', uri, name);
+    else data.append('file', uri);
   } else {
     data.append('file', {
       uri,

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -2990,16 +2990,27 @@ describe('Chat', () => {
 				await channel.watch();
 			});
 
-			it('Upload a file', async () => {
+			it('Upload a file with specific name', async () => {
 				const file = fs.createReadStream('./helloworld.txt');
-				const data = await channel.sendFile(file, 'hello_world.txt');
+				const data = await channel.sendFile(file, 'XX.txt');
+
 				expect(data.file).to.be.not.empty;
+				expect(data.file.includes('XX.txt?')).to.be.ok;
+			});
+
+			it('Upload a file without name', async () => {
+				const file = fs.createReadStream('./helloworld.txt');
+				const data = await channel.sendFile(file);
+
+				expect(data.file).to.be.not.empty;
+				expect(data.file.includes('helloworld.txt?')).to.be.ok;
 			});
 
 			it('Upload a stream', (done) => {
 				https.get('https://nodejs.org/static/legacy/images/logo.png', (file) => {
 					channel.sendFile(file).then((data) => {
 						expect(data.file).to.be.not.empty;
+						expect(data.file.includes('logo.png?')).to.be.ok;
 						done();
 					});
 				});
@@ -3009,18 +3020,21 @@ describe('Chat', () => {
 				const file = Buffer.from('random string');
 				const data = await channel.sendFile(file, 'hello_world.txt');
 				expect(data.file).to.be.not.empty;
+				expect(data.file.includes('hello_world.txt?')).to.be.ok;
 			});
 
 			it('Upload an image', async () => {
 				const file = fs.createReadStream('./helloworld.jpg');
 				const data = await channel.sendImage(file, 'hello_world.jpg');
 				expect(data.file).to.be.not.empty;
+				expect(data.file.includes('hello_world.jpg?')).to.be.ok;
 			});
 
 			it('Upload a less common image format', async () => {
 				const file = fs.createReadStream('./helloworld.heic');
 				const data = await channel.sendImage(file, 'hello_world.heic');
 				expect(data.file).to.be.not.empty;
+				expect(data.file.includes('hello_world.heic?')).to.be.ok;
 			});
 
 			it('File upload entire flow', async () => {


### PR DESCRIPTION
apparently `FormData.append()` signature is different between the browser and 3rd party library we use for the node env, 3rd argument should only be `filename: string` 

similar to https://github.com/GetStream/stream-js/pull/393