### PR TITLE
fix: duplicated new messages by current user

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1542,9 +1542,11 @@ export class Channel<
         break;
       case 'message.new':
         if (event.message) {
-          s.addMessageSorted(event.message);
+          /* if message belongs to current user, always assume timestamp is changed to filter it out and add again to avoid duplication */
+          const ownMessage = event.user?.id === this.getClient().user?.id;
+          s.addMessageSorted(event.message, ownMessage);
 
-          if (event.user?.id === this.getClient().user?.id) {
+          if (ownMessage) {
             s.unreadCount = 0;
           } else if (this._countMessageAsUnread(event.message)) {
             s.unreadCount = s.unreadCount + 1;


### PR DESCRIPTION
There are some edgy cases with react components when message preview is added and gets updated after it's actually is sent. Few users are experiencing race condition when the actual event update the list before react is able to do so.
