### PR TITLE
Update sort types

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,7 +1,7 @@
 import Immutable from 'seamless-immutable';
 import { ChannelState } from './channel_state';
 import { isValidEventType } from './events';
-import { logChatPromiseExecution } from './utils';
+import { logChatPromiseExecution, normalizeQuerySort } from './utils';
 import { StreamChat } from './client';
 import {
   APIResponse,
@@ -355,7 +355,7 @@ export class Channel<
    * queryMembers - Query Members
    *
    * @param {UserFilters<UserType>}  filterConditions object MongoDB style filters
-   * @param {UserSort<UserType> | UserSort<UserType>[]} [sort] Sort options, for instance {created_at: -1}.
+   * @param {UserSort<UserType>} [sort] Sort options, for instance {created_at: -1}.
    * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_active: -1}, {created_at: 1}]
    * @param {{ limit?: number; offset?: number }} [options] Option object, {limit: 10, offset:10}
    *
@@ -363,7 +363,7 @@ export class Channel<
    */
   async queryMembers(
     filterConditions: UserFilters<UserType>,
-    sort: UserSort<UserType> | UserSort<UserType>[] = [],
+    sort: UserSort<UserType> = [],
     options: { limit?: number; offset?: number } = {},
   ) {
     let id: string | undefined;
@@ -382,7 +382,7 @@ export class Channel<
           type,
           id,
           members,
-          sort: this.getClient()._normalizeQuerySort(sort),
+          sort: normalizeQuerySort(sort),
           filter_conditions: filterConditions,
           ...options,
         },

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,13 +11,12 @@ import { StableWSConnection } from './connection';
 import { isValidEventType } from './events';
 import { JWTUserToken, DevToken, CheckSignature } from './signing';
 import { TokenManager } from './token_manager';
-import { isFunction, addFileToFormData, chatCodes } from './utils';
+import { isFunction, addFileToFormData, chatCodes, normalizeQuerySort } from './utils';
 
 import {
   APIResponse,
   AppSettings,
   AppSettingsAPIResponse,
-  AscDesc,
   BanUserOptions,
   BlockList,
   BlockListResponse,
@@ -1055,26 +1054,6 @@ export class StreamChat<
     }
   }
 
-  _normalizeQuerySort(
-    // todo: generalize type
-    sort: UserSort | ChannelSort | ChannelSort[] | UserSort[],
-  ): Array<{ field: string; direction?: AscDesc }> {
-    const sortFields: Array<{ field: string; direction?: AscDesc }> = [];
-    const sortArr = Array.isArray(sort) ? sort : [sort];
-    for (const item of sortArr) {
-      const entries = Object.entries(item);
-      if (entries.length > 1) {
-        console.warn(
-          "client._buildSort() - multiple fields in a single sort object detected. Object's field order is not guaranteed",
-        );
-      }
-      for (const [field, direction] of entries) {
-        sortFields.push({ field, direction });
-      }
-    }
-    return sortFields;
-  }
-
   async connect() {
     this.connecting = true;
     const client = this;
@@ -1129,7 +1108,7 @@ export class StreamChat<
    * queryUsers - Query users and watch user presence
    *
    * @param {UserFilters<UserType>} filterConditions MongoDB style filter conditions
-   * @param {UserSort<UserType> | UserSort<UserType>[]} sort Sort options, for instance {last_active: -1}.
+   * @param {UserSort<UserType>} sort Sort options, for instance {last_active: -1}.
    * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_active: -1}, {created_at: 1}]
    * @param {UserOptions} options Option object, {presence: true}
    *
