### PR TITLE
[CHAT-1516] Support pinned messages in channel state

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1728,11 +1728,10 @@ export class Channel<
       this.state.messages = Immutable([]);
     }
     this.state.addMessagesSorted(messages, false, true);
-    const pinnedMessages = state.pinned_messages || [];
-    if (!this.state.pinned_messages) {
-      this.state.pinned_messages = Immutable([]);
+    if (!this.state.pinnedMessages) {
+      this.state.pinnedMessages = Immutable([]);
     }
-    this.state.setPinnedMessages(pinnedMessages);
+    this.state.setPinnedMessages(state.pinned_messages || []);
     this.state.watcher_count = state.watcher_count ? state.watcher_count : 0;
     // convert the arrays into objects for easier syncing...
     if (state.watchers) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1556,6 +1556,9 @@ export class Channel<
         if (event.message) {
           if (event.hard_delete) s.removeMessage(event.message);
           else s.addMessageSorted(event.message);
+          if (event.message.pinned) {
+            s.removePinnedMessage(event.message);
+          }
         }
         break;
       case 'message.new':
@@ -1569,7 +1572,7 @@ export class Channel<
             s.addMessageSorted(event.message, ownMessage);
           }
           if (event.message.pinned) {
-            s.setPinnedMessage(event.message);
+            s.addPinnedMessage(event.message);
           }
 
           if (ownMessage && event.user?.id) {
@@ -1589,7 +1592,11 @@ export class Channel<
       case 'message.updated':
         if (event.message) {
           s.addMessageSorted(event.message);
-          s.setPinnedMessage(event.message);
+          if (event.message.pinned) {
+            s.addPinnedMessage(event.message);
+          } else {
+            s.removePinnedMessage(event.message);
+          }
         }
         break;
       case 'channel.truncated':
@@ -1731,7 +1738,7 @@ export class Channel<
     if (!this.state.pinnedMessages) {
       this.state.pinnedMessages = Immutable([]);
     }
-    this.state.setPinnedMessages(state.pinned_messages || []);
+    this.state.addPinnedMessages(state.pinned_messages || []);
     this.state.watcher_count = state.watcher_count ? state.watcher_count : 0;
     // convert the arrays into objects for easier syncing...
     if (state.watchers) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1568,6 +1568,9 @@ export class Channel<
           if (this.state.isUpToDate || isThreadMessage) {
             s.addMessageSorted(event.message, ownMessage);
           }
+          if (event.message.pinned) {
+            s.setPinnedMessage(event.message);
+          }
 
           if (ownMessage && event.user?.id) {
             s.unreadCount = 0;
@@ -1586,6 +1589,7 @@ export class Channel<
       case 'message.updated':
         if (event.message) {
           s.addMessageSorted(event.message);
+          s.setPinnedMessage(event.message);
         }
         break;
       case 'channel.truncated':
@@ -1724,6 +1728,11 @@ export class Channel<
       this.state.messages = Immutable([]);
     }
     this.state.addMessagesSorted(messages, false, true);
+    const pinnedMessages = state.pinned_messages || [];
+    if (!this.state.pinned_messages) {
+      this.state.pinned_messages = Immutable([]);
+    }
+    this.state.setPinnedMessages(pinnedMessages);
     this.state.watcher_count = state.watcher_count ? state.watcher_count : 0;
     // convert the arrays into objects for easier syncing...
     if (state.watchers) {

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -1,4 +1,4 @@
-import Immutable from 'seamless-immutable';
+import Immutable, { ImmutableDate } from 'seamless-immutable';
 import { Channel } from './channel';
 import {
   ChannelMemberResponse,
@@ -600,11 +600,13 @@ export class ChannelState<
     // for empty list just concat and return
     if (messageArr.length === 0) return messageArr.concat(message);
 
-    const messageTime = message[sortBy]?.getTime() || 0;
-    const lastMessageTime = messageArr[messageArr.length - 1][sortBy]?.getTime() || 0;
+    const messageTime = (message[sortBy] as ImmutableDate).getTime();
 
     // if message is newer than last item in the list concat and return
-    if (lastMessageTime < messageTime) return messageArr.concat(message);
+    if (
+      (messageArr[messageArr.length - 1][sortBy] as ImmutableDate).getTime() < messageTime
+    )
+      return messageArr.concat(message);
 
     // find the closest index to push the new message
     let left = 0;
@@ -612,8 +614,8 @@ export class ChannelState<
     let right = messageArr.length - 1;
     while (left <= right) {
       middle = Math.floor((right + left) / 2);
-      const time = messageArr[middle][sortBy]?.getTime() || 0;
-      if (time <= messageTime) left = middle + 1;
+      if ((messageArr[middle][sortBy] as ImmutableDate).getTime() <= messageTime)
+        left = middle + 1;
       else right = middle - 1;
     }
 

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -285,12 +285,12 @@ export class ChannelState<
   }
 
   /**
-   * setPinnedMessages - updates messages in pinned_messages property
+   * addPinnedMessages - adds messages in pinnedMessages property
    *
    * @param {Array<MessageResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} pinnedMessages A list of pinned messages
    *
    */
-  setPinnedMessages(
+  addPinnedMessages(
     pinnedMessages: MessageResponse<
       AttachmentType,
       ChannelType,
@@ -301,18 +301,17 @@ export class ChannelState<
     >[],
   ) {
     for (let i = 0; i < pinnedMessages.length; i += 1) {
-      this.setPinnedMessage(pinnedMessages[i]);
+      this.addPinnedMessage(pinnedMessages[i]);
     }
   }
 
   /**
-   * setPinnedMessage - update message in pinned_messages property. The messages will be added to pinned_messages if it
-   * is pinned and removed otherwise
+   * addPinnedMessage - adds message in pinnedMessages
    *
    * @param {MessageResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>} pinnedMessage message to update
    *
    */
-  setPinnedMessage(
+  addPinnedMessage(
     pinnedMessage: MessageResponse<
       AttachmentType,
       ChannelType,
@@ -322,18 +321,32 @@ export class ChannelState<
       UserType
     >,
   ) {
-    const message = this.messageToImmutable(pinnedMessage);
-    if (message.pinned) {
-      this.pinnedMessages = this._addToMessageList(
-        this.pinnedMessages,
-        message,
-        false,
-        'pinned_at',
-      );
-    } else {
-      const { result } = this.removeMessageFromArray(this.pinnedMessages, message);
-      this.pinnedMessages = result;
-    }
+    this.pinnedMessages = this._addToMessageList(
+      this.pinnedMessages,
+      this.messageToImmutable(pinnedMessage),
+      false,
+      'pinned_at',
+    );
+  }
+
+  /**
+   * removePinnedMessage - removes pinned message from pinnedMessages
+   *
+   * @param {MessageResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>} message message to remove
+   *
+   */
+  removePinnedMessage(
+    message: MessageResponse<
+      AttachmentType,
+      ChannelType,
+      CommandType,
+      MessageType,
+      ReactionType,
+      UserType
+    >,
+  ) {
+    const { result } = this.removeMessageFromArray(this.pinnedMessages, message);
+    this.pinnedMessages = result;
   }
 
   addReaction(

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -601,10 +601,10 @@ export class ChannelState<
     if (messageArr.length === 0) return messageArr.concat(message);
 
     const messageTime = message[sortBy]?.getTime() || 0;
+    const lastMessageTime = messageArr[messageArr.length - 1][sortBy]?.getTime() || 0;
 
     // if message is newer than last item in the list concat and return
-    if (messageArr[messageArr.length - 1][sortBy]?.getTime() || 0 < messageTime)
-      return messageArr.concat(message);
+    if (lastMessageTime < messageTime) return messageArr.concat(message);
 
     // find the closest index to push the new message
     let left = 0;
@@ -612,7 +612,8 @@ export class ChannelState<
     let right = messageArr.length - 1;
     while (left <= right) {
       middle = Math.floor((right + left) / 2);
-      if (messageArr[middle][sortBy]?.getTime() || 0 <= messageTime) left = middle + 1;
+      const time = messageArr[middle][sortBy]?.getTime() || 0;
+      if (time <= messageTime) left = middle + 1;
       else right = middle - 1;
     }
 

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -221,7 +221,7 @@ export class ChannelState<
       ...message,
       __html: message.html,
       // parse the date..
-      pinned_at: message.pinned_at ? new Date(message.pinned_at) : new Date(),
+      pinned_at: message.pinned_at ? new Date(message.pinned_at) : null,
       created_at: message.created_at ? new Date(message.created_at) : new Date(),
       updated_at: message.updated_at ? new Date(message.updated_at) : new Date(),
       status: message.status || 'received',
@@ -600,10 +600,10 @@ export class ChannelState<
     // for empty list just concat and return
     if (messageArr.length === 0) return messageArr.concat(message);
 
-    const messageTime = message[sortBy].getTime();
+    const messageTime = message[sortBy]?.getTime() || 0;
 
     // if message is newer than last item in the list concat and return
-    if (messageArr[messageArr.length - 1][sortBy].getTime() < messageTime)
+    if (messageArr[messageArr.length - 1][sortBy]?.getTime() || 0 < messageTime)
       return messageArr.concat(message);
 
     // find the closest index to push the new message
@@ -612,7 +612,7 @@ export class ChannelState<
     let right = messageArr.length - 1;
     while (left <= right) {
       middle = Math.floor((right + left) / 2);
-      if (messageArr[middle][sortBy].getTime() <= messageTime) left = middle + 1;
+      if (messageArr[middle][sortBy]?.getTime() || 0 <= messageTime) left = middle + 1;
       else right = middle - 1;
     }
 

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -590,19 +590,6 @@ export class ChannelState<
     sortBy: 'pinned_at' | 'created_at' = 'created_at',
   ) {
     let messageArr = messages;
-    const mutable = messageArr.asMutable() as Array<
-      ReturnType<
-        ChannelState<
-          AttachmentType,
-          ChannelType,
-          CommandType,
-          EventType,
-          MessageType,
-          ReactionType,
-          UserType
-        >['messageToImmutable']
-      >
-    >;
 
     // if created_at has changed, message should be filtered and re-inserted in correct order
     // slow op but usually this only happens for a message inserted to state before actual response with correct timestamp
@@ -616,7 +603,7 @@ export class ChannelState<
     const messageTime = message[sortBy].getTime();
 
     // if message is newer than last item in the list concat and return
-    if (mutable[messageArr.length - 1][sortBy].getTime() < messageTime)
+    if (messageArr[messageArr.length - 1][sortBy].getTime() < messageTime)
       return messageArr.concat(message);
 
     // find the closest index to push the new message
@@ -625,7 +612,7 @@ export class ChannelState<
     let right = messageArr.length - 1;
     while (left <= right) {
       middle = Math.floor((right + left) / 2);
-      if (mutable[middle][sortBy].getTime() <= messageTime) left = middle + 1;
+      if (messageArr[middle][sortBy].getTime() <= messageTime) left = middle + 1;
       else right = middle - 1;
     }
 
@@ -640,6 +627,19 @@ export class ChannelState<
         return messageArr.set(left - 1, message);
     }
 
+    const mutable = messageArr.asMutable() as Array<
+      ReturnType<
+        ChannelState<
+          AttachmentType,
+          ChannelType,
+          CommandType,
+          EventType,
+          MessageType,
+          ReactionType,
+          UserType
+        >['messageToImmutable']
+      >
+    >;
     mutable.splice(left, 0, message);
     return Immutable(mutable);
   }

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -62,6 +62,19 @@ export class ChannelState<
       >['messageToImmutable']
     >
   >;
+  pinned_messages: Immutable.ImmutableArray<
+    ReturnType<
+      ChannelState<
+        AttachmentType,
+        ChannelType,
+        CommandType,
+        EventType,
+        MessageType,
+        ReactionType,
+        UserType
+      >['messageToImmutable']
+    >
+  >;
   threads: Immutable.ImmutableObject<{
     [key: string]: Immutable.ImmutableArray<
       ReturnType<
@@ -127,6 +140,7 @@ export class ChannelState<
       }>;
     }>({});
     this.messages = Immutable([]);
+    this.pinned_messages = Immutable([]);
     this.threads = Immutable<{
       [key: string]: Immutable.ImmutableArray<
         ReturnType<

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -284,6 +284,12 @@ export class ChannelState<
     }
   }
 
+  /**
+   * setPinnedMessages - updates messages in pinned_messages property. See setPinnedMessages for details
+   *
+   * @param {Array<MessageResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} newMessages A list of messages
+   *
+   */
   setPinnedMessages(
     newMessages: MessageResponse<
       AttachmentType,
@@ -299,6 +305,13 @@ export class ChannelState<
     }
   }
 
