### PR TITLE
[CJS3] client single instance

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -104,7 +104,7 @@ export class StreamChat<
   ReactionType extends UnknownType = UnknownType,
   UserType extends UnknownType = UnknownType
 > {
-  private static _instance: StreamChat;
+  private static _instance?: unknown | StreamChat; // type is undefined|StreamChat, unknown is due to TS limitations with statics
 
   _user?: OwnUserResponse<ChannelType, CommandType, UserType> | UserResponse<UserType>;
   activeChannels: {
@@ -338,26 +338,101 @@ export class StreamChat<
    * @example <caption>secret is optional and only used in server side mode</caption>
    * StreamChat.getInstance('api_key', "secret", { httpsAgent: customAgent })
    */
-  public static getInstance(key: string, options?: StreamChatOptions): StreamChat;
-  public static getInstance(
+  public static getInstance<
+    AttachmentType extends UnknownType = UnknownType,
+    ChannelType extends UnknownType = UnknownType,
+    CommandType extends string = LiteralStringForUnion,
+    EventType extends UnknownType = UnknownType,
+    MessageType extends UnknownType = UnknownType,
+    ReactionType extends UnknownType = UnknownType,
+    UserType extends UnknownType = UnknownType
+  >(
+    key: string,
+    options?: StreamChatOptions,
+  ): StreamChat<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    EventType,
+    MessageType,
+    ReactionType,
+    UserType
+  >;
+  public static getInstance<
+    AttachmentType extends UnknownType = UnknownType,
+    ChannelType extends UnknownType = UnknownType,
+    CommandType extends string = LiteralStringForUnion,
+    EventType extends UnknownType = UnknownType,
+    MessageType extends UnknownType = UnknownType,
+    ReactionType extends UnknownType = UnknownType,
+    UserType extends UnknownType = UnknownType
+  >(
     key: string,
     secret?: string,
     options?: StreamChatOptions,
-  ): StreamChat;
-  public static getInstance(
+  ): StreamChat<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    EventType,
+    MessageType,
+    ReactionType,
+    UserType
+  >;
+  public static getInstance<
+    AttachmentType extends UnknownType = UnknownType,
+    ChannelType extends UnknownType = UnknownType,
+    CommandType extends string = LiteralStringForUnion,
+    EventType extends UnknownType = UnknownType,
+    MessageType extends UnknownType = UnknownType,
+    ReactionType extends UnknownType = UnknownType,
+    UserType extends UnknownType = UnknownType
+  >(
     key: string,
     secretOrOptions?: StreamChatOptions | string,
     options?: StreamChatOptions,
-  ): StreamChat {
+  ): StreamChat<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    EventType,
+    MessageType,
+    ReactionType,
+    UserType
+  > {
     if (!StreamChat._instance) {
       if (typeof secretOrOptions === 'string') {
-        StreamChat._instance = new StreamChat(key, secretOrOptions, options);
+        StreamChat._instance = new StreamChat<
+          AttachmentType,
+          ChannelType,
+          CommandType,
+          EventType,
+          MessageType,
+          ReactionType,
+          UserType
+        >(key, secretOrOptions, options);
       } else {
-        StreamChat._instance = new StreamChat(key, secretOrOptions);
+        StreamChat._instance = new StreamChat<
+          AttachmentType,
+          ChannelType,
+          CommandType,
+          EventType,
+          MessageType,
+          ReactionType,
+          UserType
+        >(key, secretOrOptions);
       }
     }
 
-    return StreamChat._instance;
+    return StreamChat._instance as StreamChat<
+      AttachmentType,
+      ChannelType,
+      CommandType,
+      EventType,
+      MessageType,
+      ReactionType,
+      UserType
+    >;
   }
 
   devToken(userID: string) {

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -23,7 +23,7 @@ import {
   PartialUserUpdate,
   PermissionObject,
   ConnectAPIResponse,
-} from '../../';
+} from '../../dist/types';
 const apiKey = 'apiKey';
 
 type UserType = {
@@ -80,6 +80,31 @@ const clientWithoutSecret: StreamChat<
   logger: (logLevel: string, msg: string, extraData?: Record<string, unknown>) => {},
 });
 
+const singletonClient = StreamChat.getInstance<
+  AttachmentType,
+  ChannelType,
+  CommandType,
+  EventType,
+  MessageType,
+  ReactionType,
+  UserType
+>(apiKey);
+
+const singletonClient1: StreamChat<
+  {},
+  ChannelType,
+  string & {},
+  {},
+  {},
+  {},
+  UserType
+> = StreamChat.getInstance<{}, ChannelType, string & {}, {}, {}, {}, UserType>(apiKey);
+
+const singletonClient2: StreamChat<{}, ChannelType> = StreamChat.getInstance<
+  {},
+  ChannelType
+>(apiKey, '', {});
+
 const devToken: string = client.devToken('joshua');
 const token: string = client.createToken('james', 3600);
 const authType: string = client.getAuthType();
@@ -103,6 +128,10 @@ const updateUser: Promise<{
 const updateUsers: Promise<{
   users: { [key: string]: UserResponse<UserType> };
 }> = client.partialUpdateUsers([updateRequest]);
+
+const updateUsersWithSingletonClient: Promise<{
+  users: { [key: string]: UserResponse<UserType> };
+}> = singletonClient.partialUpdateUsers([updateRequest]);
 
 const eventHandler = (event: Event) => {};
 voidReturn = client.on(eventHandler);

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -23,7 +23,7 @@ import {
   PartialUserUpdate,
   PermissionObject,
   ConnectAPIResponse,
-} from '../../dist/types';
+} from '../../';
 const apiKey = 'apiKey';
 
 type UserType = {

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -3,6 +3,35 @@ import { StreamChat } from '../../src/client';
 
 const expect = chai.expect;
 
+describe('StreamChat getInstance', () => {
+	beforeEach(() => {
+		delete StreamChat._instance;
+	});
+
+	it('instance is stored as static property', function () {
+		expect(StreamChat._instance).to.be.undefined;
+
+		const client = StreamChat.getInstance('key');
+		expect(client).to.equal(StreamChat._instance);
+	});
+
+	it('always return the same instance', function () {
+		const client1 = StreamChat.getInstance('key1');
+		const client2 = StreamChat.getInstance('key1');
+		const client3 = StreamChat.getInstance('key1');
+		expect(client1).to.equal(client2);
+		expect(client2).to.equal(client3);
+	});
+
+	it('changin params has no effect', function () {
+		const client1 = StreamChat.getInstance('key2');
+		const client2 = StreamChat.getInstance('key3');
+
+		expect(client1).to.equal(client2);
+		expect(client2.key).to.eql('key2');
+	});
+});
+
 describe('Client userMuteStatus', function () {
 	const client = new StreamChat('', '');
 	const user = { id: 'user' };

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -8,14 +8,14 @@ describe('StreamChat getInstance', () => {
 		delete StreamChat._instance;
 	});
 
-	it('instance is stored as static property', function () {
+	it('instance is stored as static property', () => {
 		expect(StreamChat._instance).to.be.undefined;
 
 		const client = StreamChat.getInstance('key');
 		expect(client).to.equal(StreamChat._instance);
 	});
 
-	it('always return the same instance', function () {
+	it('always return the same instance', () => {
 		const client1 = StreamChat.getInstance('key1');
 		const client2 = StreamChat.getInstance('key1');
 		const client3 = StreamChat.getInstance('key1');
@@ -23,12 +23,24 @@ describe('StreamChat getInstance', () => {
 		expect(client2).to.equal(client3);
 	});
 
-	it('changin params has no effect', function () {
+	it('changin params has no effect', () => {
 		const client1 = StreamChat.getInstance('key2');
 		const client2 = StreamChat.getInstance('key3');
 
 		expect(client1).to.equal(client2);
 		expect(client2.key).to.eql('key2');
+	});
+
+	it('should throw error if connectUser called twice on an instance', async () => {
+		const client1 = StreamChat.getInstance('key2', { allowServerSideConnect: true });
+		client1._setupConnection = () => Promise.resolve();
+		client1._setToken = () => Promise.resolve();
+
+		await client1.connectUser({ id: 'vishal' }, 'token');
+		const client2 = StreamChat.getInstance('key2');
+		expect(() => client2.connectUser({ id: 'Amin' }, 'token')).to.throw(
+			/connectUser was called twice/,
+		);
 	});
 });
 


### PR DESCRIPTION
Unfortunately Lots of TS boilerplates due to generics.

Potential Future improvements: `connectUser` can return the resolved promise for the second call instead of throwing an error if the user id in the token remains the same
