### PR TITLE
[CHAT-1411] make accept/reject invite a NOOP if the user is already accepted or rejected the invite

### DIFF
--- a/test/integration/invites.js
+++ b/test/integration/invites.js
@@ -152,9 +152,12 @@ describe('Member style channel init', () => {
 		expect(response.members[1].invite_accepted_at).to.not.equal(null);
 		await notificationReceived;
 		// second time should be a noop
-		response = nickChannel.acceptInvite();
+		response = await nickChannel.acceptInvite({
+			message: { text: 'Nick accepted the chat invite.' },
+		});
 		expect(response.members[1].user.id).to.equal('nick');
 		expect(response.members[1].invite_accepted_at).to.not.equal(null);
+		expect(response.message).to.be.undefined;
 	});
 
 	it('Reject an invite', async () => {

--- a/test/integration/invites.js
+++ b/test/integration/invites.js
@@ -151,10 +151,10 @@ describe('Member style channel init', () => {
 		expect(response.members[1].user.id).to.equal('nick');
 		expect(response.members[1].invite_accepted_at).to.not.equal(null);
 		await notificationReceived;
-		// second time be a noop
+		// second time should be a noop
 		response = nickChannel.acceptInvite();
-		expect(response.message.text).to.equal('Nick accepted the chat invite.');
 		expect(response.members[1].user.id).to.equal('nick');
+		expect(response.members[1].invite_accepted_at).to.not.equal(null);
 	});
 
 	it('Reject an invite', async () => {

--- a/test/integration/invites.js
+++ b/test/integration/invites.js
@@ -143,7 +143,7 @@ describe('Member style channel init', () => {
 			});
 		});
 
-		const response = await nickChannel.acceptInvite({
+		let response = await nickChannel.acceptInvite({
 			message: { text: 'Nick accepted the chat invite.' },
 		});
 		await nickChannel.watch();
@@ -151,13 +151,10 @@ describe('Member style channel init', () => {
 		expect(response.members[1].user.id).to.equal('nick');
 		expect(response.members[1].invite_accepted_at).to.not.equal(null);
 		await notificationReceived;
-		// second time should fail...
-		await expectHTTPErrorCode(
-			400,
-			nickChannel.acceptInvite({
-				message: { text: 'Nick accepted the chat invite.' },
-			}),
-		);
+		// second time be a noop
+		response = nickChannel.acceptInvite();
+		expect(response.message.text).to.equal('Nick accepted the chat invite.');
+		expect(response.members[1].user.id).to.equal('nick');
 	});
 
 	it('Reject an invite', async () => {
@@ -184,13 +181,15 @@ describe('Member style channel init', () => {
 		});
 		await thierryChannel.watch();
 		await nickChannel.watch();
-		const response = await nickChannel.rejectInvite();
+		let response = await nickChannel.rejectInvite();
 		expect(response.members[1].user.id).to.equal('nick');
 		expect(response.members[1].invite_rejected_at).to.not.equal(null);
 		await inviteRejected;
 		await updateReceived;
-		// second time should fail...
-		await expectHTTPErrorCode(400, nickChannel.rejectInvite());
+		// second time should be a noop
+		response = await nickChannel.rejectInvite();
+		expect(response.members[1].user.id).to.equal('nick');
+		expect(response.members[1].invite_rejected_at).to.not.equal(null);
 	});
 });
 


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
