### PR TITLE
replace uuid with nanoid

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "form-data": "^3.0.0",
     "isomorphic-ws": "^4.0.1",
     "jsonwebtoken": "^8.5.1",
-    "nanoid": "^3.1.18",
     "seamless-immutable": "^7.1.4",
     "ws": "^7.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -38,15 +38,14 @@
     "@babel/runtime": "^7.12.1",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/seamless-immutable": "7.1.13",
-    "@types/uuid": "^8.3.0",
     "@types/ws": "^7.2.7",
     "axios": "^0.21.0",
     "base64-js": "^1.3.1",
     "form-data": "^3.0.0",
     "isomorphic-ws": "^4.0.1",
     "jsonwebtoken": "^8.5.1",
+    "nanoid": "^3.1.18",
     "seamless-immutable": "^7.1.4",
-    "uuid": "^8.3.1",
     "ws": "^7.3.1"
   },
   "devDependencies": {
@@ -109,7 +108,8 @@
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^7.0.2",
     "sinon": "^9.2.0",
-    "typescript": "^4.0.3"
+    "typescript": "^4.0.3",
+    "uuid": "^8.3.1"
   },
   "scripts": {
     "start": "yarn run compile -w",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,7 @@ const externalPackages = [
 	'form-data',
 	'isomorphic-ws',
 	'seamless-immutable',
-	'uuid',
+	'nanoid/non-secure',
 	'base64-js',
 	/@babel\/runtime/,
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,7 +15,6 @@ const externalPackages = [
 	'form-data',
 	'isomorphic-ws',
 	'seamless-immutable',
-	'nanoid/non-secure',
 	'base64-js',
 	/@babel\/runtime/,
 ];

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,8 +4,6 @@
 import axios, { AxiosRequestConfig, AxiosInstance, AxiosResponse } from 'axios';
 import https from 'https';
 import WebSocket from 'isomorphic-ws';
-/** safe to use non-secure to support ReactNative */
-import { nanoid } from 'nanoid/non-secure';
 
 import { Channel } from './channel';
 import { ClientState } from './client_state';
@@ -13,7 +11,13 @@ import { StableWSConnection } from './connection';
 import { isValidEventType } from './events';
 import { JWTUserToken, DevToken, CheckSignature } from './signing';
 import { TokenManager } from './token_manager';
-import { isFunction, addFileToFormData, chatCodes, normalizeQuerySort } from './utils';
+import {
+  isFunction,
+  addFileToFormData,
+  chatCodes,
+  normalizeQuerySort,
+  randomId,
+} from './utils';
 
 import {
   APIResponse,
@@ -302,7 +306,7 @@ export class StreamChat<
   }
 
   _setupConnection = () => {
-    this.clientID = `${this.userID}--${nanoid()}`;
+    this.clientID = `${this.userID}--${randomId()}`;
     this.wsPromise = this.connect();
     this._startCleaning();
     return this.wsPromise;
@@ -466,7 +470,7 @@ export class StreamChat<
 
   setAnonymousUser = () => {
     this.anonymous = true;
-    this.userID = nanoid();
+    this.userID = randomId();
     const anonymousUser = {
       id: this.userID,
       anon: true,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,8 +3,10 @@
 
 import axios, { AxiosRequestConfig, AxiosInstance, AxiosResponse } from 'axios';
 import https from 'https';
-import { v4 as uuidv4 } from 'uuid';
 import WebSocket from 'isomorphic-ws';
+/** safe to use non-secure to support ReactNative */
+import { nanoid } from 'nanoid/non-secure';
+
 import { Channel } from './channel';
 import { ClientState } from './client_state';
 import { StableWSConnection } from './connection';
@@ -145,7 +147,6 @@ export class StreamChat<
   user?: UserResponse<UserType>;
   userAgent?: string;
   userID?: string;
-  UUID?: string;
   wsBaseURL?: string;
   wsConnection: StableWSConnection<ChannelType, CommandType, UserType> | null;
   wsPromise: ConnectAPIResponse<ChannelType, CommandType, UserType> | null;
@@ -301,8 +302,7 @@ export class StreamChat<
   }
 
   _setupConnection = () => {
-    this.UUID = uuidv4();
-    this.clientID = `${this.userID}--${this.UUID}`;
+    this.clientID = `${this.userID}--${nanoid()}`;
     this.wsPromise = this.connect();
     this._startCleaning();
     return this.wsPromise;
@@ -466,7 +466,7 @@ export class StreamChat<
 
   setAnonymousUser = () => {
     this.anonymous = true;
-    this.userID = uuidv4();
+    this.userID = nanoid();
     const anonymousUser = {
       id: this.userID,
       anon: true,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,3 +96,13 @@ export function normalizeQuerySort<T extends QuerySort>(sort: T) {
   }
   return sortFields;
 }
+
+/** adopted from https://github.com/ai/nanoid/blob/master/non-secure/index.js */
+const alphabet = 'ModuleSymbhasOwnPr0123456789ABCDEFGHNRVfgctiUvzKqYTJkLxpZXIjQW';
+export function randomId() {
+  let id = '';
+  for (let i = 0; i < 21; i++) {
+    id += alphabet[(Math.random() * 64) | 0];
+  }
+  return id;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,11 +1407,6 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz#3a84cf5ec3249439015e14049bd3161419bf9eae"
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
 
-"@types/uuid@^8.3.0":
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
-  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
-
 "@types/ws@^7.2.7":
   version "7.2.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.2.7.tgz#362ad1a1d62721bdb725e72c8cccf357078cf5a3"
@@ -4101,6 +4096,11 @@ nanoid@3.1.12:
   version "3.1.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+
+nanoid@^3.1.18:
+  version "3.1.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.18.tgz#0680db22ab01c372e89209f5d18283d98de3e96d"
+  integrity sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==
 
 nanomatch@^1.2.9:
   version "1.2.13"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4097,11 +4097,6 @@ nanoid@3.1.12:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
   integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
 
-nanoid@^3.1.18:
-  version "3.1.18"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.18.tgz#0680db22ab01c372e89209f5d18283d98de3e96d"
-  integrity sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
we don't really need cryptographically strong random values here, simpler implementation to support ReactNative/Expo apps.

clientID will look like this `firh1Xuozx1Q0UHUgUENp` instead of UUID format in API logs. 

[`nanoid/non-secure`](https://github.com/ai/nanoid/blob/master/non-secure/index.js) implemention : 
```js
// This alphabet uses `A-Za-z0-9_-` symbols. The genetic algorithm helped optimize the gzip compression for this alphabet.
urlAlphabet = 'ModuleSymbhasOwnPr-0123456789ABCDEFGHNRVfgctiUvz_KqYTJkLxpZXIjQW';

 nanoid = (size = 21) => {
  let id = ''
  // A compact alternative for `for (var i = 0; i < step; i++)`.
  let i = size
  while (i--) {
    // `| 0` is more compact and faster than `Math.floor()`.
    id += urlAlphabet[(Math.random() * 64) | 0]
  }
  return id
}

```