### PR TITLE
Cleaned up deprecated methods usages

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,16 @@ Custom types are carried into all creation functions as well.
 
 ```typescript
 // Valid
-client.setUser({ id: 'testId', nickname: 'testUser', age: 3 }, 'TestToken');
-client.setUser({ id: 'testId', nickname: 'testUser', avatar: 'testAvatar' }, 'TestToken');
+client.connectUser({ id: 'testId', nickname: 'testUser', age: 3 }, 'TestToken');
+client.connectUser(
+  { id: 'testId', nickname: 'testUser', avatar: 'testAvatar' },
+  'TestToken',
+);
 
 // Invalid
-client.setUser({ id: 'testId' }, 'TestToken'); // Type ChatUser1 | ChatUser2 requires nickname for both types
-client.setUser({ id: 'testId', nickname: true }, 'TestToken'); // nickname must be a string
-client.setUser({ id: 'testId', nickname: 'testUser', country: 'NL' }, 'TestToken'); // country does not exist on type ChatUser1 | ChatUser2
+client.connectUser({ id: 'testId' }, 'TestToken'); // Type ChatUser1 | ChatUser2 requires nickname for both types
+client.connectUser({ id: 'testId', nickname: true }, 'TestToken'); // nickname must be a string
+client.connectUser({ id: 'testId', nickname: 'testUser', country: 'NL' }, 'TestToken'); // country does not exist on type ChatUser1 | ChatUser2
 ```
 
 ## More

