### PR TITLE
[CHAT-1176] Add tests to prove sort's deterministic nature

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1055,6 +1055,16 @@ export class StreamChat<
     }
   }
 
+  _buildSort(
+    sort: UserSort | ChannelSort,
+  ): Array<{ field: string; direction?: AscDesc }> {
+    const sortFields: Array<{ field: string; direction?: AscDesc }> = [];
+    for (const [field, direction] of Object.entries(sort)) {
+      sortFields.push({ field, direction });
+    }
+    return sortFields;
+  }
+
   async connect() {
     this.connecting = true;
     const client = this;
@@ -1119,11 +1129,6 @@ export class StreamChat<
     sort: UserSort<UserType> = {},
     options: UserOptions = {},
   ) {
-    const sortFields: Array<{ field: string; direction?: AscDesc }> = [];
-    for (const [k, v] of Object.entries(sort)) {
-      sortFields.push({ field: k, direction: v });
-    }
-
     const defaultOptions = {
       presence: false,
     };
@@ -1143,7 +1148,7 @@ export class StreamChat<
     >(this.baseURL + '/users', {
       payload: {
         filter_conditions: filterConditions,
-        sort: sortFields,
+        sort: this._buildSort(sort),
         ...defaultOptions,
         ...options,
       },
@@ -1159,12 +1164,6 @@ export class StreamChat<
     sort: ChannelSort = {},
     options: ChannelOptions = {},
   ) {
-    const sortFields: { field: string; direction?: AscDesc }[] = [];
-
-    for (const [k, v] of Object.entries(sort)) {
-      sortFields.push({ field: k, direction: v });
-    }
-
     const defaultOptions: ChannelOptions = {
       state: true,
       watch: true,
@@ -1181,7 +1180,7 @@ export class StreamChat<
     // Return a list of channels
     const payload = {
       filter_conditions: filterConditions,
-      sort: sortFields,
+      sort: this._buildSort(sort),
       user_details: this._user,
       ...defaultOptions,
       ...options,

--- a/test/unit/sort.js
+++ b/test/unit/sort.js
@@ -1,0 +1,27 @@
+import chai from 'chai';
+import { StreamChat } from '../../src';
+
+const expect = chai.expect;
+
+describe('test if sort is deterministic', () => {
+	const client = new StreamChat('');
+	it('test sort order', () => {
+		let sort = client._buildSort({
+			created_at: 1,
+			has_unread: -1,
+		});
+		expect(sort).to.have.length(2);
+		expect(sort[0].field).to.be.equal('created_at');
+		expect(sort[0].direction).to.be.equal(1);
+		expect(sort[1].field).to.be.equal('has_unread');
+		expect(sort[1].direction).to.be.equal(-1);
+		sort = client._buildSort({
+			has_unread: -1,
+			created_at: 1,
+		});
+		expect(sort[0].field).to.be.equal('has_unread');
+		expect(sort[0].direction).to.be.equal(-1);
+		expect(sort[1].field).to.be.equal('created_at');
+		expect(sort[1].direction).to.be.equal(1);
+	});
+});


### PR DESCRIPTION
This PR adds a test for sort functions which proves that field order in multi-sort situations is preserved