### PR TITLE
QA tests for quoted message improvements

### DIFF
--- a/test/integration/channels.js
+++ b/test/integration/channels.js
@@ -2758,7 +2758,6 @@ describe('Quote messages', () => {
 			expect(updatedEvent.message.parent_id).to.be.undefined;
 			expect(updatedEvent.message.quoted_message.user).to.not.be.undefined;
 
-			console.log('before teardown');
 			await webhook.tearDown();
 		});
 

--- a/test/integration/channels.js
+++ b/test/integration/channels.js
@@ -10,6 +10,7 @@ import {
 	sleep,
 	createEventWaiter,
 	randomUnicodeString,
+	setupWebhook,
 } from './utils';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -2569,6 +2570,8 @@ describe('Quote messages', () => {
 	});
 
 	describe('Friend replies to the message in a thread', () => {
+		let firstThreadReply;
+
 		it('is possible to reply to the message', async () => {
 			const res = await channel.sendMessage({
 				text: 'The first threaded reply',
@@ -2578,8 +2581,48 @@ describe('Quote messages', () => {
 
 			expect(res.message).to.not.be.undefined;
 			expect(res.message.id).to.not.be.empty;
-			expect(res.message.parent_id).to.not.be.undefined;
+			expect(res.message.parent_id).to.equal(firstMessage.id);
 			expect(res.message.type).to.equal('reply');
+		});
+
+		it('should be possible to quote the message in a thread', async () => {
+			const res = await channel.sendMessage({
+				text: 'The first thread reply that also quotes a message',
+				user_id: friend,
+				parent_id: firstMessage.id,
+				quoted_message_id: firstMessage.id,
+			});
+
+			expect(res.message).to.not.be.undefined;
+			expect(res.message.id).to.not.be.empty;
+			expect(res.message.quoted_message).to.not.be.undefined;
+			expect(res.message.quoted_message_id).to.equal(firstMessage.id);
+			expect(res.message.quoted_message.id).to.equal(firstMessage.id);
+			expect(res.message.quoted_message.text).to.equal(firstMessage.text);
+			expect(res.message.type).to.equal('reply');
+			expect(res.message.parent_id).to.equal(firstMessage.id);
+			expect(res.message.quoted_message.user).to.not.be.undefined;
+			firstThreadReply = res.message;
+		});
+
+		it('should be possible quote the regular reply in a thread', async () => {
+			const res = await channel.sendMessage({
+				text:
+					'The first thread reply that quotes another reply in the same thread',
+				user_id: friend,
+				parent_id: firstMessage.id,
+				quoted_message_id: firstThreadReply.id,
+			});
+
+			expect(res.message).to.not.be.undefined;
+			expect(res.message.id).to.not.be.empty;
+			expect(res.message.quoted_message).to.not.be.undefined;
+			expect(res.message.quoted_message_id).to.equal(firstThreadReply.id);
+			expect(res.message.quoted_message.id).to.equal(firstThreadReply.id);
+			expect(res.message.quoted_message.text).to.equal(firstThreadReply.text);
+			expect(res.message.type).to.equal('reply');
+			expect(res.message.parent_id).to.equal(firstMessage.id);
+			expect(res.message.quoted_message.user).to.not.be.undefined;
 		});
 	});
 
@@ -2657,6 +2700,66 @@ describe('Quote messages', () => {
 			expect(clm.type).to.equal('regular');
 			expect(clm.parent_id).to.be.undefined;
 			expect(clm.quoted_message.user).to.not.be.undefined;
+		});
+
+		it('is possible to otherwise change a message that contains a quoted_message', async () => {
+			const msgText =
+				'The first message that quotes a message, now with changed text';
+
+			let messageUpdatedListenerRes;
+			const messageUpdatedListener = new Promise((res) => {
+				messageUpdatedListenerRes = res;
+			});
+
+			const webhook = await setupWebhook(
+				client,
+				'webhook_url',
+				(request, body, response) => {
+					const b = JSON.parse(body);
+					if (b.type === 'message.updated') {
+						messageUpdatedListenerRes(b);
+					}
+					response.writeHead(200);
+				},
+			);
+
+			const updateMessageReq = client.updateMessage(
+				{
+					id: messageWithQuote.id,
+					text: msgText,
+				},
+				friend,
+			);
+
+			const [updatedEvent, res] = await Promise.all([
+				messageUpdatedListener,
+				updateMessageReq,
+			]);
+
+			expect(res.message).to.not.be.undefined;
+			expect(res.message.id).to.not.be.empty;
+			expect(res.message.text).to.equal(msgText);
+			expect(res.message.quoted_message).to.not.be.undefined;
+			expect(res.message.quoted_message_id).to.equal(secondMessage.id);
+			expect(res.message.quoted_message.id).to.equal(secondMessage.id);
+			expect(res.message.quoted_message.text).to.equal(secondMessage.text);
+			expect(res.message.type).to.equal('regular');
+			expect(res.message.parent_id).to.be.undefined;
+			expect(res.message.quoted_message.user).to.not.be.undefined;
+
+			expect(updatedEvent.message).to.not.be.undefined;
+			expect(updatedEvent.message.id).to.not.be.empty;
+			expect(updatedEvent.message.text).to.equal(msgText);
+			expect(updatedEvent.message.quoted_message).to.not.be.undefined;
+			expect(updatedEvent.message.quoted_message_id).to.equal(secondMessage.id);
+			expect(updatedEvent.message.quoted_message.id).to.equal(secondMessage.id);
+			expect(updatedEvent.message.quoted_message.text).to.equal(secondMessage.text);
+			expect(updatedEvent.message.type).to.equal('regular');
+			expect(updatedEvent.message.parent_id).to.be.undefined;
+			expect(updatedEvent.message.quoted_message.user).to.not.be.undefined;
+
+			console.log('before teardown');
+			await webhook.tearDown();
 		});
 
 		it('is possible to change the quoted_message_id back', async () => {


### PR DESCRIPTION
1. Enable quoting messages in threads
2. Fix bug where updating a message could lead to an error when the quoted_message_id was left out
3. Make sure the quoted_message is enriched in the message.updated event