### PR TITLE
Removed unused field from `query_channels`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1213,7 +1213,6 @@ export class StreamChat<
     const payload = {
       filter_conditions: filterConditions,
       sort: normalizeQuerySort(sort),
-      user_details: this._user,
       ...defaultOptions,
       ...options,
     };


### PR DESCRIPTION
Field `user_details` is not used in `query_channels` API in any way. In cases when `this._user` field gets too large, application could experience performance issues.