--- a/docs/userToken.md
+++ b/docs/userToken.md
@@ -4,12 +4,12 @@
 
 ```js
 const client = new StreamChat('api_key');
-client.setUser({ id: 'vishal' }, 'user_token_string');
+client.connectUser({ id: 'vishal' }, 'user_token_string');
 ```
 
 ## Token Provider
 
 ```js
 const client = new StreamChat('api_key');
-client.setUser({ id: 'vishal' }, async () => await fetchTokenFromApi());
+client.connectUser({ id: 'vishal' }, async () => await fetchTokenFromApi());
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -448,8 +448,6 @@ export type MessageResponse<
   status?: string;
   type?: string;
   updated_at?: string;
-  webhook_failed?: boolean;
-  webhook_id?: string;
 };
 
 export type MuteResponse<UserType = UnknownType> = {

--- a/test/integration/ban_by_ip.js
+++ b/test/integration/ban_by_ip.js
@@ -57,8 +57,8 @@ describe('ban user by ip', () => {
 
 	before(async () => {
 		await createUsers([adminUser.id]);
-		await tommasoClient1.setUser({ id: tommasoID }, tommasoToken);
-		await thierryClient1.setUser({ id: thierryID }, thierryToken);
+		await tommasoClient1.connectUser({ id: tommasoID }, tommasoToken);
+		await thierryClient1.connectUser({ id: thierryID }, thierryToken);
 	});
 
 	it('tommaso and thierry create channels', async () => {
@@ -98,8 +98,8 @@ describe('ban user by ip', () => {
 	});
 
 	it('tommaso and thierry switch IP addresses', async () => {
-		await tommasoClient2.setUser({ id: tommasoID }, tommasoToken);
-		await thierryClient2.setUser({ id: thierryID }, thierryToken);
+		await tommasoClient2.connectUser({ id: tommasoID }, tommasoToken);
+		await thierryClient2.connectUser({ id: thierryID }, thierryToken);
 		await tommasoClient2.channel('messaging', tommasoChannelId).watch();
 		await thierryClient2.channel('messaging', thierryChannelId).watch();
 	});

--- a/test/integration/channel_permissions.js
+++ b/test/integration/channel_permissions.js
@@ -28,13 +28,13 @@ class Context {
 	}
 
 	async setup() {
-		await this.authClient.updateUser(this.adminUser);
-		await this.authClient.updateUser(this.moderator);
-		await this.authClient.updateUser(this.guestUser);
-		await this.authClient.updateUser(this.channelMember);
-		await this.authClient.updateUser(this.channelOwner);
-		await this.authClient.updateUser(this.messageOwner);
-		await this.authClient.updateUser(this.scapegoatUser);
+		await this.authClient.upsertUser(this.adminUser);
+		await this.authClient.upsertUser(this.moderator);
+		await this.authClient.upsertUser(this.guestUser);
+		await this.authClient.upsertUser(this.channelMember);
+		await this.authClient.upsertUser(this.channelOwner);
+		await this.authClient.upsertUser(this.messageOwner);
+		await this.authClient.upsertUser(this.scapegoatUser);
 
 		this.channel = this.authClient.channel(this.channelType, this.channelId, {
 			created_by: this.channelOwner,
@@ -55,13 +55,13 @@ function setupUser(ctx, user, done, test) {
 	const client = getTestClient(false);
 	const token = ctx.authClient.createToken(user.id);
 	return client
-		.setUser(user, token)
+		.connectUser(user, token)
 		.then(() => {
 			test(client);
 		})
 		.catch((e) => {
 			console.log(e);
-			done('failed to setUser');
+			done('failed to connectUser');
 		});
 }
 
@@ -240,7 +240,7 @@ function changeRole(ctx, user, responseTest) {
 			const newUser = Object.assign({}, user, {
 				role: user.role !== 'user' ? 'user' : 'admin',
 			});
-			responseTest(client.updateUser(newUser), done);
+			responseTest(client.upsertUser(newUser), done);
 		});
 	};
 }
@@ -249,7 +249,7 @@ function changeOwnUser(ctx, user, responseTest) {
 	return function (done) {
 		setupUser(ctx, user, done, (client) => {
 			const newUser = Object.assign({}, user, { changed: true });
-			responseTest(client.updateUser(newUser), done);
+			responseTest(client.upsertUser(newUser), done);
 		});
 	};
 }
@@ -260,7 +260,7 @@ function changeOtherUser(ctx, user, responseTest) {
 			const newUser = Object.assign({}, ctx.scapegoatUser, {
 				name: 'new-name',
 			});
-			responseTest(client.updateUser(newUser), done);
+			responseTest(client.upsertUser(newUser), done);
 		});
 	};
 }

--- a/test/integration/channels.js
+++ b/test/integration/channels.js
@@ -204,8 +204,8 @@ describe('Channels - members', function () {
 	let tommasoMessageID;
 
 	before(async () => {
-		await tommasoClient.setUser({ id: tommasoID }, tommasoToken);
-		await thierryClient.setUser({ id: thierryID }, thierryToken);
+		await tommasoClient.connectUser({ id: tommasoID }, tommasoToken);
+		await thierryClient.connectUser({ id: thierryID }, thierryToken);
 	});
 
 	it('tommaso creates a new channel', async function () {
@@ -497,9 +497,9 @@ describe('Channels - members', function () {
 				const userY = 'y-' + uuidv4();
 				await createUsers([userX, userY]);
 				const clientX = getTestClient();
-				await clientX.setUser({ id: userX }, createUserToken(userX));
+				await clientX.connectUser({ id: userX }, createUserToken(userX));
 				const clientY = getTestClient();
-				await clientY.setUser({ id: userY }, createUserToken(userY));
+				await clientY.connectUser({ id: userY }, createUserToken(userY));
 
 				let channelX = clientX.channel('messaging', { members: [userX, userY] });
 				await channelX.create();
@@ -830,7 +830,7 @@ describe('Channels - Member limit', function () {
 	let channel;
 	let ssClient;
 	before(async () => {
-		ssClient = await getServerTestClient();
+		ssClient = getServerTestClient();
 		await createUsers([memberOne, memberTwo, memberThree]);
 		channel = ssClient.channel('messaging', uuidv4(), {
 			unique,
@@ -893,8 +893,8 @@ describe('Channels - Distinct channels', function () {
 
 	const unique = uuidv4();
 	before(async () => {
-		await tommasoClient.setUser({ id: tommasoID }, tommasoToken);
-		await thierryClient.setUser({ id: thierryID }, thierryToken);
+		await tommasoClient.connectUser({ id: tommasoID }, tommasoToken);
+		await thierryClient.connectUser({ id: thierryID }, thierryToken);
 		await createUsers([newMember]);
 	});
 
@@ -1246,7 +1246,7 @@ describe('hard delete messages', function () {
 
 	before(async function () {
 		client = await getTestClientForUser(user);
-		ssclient = await getTestClient(true);
+		ssclient = getTestClient(true);
 		channel = client.channel('messaging', channelID);
 		await channel.create();
 	});
@@ -1951,7 +1951,7 @@ describe('unread counts on hard delete messages', function () {
 	before(async function () {
 		await createUsers([tommaso, thierry, nick]);
 		client = await getTestClientForUser(tommaso);
-		ssclient = await getTestClient(true);
+		ssclient = getTestClient(true);
 
 		channel = client.channel('messaging', uuidv4(), {
 			members: [tommaso, thierry, nick],
@@ -2364,7 +2364,7 @@ describe('update channel with reserved fields', function () {
 	let channel;
 	let client;
 	before(async function () {
-		client = await getServerTestClient();
+		client = getServerTestClient();
 
 		await client.createChannelType({
 			name: channelType,
@@ -2394,7 +2394,7 @@ describe('notification.channel_deleted', () => {
 	before(async () => {
 		const creator = 'creator' + uuidv4();
 		await createUsers([member, creator]);
-		const c = await getTestClient(true);
+		const c = getTestClient(true);
 
 		channel = c.channel('messaging', uuidv4(), {
 			created_by_id: creator,
@@ -2422,7 +2422,7 @@ describe('partial update channel', () => {
 	const owner = uuidv4();
 
 	before(async () => {
-		ssClient = await getServerTestClient();
+		ssClient = getServerTestClient();
 		ownerClient = await getTestClientForUser(owner);
 		modClient = await getTestClientForUser(moderator);
 		memberClient = await getTestClientForUser(member);
@@ -2785,7 +2785,7 @@ describe('Channel - isUpToDate', async () => {
 		});
 		await channelVish.watch();
 
-		const serverClient = await getServerTestClient();
+		const serverClient = getServerTestClient();
 		const channelAmin = serverClient.channel('messaging', channelId);
 
 		// First lets try with upToDate list.

--- a/test/integration/connection.js
+++ b/test/integration/connection.js
@@ -261,7 +261,7 @@ describe('Connection and reconnect behaviour', function () {
 
 	it('Http request with expired token should reload token', async () => {
 		const client = getTestClient(false);
-		await client.setUser({ id: 'thierry' }, () =>
+		await client.connectUser({ id: 'thierry' }, () =>
 			createUserToken('thierry', Math.floor(Date.now() / 1000) + 1),
 		);
 

--- a/test/integration/gdpr.js
+++ b/test/integration/gdpr.js
@@ -27,7 +27,7 @@ describe('GDPR endpoints', function () {
 		const userID = uuidv4();
 		const creatorID = uuidv4();
 		const channelID = uuidv4();
-		const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+		const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 		const channel = serverClient.channel('livestream', channelID, {
 			created_by: { id: creatorID },
 		});
@@ -61,13 +61,13 @@ describe('GDPR endpoints', function () {
 			// setup
 			const userID = uuidv4();
 
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 
 			const { user } = await serverClient.deactivateUser(userID);
 			expect(user.id).to.equal(userID);
 			expect(user.deactivated_at).to.not.be.undefined;
 
-			const p = serverClient.updateUser({ id: userID, name: 'new name' });
+			const p = serverClient.upsertUser({ id: userID, name: 'new name' });
 
 			await expect(p).to.be.rejectedWith('was deactivated');
 		});
@@ -77,7 +77,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+			const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -114,7 +114,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+			const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -154,7 +154,7 @@ describe('GDPR endpoints', function () {
 	describe('reactivate user', function () {
 		it('cannot reactivate active user', async function () {
 			const userID = uuidv4();
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 
 			const p = serverClient.reactivateUser(userID);
 
@@ -165,7 +165,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -201,7 +201,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -275,7 +275,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -329,13 +329,13 @@ describe('GDPR endpoints', function () {
 			// setup
 			const userID = uuidv4();
 
-			await serverClient.updateUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
 
 			const { user } = await serverClient.deleteUser(userID);
 			expect(user.id).to.equal(userID);
 			expect(user.deleted_at).to.not.be.undefined;
 
-			const p = serverClient.updateUser({ id: userID, name: 'new name' });
+			const p = serverClient.upsertUser({ id: userID, name: 'new name' });
 
 			await expect(p).to.be.rejectedWith('was deleted');
 		});
@@ -345,7 +345,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+			const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -384,7 +384,7 @@ describe('GDPR endpoints', function () {
 			const userID = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+			const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});
@@ -425,9 +425,9 @@ describe('GDPR endpoints', function () {
 			const userID2 = uuidv4();
 			const userID3 = uuidv4();
 
-			await serverClient.updateUser({ id: userID, name: 'hello' });
-			await serverClient.updateUser({ id: userID2 });
-			await serverClient.updateUser({ id: userID3 });
+			await serverClient.upsertUser({ id: userID, name: 'hello' });
+			await serverClient.upsertUser({ id: userID2 });
+			await serverClient.upsertUser({ id: userID3 });
 
 			const chan1 = serverClient.channel('messaging', {
 				members: [userID, userID2],
@@ -496,7 +496,7 @@ describe('GDPR endpoints', function () {
 			const userID2 = uuidv4();
 			const creatorID = uuidv4();
 			const channelID = uuidv4();
-			const user = await serverClient.updateUser({ id: userID, name: 'hello' });
+			const user = await serverClient.upsertUser({ id: userID, name: 'hello' });
 			const channel = serverClient.channel('livestream', channelID, {
 				created_by: { id: creatorID },
 			});

--- a/test/integration/invites.js
+++ b/test/integration/invites.js
@@ -45,7 +45,7 @@ describe('Member style server side', () => {
 		await createUsers(['thierry', 'tommaso']);
 	});
 	it('member based id server side', async () => {
-		const client = await getServerTestClient();
+		const client = getServerTestClient();
 		const c = client.channel('messaging', {
 			name: 'Founder Chat',
 			image: 'http://bit.ly/2O35mws',
@@ -260,7 +260,7 @@ describe('Query invites', function () {
 		});
 	});
 	it('Querying for invites with server side auth require an user to be set', async function () {
-		const ssClient = await getTestClient(true);
+		const ssClient = getTestClient(true);
 		const resp = ssClient.queryChannels({ invite: 'pending' });
 		expect(resp).to.be.rejectedWith(
 			'StreamChat error code 4: QueryChannels failed with error: "invite requires a valid user"',
@@ -278,7 +278,7 @@ describe('Query invites', function () {
 		expect(state.channel.id).to.be.equal(channelID);
 	});
 	it('Querying for invites with server side user should work if the user is provided', async function () {
-		const ssClient = await getTestClient(true);
+		const ssClient = getTestClient(true);
 		const resp = await ssClient.queryChannels(
 			{ invite: 'pending' },
 			{},

--- a/test/integration/moderation.js
+++ b/test/integration/moderation.js
@@ -632,7 +632,7 @@ describe('Moderation', function () {
 		expect(response.mute.target.id).to.equal(user2);
 		// verify we return the right user mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -662,7 +662,7 @@ describe('Moderation', function () {
 		expect(response.mute.target.id).to.equal(user2);
 		// verify we return the right user mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -687,7 +687,7 @@ describe('Moderation', function () {
 			.sendMessage({ text: 'yototototo' });
 		// verify we return the right user mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -718,7 +718,7 @@ describe('Moderation', function () {
 
 		// verify we return the right user mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -766,7 +766,7 @@ describe('mute channels', function () {
 
 		// verify we return the right channel mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -783,7 +783,7 @@ describe('mute channels', function () {
 			.sendMessage({ text: 'message to muted channel' });
 
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -833,7 +833,7 @@ describe('mute channels', function () {
 
 		// verify we return the right channel mute upon connect
 		const client = getTestClient(false);
-		const connectResponse = await client.setUser(
+		const connectResponse = await client.connectUser(
 			{ id: user1 },
 			createUserToken(user1),
 		);
@@ -963,7 +963,7 @@ describe('channel muteStatus', function () {
 		});
 	});
 
-	it('setUser populate internal mute state', async function () {
+	it('connectUser populate internal mute state', async function () {
 		const c = await getTestClientForUser(userID);
 		expect(c.health.me.channel_mutes.length).to.be.equal(1);
 		expect(c.health.me.channel_mutes[0].channel.cid).to.be.equal(channel.cid);

--- a/test/integration/multitenant.js
+++ b/test/integration/multitenant.js
@@ -355,7 +355,7 @@ describe('User teams field', function () {
 
 	before(async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 		await client.disconnect(5000);
 	});
 
@@ -375,7 +375,7 @@ describe('User teams field', function () {
 	it('should not be possible to set user.team on connect', function (done) {
 		const client = getTestClient(false);
 		const userToken = uuidv4();
-		const p = client.setUser(
+		const p = client.connectUser(
 			{ id: userToken, teams: ['alpha', 'bravo'] },
 			createUserToken(userToken),
 		);
@@ -386,7 +386,7 @@ describe('User teams field', function () {
 
 	it('should not be possible to update user.team on connect', async function () {
 		const client = getTestClient(false);
-		const p = client.setUser({ id: userId, teams: ['alpha', 'bravo'] }, token);
+		const p = client.connectUser({ id: userId, teams: ['alpha', 'bravo'] }, token);
 
 		await expect(p).to.be.rejectedWith(
 			'user teams cannot be changed at connection time',
@@ -396,7 +396,7 @@ describe('User teams field', function () {
 	it('create users server-side with team is OK', async function () {
 		const client = getTestClient(true);
 		const id = uuidv4();
-		const p = client.updateUser({ id, teams: ['red'] });
+		const p = client.upsertUser({ id, teams: ['red'] });
 		await expect(p).to.not.be.rejected;
 		const response = await p;
 		expect(response.users[id].teams).to.eql(['red']);
@@ -404,7 +404,7 @@ describe('User teams field', function () {
 
 	it('change a user team server-side is OK', async function () {
 		const client = getTestClient(true);
-		const p = client.updateUser({ id: userId, teams: ['alpha', 'bravo'] });
+		const p = client.upsertUser({ id: userId, teams: ['alpha', 'bravo'] });
 		await expect(p).to.not.be.rejected;
 		const response = await p;
 		expect(response.users[userId].teams).to.eql(['alpha', 'bravo']);
@@ -412,36 +412,36 @@ describe('User teams field', function () {
 
 	it('should be possible to send user.team on connect as long as it did not change', async function () {
 		const client = getTestClient(false);
-		const p = client.setUser({ id: userId, teams: ['bravo', 'alpha'] }, token);
+		const p = client.connectUser({ id: userId, teams: ['bravo', 'alpha'] }, token);
 
 		await expect(p).to.not.be.rejected;
 	});
 
-	it('should not be possible to update own user teams with the updateUser endpoint', async function () {
+	it('should not be possible to update own user teams with the upsertUser endpoint', async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 
-		const p = client.updateUser({ id: userId, teams: [uuidv4()] });
+		const p = client.upsertUser({ id: userId, teams: [uuidv4()] });
 		await expect(p).to.be.rejectedWith('user teams can only be updated server-side');
 	});
 
-	it('should be possible to update own user with the updateUser endpoint if teams are not sent', async function () {
+	it('should be possible to update own user with the upsertUser endpoint if teams are not sent', async function () {
 		const client = getTestClient(false);
-		const response = await client.setUser({ id: userId }, token);
+		const response = await client.connectUser({ id: userId }, token);
 
-		const p1 = client.updateUser({ id: userId, teams: response.me.teams });
+		const p1 = client.upsertUser({ id: userId, teams: response.me.teams });
 		await expect(p1).to.not.be.rejected;
 
-		const p2 = client.updateUser({ id: userId, teams: null });
+		const p2 = client.upsertUser({ id: userId, teams: null });
 		await expect(p2).to.not.be.rejected;
 
-		const p3 = client.updateUser({ id: userId, teams: [] });
+		const p3 = client.upsertUser({ id: userId, teams: [] });
 		await expect(p3).to.not.be.rejected;
 	});
 
 	it('should not be possible to create a channel without team', async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 		const p = client.channel('messaging', uuidv4()).create();
 		await expect(p).to.be.rejectedWith(
 			'StreamChat error code 5: GetOrCreateChannel failed with error: "user from teams ["alpha" "bravo"] cannot create a channel for team """',
@@ -450,7 +450,7 @@ describe('User teams field', function () {
 
 	it('should not be possible to create a channel for a different team', async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 		const p = client.channel('messaging', uuidv4(), { team: 'tango' }).create();
 		await expect(p).to.be.rejectedWith(
 			'StreamChat error code 5: GetOrCreateChannel failed with error: "user from teams ["alpha" "bravo"] cannot create a channel for team "tango""',
@@ -459,14 +459,14 @@ describe('User teams field', function () {
 
 	it('should be possible to create a channel for same team', async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 		const p = client.channel('messaging', uuidv4(), { team: 'alpha' }).create();
 		await expect(p).to.not.be.rejected;
 	});
 
 	it('should not be possible to update channel.team using client side auth', async function () {
 		const client = getTestClient(false);
-		await client.setUser({ id: userId }, token);
+		await client.connectUser({ id: userId }, token);
 
 		const chan = client.channel('messaging', uuidv4(), { team: 'bravo' });
 		const p1 = chan.create();
@@ -517,7 +517,7 @@ describe('Full test', function () {
 			multi_tenant_enabled: true,
 		});
 
-		await client.updateUsers([
+		await client.upsertUsers([
 			{ id: team1User, teams: [team1] },
 			{ id: team2User, teams: [team2] },
 		]);
@@ -677,8 +677,8 @@ describe('Full test', function () {
 		let channel;
 		const jaap = 'jaap' + uuidv4();
 
-		const ss = await getTestClient(true);
-		await ss.updateUser({ id: jaap, teams: ['red', 'blue'] });
+		const ss = getTestClient(true);
+		await ss.upsertUser({ id: jaap, teams: ['red', 'blue'] });
 		channel = ss.channel('messaging', uuidv4(), {
 			members: [jaap],
 			team: 'blue',

--- a/test/integration/notifications.js
+++ b/test/integration/notifications.js
@@ -181,8 +181,8 @@ describe('Mark all read server-side', function () {
 	const tommasoID = `tommaso-${uuidv4()}`;
 
 	before(async () => {
-		await serverSideClient.updateUser({ id: tommasoID });
-		await serverSideClient.updateUser({ id: thierryID });
+		await serverSideClient.upsertUser({ id: tommasoID });
+		await serverSideClient.upsertUser({ id: thierryID });
 
 		for (let i = 0; i < 5; i++) {
 			await serverSideClient
@@ -227,7 +227,7 @@ describe('Mark all read server-side', function () {
 
 	it('thierry connects and receives unread_count=5', async function () {
 		const thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -238,7 +238,7 @@ describe('Mark all read server-side', function () {
 
 	it('thierry checks unread counts via query channel', async function () {
 		const thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		const channelStates = await thierryClient.queryChannels(
 			{ type: 'messaging', members: { $in: [thierryID] } },
 			{ last_message_at: 1 },
@@ -258,7 +258,7 @@ describe('Mark all read server-side', function () {
 
 	it('thierry connects and receives unread_count=0', async function () {
 		const thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -270,7 +270,7 @@ describe('Mark all read server-side', function () {
 
 	it('thierry checks unread counts via query channel', async function () {
 		const thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		const channelStates = await thierryClient.queryChannels(
 			{ type: 'messaging', members: { $in: [thierryID] } },
 			{ last_message_at: 1 },
@@ -292,8 +292,8 @@ describe('Mark all read', function () {
 	const tommasoID = `tommaso-${uuidv4()}`;
 
 	before(async () => {
-		await serverSideClient.updateUser({ id: tommasoID });
-		await serverSideClient.updateUser({ id: thierryID });
+		await serverSideClient.upsertUser({ id: tommasoID });
+		await serverSideClient.upsertUser({ id: thierryID });
 
 		for (let i = 0; i < 5; i++) {
 			await serverSideClient
@@ -338,7 +338,7 @@ describe('Mark all read', function () {
 
 	it('thierry connects and receives unread_count=5', async function () {
 		const thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -350,7 +350,7 @@ describe('Mark all read', function () {
 
 	it('thierry checks unread counts via query channel', async function () {
 		const thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		const channelStates = await thierryClient.queryChannels(
 			{ type: 'messaging', members: { $in: [thierryID] } },
 			{ last_message_at: 1 },
@@ -366,14 +366,14 @@ describe('Mark all read', function () {
 
 	it('thierry marks all as read', async function () {
 		const thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		await thierryClient.markAllRead();
 		await thierryClient.disconnect(5000);
 	});
 
 	it('thierry connects and receives unread_count=0', async function () {
 		const thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -384,7 +384,7 @@ describe('Mark all read', function () {
 
 	it('thierry checks unread counts via query channel', async function () {
 		const thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		const channelStates = await thierryClient.queryChannels(
 			{ type: 'messaging', members: { $in: [thierryID] } },
 			{ last_message_at: 1 },
@@ -407,8 +407,8 @@ describe('Unread on connect', function () {
 	let thierryClient;
 
 	before(async () => {
-		await serverSideClient.updateUser({ id: tommasoID });
-		await serverSideClient.updateUser({ id: thierryID });
+		await serverSideClient.upsertUser({ id: tommasoID });
+		await serverSideClient.upsertUser({ id: thierryID });
 
 		for (let i = 0; i < 5; i++) {
 			await serverSideClient
@@ -469,7 +469,7 @@ describe('Unread on connect', function () {
 
 	it('thierry connects and receives unread_count=5', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -504,7 +504,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receive unread_count=4', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -514,7 +514,7 @@ describe('Unread on connect', function () {
 
 	it('thierry checks unread counts via query channel', async function () {
 		thierryClient = getTestClient(false);
-		await thierryClient.setUser({ id: thierryID }, createUserToken(thierryID));
+		await thierryClient.connectUser({ id: thierryID }, createUserToken(thierryID));
 		const channelStates = await thierryClient.queryChannels(
 			{ type: 'messaging', members: { $in: [thierryID] } },
 			{ last_message_at: 1 },
@@ -544,7 +544,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=104', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -569,7 +569,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=3', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -604,7 +604,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=2', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -618,7 +618,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=1', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -632,7 +632,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=0', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);
@@ -654,7 +654,7 @@ describe('Unread on connect', function () {
 
 	it('thierry re-connects and receives unread_count=0', async function () {
 		thierryClient = getTestClient(false);
-		const response = await thierryClient.setUser(
+		const response = await thierryClient.connectUser(
 			{ id: thierryID },
 			createUserToken(thierryID),
 		);

--- a/test/integration/presence.js
+++ b/test/integration/presence.js
@@ -61,23 +61,23 @@ describe('Presence', function () {
 	});
 
 	describe('Set User and Disconnect', () => {
-		it('calling setUser twice should trigger an error', async function () {
+		it('calling connectUser twice should trigger an error', async function () {
 			const testClientP = await getTestClientForUser('jack');
 
-			const setUserAndThrow = () => {
-				testClientP.setUser({
+			const connectUserAndThrow = () => {
+				testClientP.connectUser({
 					id: 'jimmy',
 				});
 			};
 
-			expect(setUserAndThrow).to.throw(/connectUser was called twice/);
+			expect(connectUserAndThrow).to.throw(/connectUser was called twice/);
 		});
 
 		it('login as a different user', async function () {
 			const testClientP = await getTestClientForUser('jones');
 
 			testClientP.disconnect(5000);
-			testClientP.setUser(
+			testClientP.connectUser(
 				{
 					id: 'jimmy',
 				},
@@ -215,7 +215,7 @@ describe('Presence', function () {
 			const userID = `sarah123-${channel}`;
 
 			// create a channel where channel.members contains wendy
-			await getTestClient(true).updateUser({ id: userID });
+			await getTestClient(true).upsertUser({ id: userID });
 			const b = user1Client.channel('messaging', channel, {
 				members: ['sandra', userID, 'user1'],
 			});
@@ -365,7 +365,7 @@ describe('Watchers count', function () {
 
 	before(async function () {
 		await createUsers(users);
-		await client.setUser({ id: users[0] }, createUserToken(users[0]));
+		await client.connectUser({ id: users[0] }, createUserToken(users[0]));
 		channel = client.channel('messaging', channelID, {
 			members: users,
 		});
@@ -474,12 +474,12 @@ describe('Count Anonymous users', function () {
 
 	before(async () => {
 		await createUsers([admin]);
-		await client.setUser({ id: admin }, createUserToken(admin));
+		await client.connectUser({ id: admin }, createUserToken(admin));
 		channel = client.channel('livestream', channelID);
 		await channel.create();
 		for (let i = 0; i < nClients; i++) {
-			const client1 = await getTestClient(false);
-			await client1.setAnonymousUser();
+			const client1 = getTestClient(false);
+			await client1.connectAnonymousUser();
 			const channel1 = client1.channel('livestream', channelID);
 			clients[i] = { client: client1, channel: channel1 };
 		}
@@ -529,11 +529,11 @@ describe('Count Guest users using state', function () {
 
 	before(async () => {
 		await createUsers([admin]);
-		await client.setUser({ id: admin }, createUserToken(admin));
+		await client.connectUser({ id: admin }, createUserToken(admin));
 		channel = client.channel('livestream', channelID);
 		await channel.create();
 		for (let i = 0; i < nClients; i++) {
-			const client1 = await getTestClient(false);
+			const client1 = getTestClient(false);
 			await client1.setGuestUser({ id: uuidv4() });
 			const channel1 = client1.channel('livestream', channelID);
 			clients[i] = { client: client1, channel: channel1 };

--- a/test/integration/query_members.js
+++ b/test/integration/query_members.js
@@ -38,15 +38,15 @@ describe('Query Members', function () {
 	let channel;
 	let ssClient;
 	before(async function () {
-		ssClient = await getServerTestClient();
-		await ssClient.updateUser({ id: rob, name: 'Robert' });
-		await ssClient.updateUser({ id: rob2, name: 'Robert2' });
-		await ssClient.updateUser({ id: mod, name: 'Tomas' });
-		await ssClient.updateUser({ id: adam, name: 'Adame' });
-		await ssClient.updateUser({ id: invited, name: 'Mary' });
-		await ssClient.updateUser({ id: pending, name: 'Carlos' });
-		await ssClient.updateUser({ id: rejected, name: 'Joseph' });
-		await ssClient.updateUser({ id: banned, name: 'Evil' });
+		ssClient = getServerTestClient();
+		await ssClient.upsertUser({ id: rob, name: 'Robert' });
+		await ssClient.upsertUser({ id: rob2, name: 'Robert2' });
+		await ssClient.upsertUser({ id: mod, name: 'Tomas' });
+		await ssClient.upsertUser({ id: adam, name: 'Adame' });
+		await ssClient.upsertUser({ id: invited, name: 'Mary' });
+		await ssClient.upsertUser({ id: pending, name: 'Carlos' });
+		await ssClient.upsertUser({ id: rejected, name: 'Joseph' });
+		await ssClient.upsertUser({ id: banned, name: 'Evil' });
 
 		channel = ssClient.channel('messaging', uuidv4(), {
 			created_by_id: mod,
@@ -413,7 +413,7 @@ describe('Query Members', function () {
 		let ssClient;
 		const identifier = uuidv4();
 		before(async function () {
-			ssClient = await getServerTestClient();
+			ssClient = getServerTestClient();
 			await ssClient.upsertUsers([zappa, nick, peter, noname]);
 			channel = ssClient.channel('messaging', uuidv4(), {
 				created_by: zappa,

--- a/test/integration/query_users.js
+++ b/test/integration/query_users.js
@@ -69,7 +69,7 @@ describe('Query Users', function () {
 		const userID3 = uuidv4();
 		const unique = uuidv4();
 		const serverClient = getServerTestClient();
-		await serverClient.updateUsers([
+		await serverClient.upsertUsers([
 			{
 				id: userID,
 				unique,
@@ -152,7 +152,7 @@ describe('Query Users', function () {
 		const userID3 = uuidv4();
 		const unique = uuidv4();
 
-		await client.updateUsers([
+		await client.upsertUsers([
 			{
 				id: userID,
 				unique,
@@ -195,7 +195,7 @@ describe('Query Users', function () {
 		const userID3 = uuidv4();
 		const unique = uuidv4();
 
-		await client.updateUsers([
+		await client.upsertUsers([
 			{
 				id: userID,
 				unique,

--- a/test/integration/serverside.js
+++ b/test/integration/serverside.js
@@ -657,12 +657,15 @@ describe('App configs', function () {
 		await client.updateAppSettings({
 			disable_auth_checks: false,
 		});
-		await expectHTTPErrorCode(401, client2.setUser(user, userToken));
+		await expectHTTPErrorCode(401, client2.connectUser(user, userToken));
 		client2.disconnect(5000);
 	});
 
 	it('Using dev token fails because of auth enabled', async () => {
-		await expectHTTPErrorCode(401, client2.setUser(user, client2.devToken(user.id)));
+		await expectHTTPErrorCode(
+			401,
+			client2.connectUser(user, client2.devToken(user.id)),
+		);
 		client2.disconnect(5000);
 	});
 
@@ -674,12 +677,12 @@ describe('App configs', function () {
 	});
 
 	it('Using a tampered token does not fail because auth is disabled', async () => {
-		await client2.setUser(user, userToken);
+		await client2.connectUser(user, userToken);
 		client2.disconnect(5000);
 	});
 
 	it('Using dev token does not fail because auth is disabled', async () => {
-		await client2.setUser(user, client2.devToken(user.id));
+		await client2.connectUser(user, client2.devToken(user.id));
 		client2.disconnect(5000);
 	});
 
@@ -691,7 +694,7 @@ describe('App configs', function () {
 	});
 
 	it('A user can do super stuff because permission checks are off', async () => {
-		await client2.setUser(user, userToken);
+		await client2.connectUser(user, userToken);
 		await client2.channel('messaging', 'secret-place').watch();
 		client2.disconnect(5000);
 	});
@@ -719,7 +722,7 @@ describe('App configs', function () {
 	});
 
 	it('Using a tampered token fails because auth is back on', async () => {
-		await expectHTTPErrorCode(401, client2.setUser(user, userToken));
+		await expectHTTPErrorCode(401, client2.connectUser(user, userToken));
 		client2.disconnect(5000);
 	});
 
@@ -2447,7 +2450,7 @@ describe('Moderation', function () {
 			expect(data.mute.target.id).to.equal(targetUser);
 
 			const client = getTestClient(false);
-			const connectResponse = await client.setUser(
+			const connectResponse = await client.connectUser(
 				{ id: srcUser },
 				createUserToken(srcUser),
 			);
@@ -2464,7 +2467,7 @@ describe('Moderation', function () {
 			await srvClient.unmuteUser(targetUser, srcUser);
 
 			const client = getTestClient(false);
-			const connectResponse = await client.setUser(
+			const connectResponse = await client.connectUser(
 				{ id: srcUser },
 				createUserToken(srcUser),
 			);
@@ -2642,7 +2645,7 @@ describe('User management', function () {
 
 		const channelID = uuidv4();
 
-		userClient.setUser(user, createUserToken(userID));
+		userClient.connectUser(user, createUserToken(userID));
 		const channel = userClient.channel('livestream', channelID);
 		await channel.watch();
 
@@ -3407,8 +3410,8 @@ describe('Unread counts are properly initialised', function () {
 	before(async () => {
 		//create 3 user in 3 different ways
 		//it is possible to create users by
-		//   * client.setUser
-		//   * client.updateUser
+		//   * client.connectUser
+		//   * client.upsertUser
 		//   * client.sendMessage/channel.create
 		serverSideClient = getTestClient(true);
 		await serverSideClient.upsertUser({ id: userCreatedByUpdateUsers });
@@ -3416,7 +3419,7 @@ describe('Unread counts are properly initialised', function () {
 			created_by_id: userCreatedByCreateChannel,
 		});
 		await channel.create();
-		await serverSideClient.setUser({ id: userCreatedByConnect });
+		await serverSideClient.connectUser({ id: userCreatedByConnect });
 		serverSideClient = getTestClient(true);
 		channel = serverSideClient.channel('messaging', channelID);
 		await channel.addMembers([

--- a/test/integration/slow_mode.js
+++ b/test/integration/slow_mode.js
@@ -17,7 +17,7 @@ describe('channel slow mode', function () {
 	let memberClient;
 	let channel;
 	before(async function () {
-		ssClient = await getTestClient(true);
+		ssClient = getTestClient(true);
 		await ssClient.upsertUsers([
 			{ id: admin, role: 'admin' },
 			{ id: member },

--- a/test/integration/sqs_events.js
+++ b/test/integration/sqs_events.js
@@ -743,10 +743,10 @@ describe('SQS event endpoint', function () {
 		expect(event.created_by.id).to.be.eq(johnID);
 	});
 
-	it('user created using setUser trigger webhook event', async function () {
+	it('user created using connectUser trigger webhook event', async function () {
 		const client = getTestClient(false);
 		const newUserID = uuidv4();
-		client.setUser({ id: newUserID }, createUserToken(newUserID));
+		client.connectUser({ id: newUserID }, createUserToken(newUserID));
 
 		const [events] = await Promise.all([promises.waitForEvents('user.updated')]);
 		const event = events[0];
@@ -754,9 +754,9 @@ describe('SQS event endpoint', function () {
 		expect(event.user.id).to.be.eq(newUserID);
 	});
 
-	it('user updated using setUser trigger webhook event', async function () {
+	it('user updated using connectUser trigger webhook event', async function () {
 		const client = getTestClient(false);
-		client.setUser({ id: paulID, cto: true }, createUserToken(paulID));
+		client.connectUser({ id: paulID, cto: true }, createUserToken(paulID));
 
 		const [events] = await Promise.all([promises.waitForEvents('user.updated')]);
 		const event = events[0];

--- a/test/integration/sync.js
+++ b/test/integration/sync.js
@@ -111,7 +111,7 @@ describe('Sync endpoint', () => {
 	let syncReply;
 
 	it('sync should return a response', async () => {
-		await userClient.setUser({ id: userID }, createUserToken(userID));
+		await userClient.connectUser({ id: userID }, createUserToken(userID));
 		syncReply = await userClient.sync(
 			[blueChannel.cid, redChannel.cid, greenChannel.cid],
 			lastEventAt,

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -64,10 +64,10 @@ describe('Chat', () => {
 			role: 'admin',
 		};
 
-		await serverAuthClient.updateUsers([thierry, tommaso, { id: 'thierry' }]);
+		await serverAuthClient.upsertUsers([thierry, tommaso, { id: 'thierry' }]);
 		//	delete thierry.role;
 		// await isn't needed but makes testing a bit easier
-		await authClient.setUser(thierry);
+		await authClient.connectUser(thierry);
 
 		channel = authClient.channel('livestream', 'ninja', {
 			mysearchablefield: 'hi',
@@ -88,7 +88,7 @@ describe('Chat', () => {
 	describe('User Update Events', () => {
 		it('should trigger user update event', async () => {
 			const userID = uuidv4();
-			await serverAuthClient.updateUser({
+			await serverAuthClient.upsertUser({
 				id: userID,
 				name: 'jack',
 				song: 'purple rain',
@@ -109,7 +109,7 @@ describe('Chat', () => {
 					expect(event.user.id).to.equal(userID);
 					resolve();
 				});
-				serverAuthClient.updateUser({
+				serverAuthClient.upsertUser({
 					id: userID,
 					name: 'jack',
 					song: 'welcome to the jungle',
@@ -123,12 +123,12 @@ describe('Chat', () => {
 			const authClient = getTestClient(true);
 			const serverAuthClient = getTestClient(true);
 
-			await serverAuthClient.updateUser({
+			await serverAuthClient.upsertUser({
 				id: u1,
 				name: 'Awesome user',
 			});
 
-			await authClient.setUser({ id: u1 });
+			await authClient.connectUser({ id: u1 });
 
 			// subscribe to user presence
 			const response = await authClient.queryUsers(
@@ -147,7 +147,7 @@ describe('Chat', () => {
 					expect(authClient.user.name).equal('Not so awesome');
 					resolve();
 				});
-				serverAuthClient.updateUser({
+				serverAuthClient.upsertUser({
 					id: u1,
 					name: 'Not so awesome',
 				});
@@ -160,8 +160,8 @@ describe('Chat', () => {
 			const client = getTestClient(false);
 			const userID = uuidv4();
 
-			const cPromise = client.setUser({ id: userID }, createUserToken(userID));
-			// watch a new channel before setUser completes
+			const cPromise = client.connectUser({ id: userID }, createUserToken(userID));
+			// watch a new channel before connectUser completes
 			const state = await client.channel('messaging', uuidv4()).watch();
 		});
 		it('reserved fields in user', async () => {
@@ -170,7 +170,7 @@ describe('Chat', () => {
 
 			await expectHTTPErrorCode(
 				400,
-				client.setUser(
+				client.connectUser(
 					{ id: userID, created_at: 'helloworld' },
 					createUserToken(userID),
 				),
@@ -237,11 +237,11 @@ describe('Chat', () => {
 			expect(client3.health.me.updated_at).to.equal(updatedAt);
 		});
 
-		it('Update/sync before calling setUser', async () => {
+		it('Update/sync before calling connectUser', async () => {
 			const userID = uuidv4();
 			const serverClient = getServerTestClient();
 
-			const updateResponse = await serverClient.updateUsers([
+			const updateResponse = await serverClient.upsertUsers([
 				{ id: userID, book: 'dune', role: 'admin' },
 			]);
 			const client = await getTestClientForUser(userID, 'test', { color: 'green' });
@@ -257,7 +257,7 @@ describe('Chat', () => {
 				'8qezxbbbn72p9rtda2uzvupkhvq6u7dmf637weppxgmadzty6g5p64g5nchgr2aaa';
 			const serverClient = new StreamChat(disabledKey, disabledSecret);
 			const userClient = new StreamChat(disabledKey);
-			const responsePromise = userClient.setUser(
+			const responsePromise = userClient.connectUser(
 				{ id: 'batman' },
 				serverClient.createToken('batman'),
 			);
@@ -266,19 +266,19 @@ describe('Chat', () => {
 			);
 		});
 
-		it('setUser and updateUsers flow', async () => {
+		it('connectUser and upsertUsers flow', async () => {
 			const userID = uuidv4();
 			const client = getTestClient(false);
 			const token = createUserToken(userID);
 			const serverClient = getServerTestClient();
 			// example for docs
-			const response = await client.setUser(
+			const response = await client.connectUser(
 				{ id: userID, role: 'admin', favorite_color: 'green' },
 				token,
 			);
 			// user object is now {id: userID, role: 'user', favorite_color: 'green'}
 			// note how you are not allowed to make the user admin via this endpoint
-			const updateResponse = await serverClient.updateUsers([
+			const updateResponse = await serverClient.upsertUsers([
 				{ id: userID, role: 'admin', book: 'dune' },
 			]);
 			// user object is now {id: userID, role: 'admin', book: 'dune'}
@@ -295,7 +295,7 @@ describe('Chat', () => {
 			const userID = uuidv4();
 			const client = getTestClient(false);
 			const token = createUserToken(userID);
-			await client.setUser({ id: userID }, token);
+			await client.connectUser({ id: userID }, token);
 
 			await client.wsConnection.disconnect(5000);
 			expect(client.wsConnection.isHealthy).to.equal(false);
@@ -319,8 +319,8 @@ describe('Chat', () => {
 				await serverClient.banUser(banned, { banned_by_id: admin.id });
 			});
 
-			it('returns banned field on setUser', async () => {
-				const response = await client.setUser(
+			it('returns banned field on connectUser', async () => {
+				const response = await client.connectUser(
 					{ id: banned, role: 'user', favorite_color: 'green' },
 					token,
 				);
@@ -361,7 +361,7 @@ describe('Chat', () => {
 			});
 
 			it('banned is set to false', async () => {
-				const response = await client.setUser(
+				const response = await client.connectUser(
 					{ id: banned, role: 'user', favorite_color: 'green' },
 					token,
 				);
@@ -394,7 +394,7 @@ describe('Chat', () => {
 			const userId = uuidv4();
 
 			before(async () => {
-				await client.setUser({ id: userId }, createUserToken(userId));
+				await client.connectUser({ id: userId }, createUserToken(userId));
 			});
 
 			describe('Adding', () => {
@@ -589,7 +589,7 @@ describe('Chat', () => {
 			const userTommaso = { id: uuidv4(), name: 'Tommaso Barbugli' };
 
 			await serverAuthClient.upsertUser(userTommaso);
-			await authClientTommaso.setUser(userTommaso);
+			await authClientTommaso.connectUser(userTommaso);
 
 			const attachments = [
 				{
@@ -736,7 +736,7 @@ describe('Chat', () => {
 		});
 
 		it('Edit a user', async () => {
-			const response = await serverAuthClient.updateUser({
+			const response = await serverAuthClient.upsertUser({
 				id: 'tommaso',
 				name: 'Tommaso Barbugli',
 				role: 'admin',
@@ -768,7 +768,7 @@ describe('Chat', () => {
 		it('Token based auth', async () => {
 			const token = createUserToken('daenerys');
 			const client3 = getTestClient(true);
-			await client3.setUser(
+			await client3.connectUser(
 				{
 					id: 'daenerys',
 					name: 'Mother of dragons',
@@ -782,7 +782,7 @@ describe('Chat', () => {
 
 			const clientSide = getTestClient();
 			await expect(
-				clientSide.setUser(
+				clientSide.connectUser(
 					{
 						id: 'daenerys',
 						name: 'Mother of dragons',
@@ -794,7 +794,7 @@ describe('Chat', () => {
 
 		it('Secret based auth', async () => {
 			const client3 = new getTestClient(true);
-			await client3.setUser({
+			await client3.connectUser({
 				id: 'daenerys',
 				name: 'Mother of dragons',
 			});
@@ -803,7 +803,7 @@ describe('Chat', () => {
 		it('No secret and no token should raise a client error', async () => {
 			const client2 = getTestClient();
 			await expect(
-				client2.setUser({
+				client2.connectUser({
 					id: 'daenerys',
 					name: 'Mother of dragons',
 				}),
@@ -813,7 +813,7 @@ describe('Chat', () => {
 		it('Invalid user token', async () => {
 			const client2 = getTestClient();
 			await expect(
-				client2.setUser(
+				client2.connectUser(
 					{
 						id: 'daenerys',
 						name: 'Mother of dragons',
@@ -823,11 +823,11 @@ describe('Chat', () => {
 			).to.be.rejectedWith(Error);
 		});
 
-		it('Invalid secret should fail setUser', async () => {
+		it('Invalid secret should fail connectUser', async () => {
 			const client3 = new StreamChat('892s22ypvt6m', 'invalidsecret');
 			await expectHTTPErrorCode(
 				401,
-				client3.setUser({
+				client3.connectUser({
 					id: 'daenerys',
 					name: 'Mother of dragons',
 				}),
@@ -851,7 +851,7 @@ describe('Chat', () => {
 			);
 
 			const anonClient = getTestClient(false);
-			await anonClient.setAnonymousUser();
+			await anonClient.connectAnonymousUser();
 			await anonClient.disconnect(5000);
 
 			p = anonClient.addDevice('deviceID', 'apn');
@@ -888,7 +888,7 @@ describe('Chat', () => {
 			const token = authClient.createToken('johny');
 
 			const client3 = getTestClient();
-			await client3.setUser(
+			await client3.connectUser(
 				{
 					id: 'johny',
 					name: 'some random guy',
@@ -912,7 +912,7 @@ describe('Chat', () => {
 				first: 'Uhtred',
 			};
 
-			const response = await client.setUser(user, token);
+			const response = await client.connectUser(user, token);
 
 			const compareUser = (userResponse) => {
 				const expectedData = { role: 'user', ...user };
@@ -950,7 +950,7 @@ describe('Chat', () => {
 				'Thierry',
 			);
 			// TODO: update the user
-			authClient.setUser({ id: 'thierry', name: 't' }, 'myusertoken');
+			authClient.connectUser({ id: 'thierry', name: 't' }, 'myusertoken');
 			// verify the update propagates
 			expect(state.messages[state.messages.length - 1].user.name).to.equal('t');
 		});
@@ -1014,7 +1014,7 @@ describe('Chat', () => {
 						resolve();
 					});
 
-					authClient.updateUser({
+					authClient.upsertUser({
 						id: user.id,
 						role: 'admin',
 						set: { test: 'true' },
@@ -1831,7 +1831,7 @@ describe('Chat', () => {
 					shadow_banned: false,
 				};
 
-				users[i] = (await serverAuthClient.updateUser(user)).users[username(i)];
+				users[i] = (await serverAuthClient.upsertUser(user)).users[username(i)];
 				userMap[username(i)] = users[i];
 			}
 		});
@@ -1932,7 +1932,7 @@ describe('Chat', () => {
 		});
 		it('Pagination on Members', async () => {
 			const id = uuidv4();
-			await serverAuthClient.updateUsers([
+			await serverAuthClient.upsertUsers([
 				{ id: 'wendy' },
 				{ id: 'helen' },
 				{ id: 'marty' },
@@ -2127,7 +2127,7 @@ describe('Chat', () => {
 			const client = getTestClient(false);
 			const userID = uuidv4();
 
-			client.setUser({ id: userID }, createUserToken(userID));
+			client.connectUser({ id: userID }, createUserToken(userID));
 			const channel = client.channel('messaging', uuidv4());
 			let result;
 			try {
@@ -2338,10 +2338,10 @@ describe('Chat', () => {
 				created_by: { id: uuidv4() },
 			});
 			await c.create();
-			await serverAuthClient.updateUser({
+			await serverAuthClient.upsertUser({
 				id: userID,
 			});
-			await client.setUser({ id: userID }, createUserToken(userID));
+			await client.connectUser({ id: userID }, createUserToken(userID));
 			await client.channel('livestream', chanName).watch();
 		});
 
@@ -2510,7 +2510,7 @@ describe('Chat', () => {
 
 		it('Create an anonymous session', async () => {
 			client = getTestClient(false);
-			await client.setAnonymousUser();
+			await client.connectAnonymousUser();
 			serverChannel = serverAuthClient.channel('livestream', channelID, {
 				created_by: owner,
 			});
@@ -2563,7 +2563,7 @@ describe('Chat', () => {
 
 		before(async () => {
 			userClient = getTestClient(false);
-			await userClient.setUser(userData, createUserToken(userData.id));
+			await userClient.connectUser(userData, createUserToken(userData.id));
 			chan = userClient.channel('livestream', 'dnd');
 			await chan.watch();
 			await chan.watch();
@@ -2577,9 +2577,9 @@ describe('Chat', () => {
 			expect(response.members).to.not.be.undefined;
 		});
 
-		it('setUser should not remove custom fields', async () => {
+		it('connectUser should not remove custom fields', async () => {
 			userClient = getTestClient(false);
-			const response = await userClient.setUser(
+			const response = await userClient.connectUser(
 				{ id: userData.id, new_field: 'yes' },
 				createUserToken(userData.id),
 			);
@@ -2591,7 +2591,10 @@ describe('Chat', () => {
 			const client = getTestClient(false);
 			await expectHTTPErrorCode(
 				413,
-				client.setUser(oversizeUserData, createUserToken(oversizeUserData.id)),
+				client.connectUser(
+					oversizeUserData,
+					createUserToken(oversizeUserData.id),
+				),
 			);
 		});
 	});
@@ -2671,8 +2674,8 @@ describe('Chat', () => {
 		let msg;
 
 		before(async () => {
-			await getTestClient(true).updateUser(thierry);
-			await getTestClient(true).updateUser({ id: userID, instrument: 'guitar' });
+			await getTestClient(true).upsertUser(thierry);
+			await getTestClient(true).upsertUser({ id: userID, instrument: 'guitar' });
 			channel = serverAuthClient.channel('team', channelID, {
 				created_by: { id: thierry.id },
 				members: [userID, thierry.id],
@@ -2731,7 +2734,7 @@ describe('Chat', () => {
 		});
 
 		it('should be possible to edit the list of mentioned users', async () => {
-			const client = await getTestClient(true);
+			const client = getTestClient(true);
 			const response = await client.updateMessage(
 				{ id: msg.id, text: msg.text, mentioned_users: [userID] },
 				thierry.id,
@@ -2910,7 +2913,7 @@ describe('Chat', () => {
 
 		before(async () => {
 			await createUsers([modUserID]);
-			await serverAuthClient.updateUser(evil);
+			await serverAuthClient.upsertUser(evil);
 		});
 
 		it('Ban', async () => {
@@ -3305,7 +3308,7 @@ describe('warm up', () => {
 		const baseUrl = 'https://chat-us-east-1.stream-io-api.com';
 		const client = getTestClient(true);
 		client.setBaseURL(baseUrl);
-		const health = await client.setUser({ id: user }, createUserToken(user));
+		const health = await client.connectUser({ id: user }, createUserToken(user));
 		client.health = health;
 		channel = await client.channel('messaging', uuidv4());
 
@@ -3315,7 +3318,7 @@ describe('warm up', () => {
 		// first client uses warmUp
 		const warmUpClient = getTestClientWithWarmUp();
 		warmUpClient.setBaseURL(baseUrl);
-		warmUpClient.health = await warmUpClient.setUser(
+		warmUpClient.health = await warmUpClient.connectUser(
 			{ id: user },
 			createUserToken(user),
 		);
@@ -3327,9 +3330,9 @@ describe('warm up', () => {
 		console.log('time taken with warm up ' + withWarmUpDur + ' milliseconds.');
 
 		// second client without warmUp
-		const noWarmUpClient = await getTestClient(false);
+		const noWarmUpClient = getTestClient(false);
 		noWarmUpClient.setBaseURL(baseUrl);
-		noWarmUpClient.health = await noWarmUpClient.setUser(
+		noWarmUpClient.health = await noWarmUpClient.connectUser(
 			{ id: user },
 			createUserToken(user),
 		);

--- a/test/integration/unique_usernames.js
+++ b/test/integration/unique_usernames.js
@@ -234,14 +234,14 @@ describe('enforce unique usernames', function () {
 		expect(result.filter((p) => p.status === 'fulfilled').length).to.eql(1);
 	});
 
-	it('should only succeed once in race client.setUser(insert) with an existing username on app level', async () => {
+	it('should only succeed once in race client.connectUser(insert) with an existing username on app level', async () => {
 		const name = uuidv4();
 		const n = 25;
 		const p = [];
 
 		for (let i = 0; i < n; i++) {
 			const client = getTestClient(true);
-			p.push(client.setUser({ id: uuidv4(), name }));
+			p.push(client.connectUser({ id: uuidv4(), name }));
 		}
 
 		const result = await Promise.allSettled(p);

--- a/test/integration/utils.js
+++ b/test/integration/utils.js
@@ -9,7 +9,8 @@ const apiSecret = process.env.STREAM_API_SECRET;
 export function getTestClient(serverSide) {
 	return new StreamChat(apiKey, serverSide ? apiSecret : null, {
 		timeout: 15000,
-		allowServerSideConnect: serverSide,
+		// we mute warnings because tests are always run on server side
+		allowServerSideConnect: true,
 	});
 }
 
@@ -19,13 +20,13 @@ export function getServerTestClient() {
 
 export function getTestClientForUser2(userID, status, options) {
 	const client = getTestClient(false);
-	client.setUser({ id: userID, status, ...options }, createUserToken(userID));
+	client.connectUser({ id: userID, status, ...options }, createUserToken(userID));
 	return client;
 }
 
 export async function getTestClientForUser(userID, status, options) {
 	const client = getTestClient(false);
-	client.health = await client.setUser(
+	client.health = await client.connectUser(
 		{ id: userID, status, ...options },
 		createUserToken(userID),
 	);

--- a/test/integration/webhook_custom_commands.js
+++ b/test/integration/webhook_custom_commands.js
@@ -85,7 +85,7 @@ describe('Custom Commands Webhook', () => {
 	const serverClient = getTestClient(true);
 	const userClient = getTestClient(false);
 	const guyon = { id: `guyon-${uuidv4()}` };
-	userClient.setUser(guyon, createUserToken(guyon.id));
+	userClient.connectUser(guyon, createUserToken(guyon.id));
 
 	let chan, webhook;
 	const channelID = `custom-commands-${uuidv4()}`;

--- a/test/integration/webhook_push.js
+++ b/test/integration/webhook_push.js
@@ -673,10 +673,10 @@ describe('Push Webhook', function () {
 		expect(event.created_by.id).to.be.eq(thierryID);
 	});
 
-	it('user created using setUser trigger webhook event', async function () {
+	it('user created using connectUser trigger webhook event', async function () {
 		const client = getTestClient(false);
 		const newUserID = uuidv4();
-		client.setUser({ id: newUserID }, createUserToken(newUserID));
+		client.connectUser({ id: newUserID }, createUserToken(newUserID));
 
 		const [events] = await Promise.all([promises.waitForEvents('user.updated')]);
 		const event = events[0];
@@ -684,9 +684,9 @@ describe('Push Webhook', function () {
 		expect(event.user.id).to.be.eq(newUserID);
 	});
 
-	it('user updated using setUser trigger webhook event', async function () {
+	it('user updated using connectUser trigger webhook event', async function () {
 		const client = getTestClient(false);
-		client.setUser({ id: tommasoID, cto: true }, createUserToken(tommasoID));
+		client.connectUser({ id: tommasoID, cto: true }, createUserToken(tommasoID));
 
 		const [events] = await Promise.all([promises.waitForEvents('user.updated')]);
 		const event = events[0];

--- a/test/typescript/response-generators/client.js
+++ b/test/typescript/response-generators/client.js
@@ -133,7 +133,7 @@ async function setUser() {
 	await client1.muteUser(user2);
 
 	const authClient = await utils.getTestClient(false);
-	return authClient.setUser({ id: user1 }, utils.createUserToken(user1));
+	return authClient.connectUser({ id: user1 }, utils.createUserToken(user1));
 }
 
 async function sync() {

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -112,7 +112,7 @@ async function flagMessage() {
 	await serverAuthClient.updateUsers([thierry, tommaso, { id: 'thierry' }]);
 	//	delete thierry.role;
 	// await isn't needed but makes testing a bit easier
-	await authClient.setUser(thierry);
+	await authClient.connectUser(thierry);
 
 	const channel = authClient.channel('livestream', `ninja-${uuidv4()}`, {
 		mysearchablefield: 'hi',
@@ -147,7 +147,7 @@ async function flagUser() {
 	await serverAuthClient.updateUsers([thierry, tommaso, { id: 'thierry' }]);
 	//	delete thierry.role;
 	// await isn't needed but makes testing a bit easier
-	await authClient.setUser(thierry);
+	await authClient.connectUser(thierry);
 	const evilId = uuidv4();
 	const evil = {
 		id: evilId,
@@ -266,7 +266,7 @@ async function unflagMessage() {
 	await serverAuthClient.updateUsers([thierry, tommaso, { id: 'thierry' }]);
 	//	delete thierry.role;
 	// await isn't needed but makes testing a bit easier
-	await authClient.setUser(thierry);
+	await authClient.connectUser(thierry);
 
 	const channel = authClient.channel('livestream', `ninja-${uuidv4()}`, {
 		mysearchablefield: 'hi',
@@ -311,7 +311,7 @@ async function unflagUser() {
 	await serverAuthClient.updateUsers([thierry, tommaso, { id: 'thierry' }]);
 	//	delete thierry.role;
 	// await isn't needed but makes testing a bit easier
-	await authClient.setUser(thierry);
+	await authClient.connectUser(thierry);
 	const modUserID = uuidv4();
 
 	await utils.createUsers([modUserID]);

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -111,10 +111,10 @@ voidReturn = client.on('message.new', eventHandler);
 voidReturn = client.off('message.new', eventHandler);
 
 let userReturn: ConnectAPIResponse<ChannelType, CommandType, UserType>;
-userReturn = client.setUser({ id: 'john', phone: 2 }, devToken);
-userReturn = client.setUser({ id: 'john', phone: 2 }, async () => 'token');
+userReturn = client.connectUser({ id: 'john', phone: 2 }, devToken);
+userReturn = client.connectUser({ id: 'john', phone: 2 }, async () => 'token');
 
-userReturn = client.setAnonymousUser();
+userReturn = client.connectAnonymousUser();
 userReturn = client.setGuestUser({ id: 'steven' });
 
 type X = { x: string };

--- a/test/typescript/utils.js
+++ b/test/typescript/utils.js
@@ -40,12 +40,12 @@ module.exports = {
 	getTestClient: function getTestClient(serverSide) {
 		return new StreamChat(apiKey, serverSide ? apiSecret : null, {
 			timeout: 8000,
-			allowServerSideConnect: serverSide,
+			allowServerSideConnect: true,
 		});
 	},
 	getTestClientForUser: async function getTestClientForUser(userID, options = {}) {
 		const client = this.getTestClient(false);
-		const health = await client.setUser(
+		const health = await client.connectUser(
 			{ id: userID, ...options },
 			this.createUserToken(userID),
 		);
@@ -54,7 +54,7 @@ module.exports = {
 	},
 	getTestClientForUser2: function getTestClientForUser2(userID, options) {
 		const client = this.getTestClient(false);
-		client.setUser({ id: userID, ...options }, this.createUserToken(userID));
+		client.connectUser({ id: userID, ...options }, this.createUserToken(userID));
 		return client;
 	},
 	runAndLogPromise: function runAndLogPromise(promiseCallable) {

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -7,7 +7,7 @@ describe('Client userMuteStatus', function () {
 	const client = new StreamChat('', '');
 	const user = { id: 'user' };
 
-	client.setUser = async () => {
+	client.connectUser = async () => {
 		client.user = user;
 		client.wsPromise = Promise.resolve();
 	};
@@ -27,8 +27,8 @@ describe('Client userMuteStatus', function () {
 		expect(() => client.userMuteStatus('')).to.throw();
 	});
 
-	it('should not throw error if setUser is called', async function () {
-		await client.setUser();
+	it('should not throw error if connectUser is called', async function () {
+		await client.connectUser();
 		expect(() => client.userMuteStatus('')).not.to.throw();
 	});
 


### PR DESCRIPTION
We often copy-paste test code to implement new tests and with this we also increase the amount of incorrect/deprecated method calls.

This is what had been done in this PR:

1. Updated all `setUser` calls to `connectUser`
2. Updated all `updateUser(s)` calls to `upsertUser(s)`
3. Fixed extra `await` for `getTestClient` non-async calls
4. Fixed `connectUser` warning when running integration tests in CI
5. Removed deprecated and unused `webhook_id` and `webhook_failed` fields from `MessageResponse`