@@ -1137,7 +1116,7 @@ export class StreamChat<
    */
   async queryUsers(
     filterConditions: UserFilters<UserType>,
-    sort: UserSort<UserType> | UserSort<UserType>[] = [],
+    sort: UserSort<UserType> = [],
     options: UserOptions = {},
   ) {
     const defaultOptions = {
@@ -1159,7 +1138,7 @@ export class StreamChat<
     >(this.baseURL + '/users', {
       payload: {
         filter_conditions: filterConditions,
-        sort: this._normalizeQuerySort(sort),
+        sort: normalizeQuerySort(sort),
         ...defaultOptions,
         ...options,
       },
@@ -1174,7 +1153,7 @@ export class StreamChat<
    * queryChannels - Query channels
    *
    * @param {ChannelFilters<ChannelType, CommandType, UserType>} filterConditions object MongoDB style filters
-   * @param {ChannelSort | ChannelSort[]} [sort] Sort options, for instance {created_at: -1}.
+   * @param {ChannelSort<ChannelType>} [sort] Sort options, for instance {created_at: -1}.
    * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_updated: -1}, {created_at: 1}]
    * @param {ChannelOptions} [options] Options object
    *
@@ -1182,7 +1161,7 @@ export class StreamChat<
    */
   async queryChannels(
     filterConditions: ChannelFilters<ChannelType, CommandType, UserType>,
-    sort: ChannelSort | ChannelSort[] = [],
+    sort: ChannelSort<ChannelType> = [],
     options: ChannelOptions = {},
   ) {
     const defaultOptions: ChannelOptions = {
@@ -1201,7 +1180,7 @@ export class StreamChat<
     // Return a list of channels
     const payload = {
       filter_conditions: filterConditions,
-      sort: this._normalizeQuerySort(sort),
+      sort: normalizeQuerySort(sort),
       user_details: this._user,
       ...defaultOptions,
       ...options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1114,7 +1114,11 @@ export type UserFilters<UserType = UnknownType> = QueryFilters<
  * Sort Types
  */
 
-export type ChannelSort<ChannelType = UnknownType> = Sort<ChannelType> & {
+export type ChannelSort<ChannelType = UnknownType> =
+  | ChannelSortBase<ChannelType>
+  | Array<ChannelSortBase<ChannelType>>;
+
+export type ChannelSortBase<ChannelType = UnknownType> = Sort<ChannelType> & {
   created_at?: AscDesc;
   has_unread?: AscDesc;
   last_message_at?: AscDesc;
@@ -1128,7 +1132,13 @@ export type Sort<T> = {
   [P in keyof T]?: AscDesc;
 };
 
-export type UserSort<UserType = UnknownType> = Sort<UserResponse<UserType>>;
+export type UserSort<UserType = UnknownType> =
+  | Sort<UserResponse<UserType>>
+  | Array<Sort<UserResponse<UserType>>>;
+
+export type QuerySort<ChannelType = UnknownType, UserType = UnknownType> =
+  | ChannelSort<ChannelType>
+  | UserSort<UserType>;
 
 /**
  * Base Types

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import FormData from 'form-data';
+import { AscDesc, QuerySort } from 'types';
 
 /**
  * logChatPromiseExecution - utility function for logging the execution of a promise..
@@ -74,4 +75,24 @@ export function addFileToFormData(
   }
 
   return data;
+}
+
+export function normalizeQuerySort<T extends QuerySort>(sort: T) {
+  const sortFields = [];
+  const sortArr = Array.isArray(sort) ? sort : [sort];
+  for (const item of sortArr) {
+    const entries = (Object.entries(item) as unknown) as [
+      T extends (infer K)[] ? keyof K : keyof T,
+      AscDesc,
+    ][];
+    if (entries.length > 1) {
+      console.warn(
+        "client._buildSort() - multiple fields in a single sort object detected. Object's field order is not guaranteed",
+      );
+    }
+    for (const [field, direction] of entries) {
+      sortFields.push({ field, direction });
+    }
+  }
+  return sortFields;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import FormData from 'form-data';
-import { AscDesc, QuerySort } from 'types';
+import { AscDesc, QuerySort } from './types';
 
 /**
  * logChatPromiseExecution - utility function for logging the execution of a promise..

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -28,8 +28,8 @@ const apiKey = 'apiKey';
 
 type UserType = {
   id: string;
-  name?: string;
   example?: number;
+  name?: string;
   phone?: number;
 };
 

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -1,12 +1,11 @@
 import chai from 'chai';
-import { StreamChat } from '../../src';
+import { normalizeQuerySort } from '../../src/utils';
 
 const expect = chai.expect;
 
 describe('test if sort is deterministic', () => {
-	const client = new StreamChat('');
 	it('test sort object', () => {
-		let sort = client._normalizeQuerySort({
+		let sort = normalizeQuerySort({
 			created_at: 1,
 			has_unread: -1,
 		});
@@ -15,7 +14,7 @@ describe('test if sort is deterministic', () => {
 		expect(sort[0].direction).to.be.equal(1);
 		expect(sort[1].field).to.be.equal('has_unread');
 		expect(sort[1].direction).to.be.equal(-1);
-		sort = client._normalizeQuerySort({
+		sort = normalizeQuerySort({
 			has_unread: -1,
 			created_at: 1,
 		});
@@ -25,20 +24,20 @@ describe('test if sort is deterministic', () => {
 		expect(sort[1].direction).to.be.equal(1);
 	});
 	it('test sort array', () => {
-		let sort = client._normalizeQuerySort([{ created_at: 1 }, { has_unread: -1 }]);
+		let sort = normalizeQuerySort([{ created_at: 1 }, { has_unread: -1 }]);
 		expect(sort).to.have.length(2);
 		expect(sort[0].field).to.be.equal('created_at');
 		expect(sort[0].direction).to.be.equal(1);
 		expect(sort[1].field).to.be.equal('has_unread');
 		expect(sort[1].direction).to.be.equal(-1);
-		sort = client._normalizeQuerySort([{ has_unread: -1 }, { created_at: 1 }]);
+		sort = normalizeQuerySort([{ has_unread: -1 }, { created_at: 1 }]);
 		expect(sort[0].field).to.be.equal('has_unread');
 		expect(sort[0].direction).to.be.equal(-1);
 		expect(sort[1].field).to.be.equal('created_at');
 		expect(sort[1].direction).to.be.equal(1);
 	});
 	it('test sort array with multi-field objects', () => {
-		let sort = client._normalizeQuerySort([
+		let sort = normalizeQuerySort([
 			{ created_at: 1, has_unread: -1 },
 			{ last_active: 1, deleted_at: -1 },
 		]);


### PR DESCRIPTION
The tests need to be fixed as I didn't have time to look at them, I believe these should be the correct typings and I don't think the helper function needs to reside on the client. @mahboubii we need to discuss the allowed syntax though. Should it be that the sort takes a sort object or an array of sort object? or should it be 1:1 with the backend, where it takes a sort object or and array of {field, direction} objects?