### PR TITLE
[CHAT-852] Add support for banned_by_id in ban methods

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1604,6 +1604,13 @@ export class StreamChat<
    * @returns {Promise<APIResponse>}
    */
   async banUser(targetUserID: string, options?: BanUserOptions<UserType>) {
+    if (options?.user_id !== undefined) {
+      options.banned_by_id = options.user_id;
+      delete options.user_id;
+      console.warn(
+        "banUser: 'user_id' is deprecated, please consider switching to 'banned_by_id'",
+      );
+    }
     return await this.post<APIResponse>(this.baseURL + '/moderation/ban', {
       target_user_id: targetUserID,
       ...options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -590,10 +590,14 @@ export type UserResponse<UserType = UnknownType> = User<UserType> & {
  */
 
 export type BanUserOptions<UserType = UnknownType> = UnBanUserOptions & {
+  banned_by_id?: string;
   ip_ban?: boolean;
   reason?: string;
   timeout?: number;
   user?: UserResponse<UserType>;
+  /**
+   * @deprecated please use banned_by_id
+   */
   user_id?: string;
 };
 

--- a/test/integration/ban_by_ip.js
+++ b/test/integration/ban_by_ip.js
@@ -74,7 +74,7 @@ describe('ban user by ip', () => {
 
 	it('ban tommaso by IP', async () => {
 		await serverClient.banUser(tommasoID, {
-			user_id: adminUser.id,
+			banned_by_id: adminUser.id,
 			ip_ban: true,
 		});
 	});

--- a/test/integration/query_members.js
+++ b/test/integration/query_members.js
@@ -60,7 +60,7 @@ describe('Query Members', function () {
 		await channel.inviteMembers([invited, pending, rejected]);
 
 		// mod bans user banned
-		await channel.banUser(banned, { user_id: mod });
+		await channel.banUser(banned, { banned_by_id: mod });
 
 		// accept the invite
 		const clientA = await getTestClientForUser(invited);

--- a/test/integration/serverside.js
+++ b/test/integration/serverside.js
@@ -604,7 +604,7 @@ describe('Managing users', function () {
 
 	it('ban user', async function () {
 		await client.banUser(evilUser, {
-			user_id: user.id,
+			banned_by_id: user.id,
 		});
 	});
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -315,8 +315,8 @@ describe('Chat', () => {
 				const admin = { id: uuidv4(), role: 'admin' };
 				const serverClient = getTestClient(true);
 
-				await serverClient.updateUsers([{ id: banned }, admin]);
-				await serverClient.banUser(banned, { user_id: admin.id });
+				await serverClient.upsertUsers([{ id: banned }, admin]);
+				await serverClient.banUser(banned, { banned_by_id: admin.id });
 			});
 
 			it('returns banned field on setUser', async () => {
@@ -353,8 +353,11 @@ describe('Chat', () => {
 				const admin = { id: uuidv4(), role: 'admin' };
 				const serverClient = getTestClient(true);
 
-				await serverClient.updateUsers([{ id: banned }, admin]);
-				await serverClient.banUser(banned, { timeout: -1, user_id: admin.id });
+				await serverClient.upsertUsers([{ id: banned }, admin]);
+				await serverClient.banUser(banned, {
+					timeout: -1,
+					banned_by_id: admin.id,
+				});
 			});
 
 			it('banned is set to false', async () => {
@@ -2773,7 +2776,7 @@ describe('Chat', () => {
 			await serverAuthClient.banUser('eviluser', {
 				timeout: 60,
 				reason: 'Stop spamming your YouTube channel',
-				user_id: modUserID,
+				banned_by_id: modUserID,
 			});
 		});
 		it('Mute', async () => {

--- a/test/integration/webhook.js
+++ b/test/integration/webhook.js
@@ -712,7 +712,7 @@ describe('Webhooks', function () {
 			promises.waitForEvents('user.banned'),
 			client.banUser(newUserID, {
 				reason: 'testy mctestify',
-				user_id: thierryID,
+				banned_by_id: thierryID,
 				timeout: 120,
 			}),
 		]);
@@ -738,7 +738,10 @@ describe('Webhooks', function () {
 		// Ban the user
 		const [events] = await Promise.all([
 			promises.waitForEvents('user.banned'),
-			chan.banUser(newUserID, { reason: 'testy mctestify', user_id: thierryID }),
+			chan.banUser(newUserID, {
+				reason: 'testy mctestify',
+				banned_by_id: thierryID,
+			}),
 		]);
 
 		const event = events[0];
@@ -758,7 +761,7 @@ describe('Webhooks', function () {
 		await client.upsertUser({ id: newUserID });
 		await client.banUser(newUserID, {
 			reason: 'testy mctestify',
-			user_id: thierryID,
+			banned_by_id: thierryID,
 		});
 
 		// Unban the user


### PR DESCRIPTION
This change deprecates user_id field in ban options to avoid misinterpretation of the field purpose. REST API will support both names, but the clients should migrate towards new name: `moderator_id`.

**This PR should be merged only after the backend release**