+  /**
+   * setPinnedMessage - update message in pinned_messages property. The messages will be added to pinned_messages if it
+   * is pinned and removed otherwise
+   *
+   * @param {MessageResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>} newMessage message to update
+   *
+   */
   setPinnedMessage(
     newMessage: MessageResponse<
       AttachmentType,
@@ -602,7 +615,7 @@ export class ChannelState<
     const messageTime = sortBy(message).getTime();
 
     // if message is newer than last item in the list concat and return
-    if (sortBy(mutable[mutable.length - 1]).getTime() < messageTime)
+    if (sortBy(mutable[messageArr.length - 1]).getTime() < messageTime)
       return messageArr.concat(message);
 
     // find the closest index to push the new message

--- a/src/types.ts
+++ b/src/types.ts
@@ -162,6 +162,14 @@ export type ChannelAPIResponse<
     ReactionType,
     UserType
   >[];
+  pinned_messages: MessageResponse<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    MessageType,
+    ReactionType,
+    UserType
+  >[];
   hidden?: boolean;
   membership?: ChannelMembership<UserType> | null;
   read?: ReadResponse<UserType>[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -437,6 +437,9 @@ export type MessageResponse<
   latest_reactions?: ReactionResponse<ReactionType, UserType>[];
   mentioned_users?: UserResponse<UserType>[];
   own_reactions?: ReactionResponse<ReactionType, UserType>[] | null;
+  pin_expires?: string;
+  pinned_at?: string;
+  pinned_by?: UserResponse<UserType> | null;
   quoted_message?: Omit<
     MessageResponse<
       AttachmentType,
@@ -1494,10 +1497,7 @@ export type MessageBase<
   html?: string;
   mml?: string;
   parent_id?: string;
-  pin_expires?: string | null;
   pinned?: boolean;
-  pinned_at?: string | null;
-  pinned_by?: UserResponse<UserType> | null;
   quoted_message_id?: string;
   show_in_channel?: boolean;
   text?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -437,8 +437,8 @@ export type MessageResponse<
   latest_reactions?: ReactionResponse<ReactionType, UserType>[];
   mentioned_users?: UserResponse<UserType>[];
   own_reactions?: ReactionResponse<ReactionType, UserType>[] | null;
-  pin_expires?: string;
-  pinned_at?: string;
+  pin_expires?: string | null;
+  pinned_at?: string | null;
   pinned_by?: UserResponse<UserType> | null;
   quoted_message?: Omit<
     MessageResponse<

--- a/test/integration/messages.js
+++ b/test/integration/messages.js
@@ -344,30 +344,27 @@ describe('pinned messages', () => {
 		before(async () => {
 			chat = await setupTestChannel('messaging', false);
 		});
-		it('pin 10 messages and see all of them', async () => {
+		it('pin 10 permanent and 11 temporary messages', async () => {
 			for (let i = 0; i < 10; i++) {
 				await chat.owner.channel.sendMessage({
 					text: 'Message #' + (i + 1),
 					pinned: true,
 				});
 			}
+			const expires = new Date();
+			expires.setSeconds(expires.getSeconds() + 5);
+			for (let i = 10; i < 21; i++) {
+				await chat.owner.channel.sendMessage({
+					text: 'Message #' + (i + 1),
+					pinned: true,
+					pin_expires: expires.toISOString(),
+				});
+			}
+			await sleep(5000);
 			const state = await chat.owner.channel.query();
 			expect(state.pinned_messages.length).to.be.equal(10);
 			for (let i = 0; i < 10; i++) {
 				expect(state.pinned_messages[i].text).to.be.equal('Message #' + (10 - i));
-			}
-		});
-		it('pin 20 messages and only see last 10', async () => {
-			for (let i = 0; i < 20; i++) {
-				await chat.owner.channel.sendMessage({
-					text: 'Message #' + (i + 1),
-					pinned: true,
-				});
-			}
-			const state = await chat.owner.channel.query();
-			expect(state.pinned_messages.length).to.be.equal(10);
-			for (let i = 0; i < 10; i++) {
-				expect(state.pinned_messages[i].text).to.be.equal('Message #' + (20 - i));
 			}
 		});
 	});

--- a/test/integration/messages.js
+++ b/test/integration/messages.js
@@ -316,6 +316,17 @@ describe('pinned messages', () => {
 			state = await chat.owner.channel.query();
 			expect(state.pinned_messages.length).to.be.equal(initialCount);
 		});
+		it('delete pinned message', async () => {
+			let state = await chat.owner.channel.query();
+			const initialCount = state.pinned_messages.length;
+			const { message } = await chat.owner.channel.sendMessage({
+				text: 'Delete me',
+				pinned: true,
+			});
+			await chat.serverSide.client.deleteMessage(message.id, true);
+			state = await chat.owner.channel.query();
+			expect(state.pinned_messages.length).to.be.equal(initialCount);
+		});
 		it('pin expires', async () => {
 			let state = await chat.owner.channel.query();
 			const initialCount = state.pinned_messages.length;

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -253,7 +253,7 @@ describe('ChannelState addMessagesSorted', function () {
 		);
 	});
 
-	it('sets pinned_messages correctly', async function () {
+	it('sets pinnedMessages correctly', async function () {
 		const msgs = [
 			generateMsg({ id: '1', date: '2020-01-01T00:00:00.001Z' }),
 			generateMsg({ id: '2', date: '2020-01-01T00:00:00.002Z' }),
@@ -266,7 +266,7 @@ describe('ChannelState addMessagesSorted', function () {
 		msgs[2].pinned = true;
 		msgs[2].pinned_at = new Date('2020-01-01T00:00:00.011Z');
 		const state = new ChannelState();
-		state.setPinnedMessages(msgs);
+		state.addPinnedMessages(msgs);
 		expect(state.pinnedMessages.length).to.be.equal(3);
 		expect(state.pinnedMessages[0].id).to.be.equal('1');
 		expect(state.pinnedMessages[1].id).to.be.equal('3');

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -267,9 +267,9 @@ describe('ChannelState addMessagesSorted', function () {
 		msgs[2].pinned_at = new Date('2020-01-01T00:00:00.011Z');
 		const state = new ChannelState();
 		state.setPinnedMessages(msgs);
-		expect(state.pinned_messages.length).to.be.equal(3);
-		expect(state.pinned_messages[0].id).to.be.equal('1');
-		expect(state.pinned_messages[1].id).to.be.equal('3');
-		expect(state.pinned_messages[2].id).to.be.equal('2');
+		expect(state.pinnedMessages.length).to.be.equal(3);
+		expect(state.pinnedMessages[0].id).to.be.equal('1');
+		expect(state.pinnedMessages[1].id).to.be.equal('3');
+		expect(state.pinnedMessages[2].id).to.be.equal('2');
 	});
 });

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -252,4 +252,24 @@ describe('ChannelState addMessagesSorted', function () {
 			new Date('2020-01-01T00:00:00.001Z').getTime(),
 		);
 	});
+
+	it('sets pinned_messages correctly', async function () {
+		const msgs = [
+			generateMsg({ id: '1', date: '2020-01-01T00:00:00.001Z' }),
+			generateMsg({ id: '2', date: '2020-01-01T00:00:00.002Z' }),
+			generateMsg({ id: '3', date: '2020-01-01T00:00:00.003Z' }),
+		];
+		msgs[0].pinned = true;
+		msgs[0].pinned_at = new Date('2020-01-01T00:00:00.010Z');
+		msgs[1].pinned = true;
+		msgs[1].pinned_at = new Date('2020-01-01T00:00:00.012Z');
+		msgs[2].pinned = true;
+		msgs[2].pinned_at = new Date('2020-01-01T00:00:00.011Z');
+		const state = new ChannelState();
+		state.setPinnedMessages(msgs);
+		expect(state.pinned_messages.length).to.be.equal(3);
+		expect(state.pinned_messages[0].id).to.be.equal('1');
+		expect(state.pinned_messages[1].id).to.be.equal('3');
+		expect(state.pinned_messages[2].id).to.be.equal('2');
+	});
 });


### PR DESCRIPTION
This PR adds support for `pinned_messages` property in channel state.

More about this feature in the docs: https://getstream.io/chat/docs/pinned_messages/?language=js