### PR TITLE
[CHAT-1428] Switched queryChannels to POST

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1221,7 +1221,7 @@ export class StreamChat<
       ...options,
     };
 
-    const data = await this.get<{
+    const data = await this.post<{
       channels: ChannelAPIResponse<
         AttachmentType,
         ChannelType,
@@ -1230,9 +1230,7 @@ export class StreamChat<
         ReactionType,
         UserType
       >[];
-    }>(this.baseURL + '/channels', {
-      payload,
-    });
+    }>(this.baseURL + '/channels', payload);
 
     const channels: Channel<
       AttachmentType,


### PR DESCRIPTION
We added support for POST in the `queryChannels` API to address performance issues