### PR TITLE
Connection related fixes/changes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -455,7 +455,7 @@ export class StreamChat<
     return this.wsPromise;
   };
 
-  _hasConnectionID = () => Boolean(this.connectionID);
+  _hasConnectionID = () => Boolean(this.wsConnection?.connectionID);
 
   /**
    * connectUser - Set the current user and open a WebSocket connection
@@ -1234,7 +1234,7 @@ export class StreamChat<
         tags: ['connection'],
       },
     );
-    this.connectionID = this.wsConnection?.connectionID;
+
     const cids = Object.keys(this.activeChannels);
     if (cids.length && this.recoverStateOnReconnect) {
       this.logger(
@@ -1335,7 +1335,6 @@ export class StreamChat<
       });
     }
 
-    this.connectionID = this.wsConnection.connectionID;
     return handshake;
   }
 
@@ -2380,7 +2379,7 @@ export class StreamChat<
         user_id: this.userID,
         ...options.params,
         api_key: this.key,
-        connection_id: this.connectionID,
+        connection_id: this.wsConnection?.connectionID,
       },
       headers: {
         Authorization: token,

--- a/src/client.ts
+++ b/src/client.ts
@@ -448,6 +448,14 @@ export class StreamChat<
     this.wsBaseURL = this.baseURL.replace('http', 'ws');
   }
 
+  disconnectWebsocket = () => {
+    this.wsConnection?.disconnect();
+  };
+
+  reconnectWebsocket = () => {
+    this._setupConnection();
+  };
+
   _setupConnection = () => {
     this.clientID = `${this.userID}--${randomId()}`;
     this.wsPromise = this.connect();

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -319,6 +319,7 @@ export class StableWSConnection<
 
     if (response) {
       this.connectionID = response.connection_id;
+
       return response;
     }
 
@@ -470,13 +471,11 @@ export class StableWSConnection<
 
   onopen = (wsID: number) => {
     if (this.wsID !== wsID) return;
+
     this.logger('info', 'connection:onopen() - onopen callback', {
       tags: ['connection'],
       wsID,
     });
-
-    // set healthy..
-    this._setHealth(true);
   };
 
   onmessage = (wsID: number, event: WebSocket.MessageEvent) => {
@@ -492,6 +491,8 @@ export class StableWSConnection<
         return;
       } else {
         this.resolvePromise?.(event);
+        // set healthy..
+        this._setHealth(true);
       }
     }
 


### PR DESCRIPTION
# Submit a pull request

- Call `setHealth(true)` only after you receive first ws event (so moved from `onopen` to `onmessage`). Only after `onmessage`, we can be sure that connection is ready. This is mentioned in one of the existing code comments as well:
> we wait till the first message before we consider the connection open..
the reason for this is that auth errors and similar errors trigger a ws.onopen and immediately
after that a ws.onclose.

Introducing this change, because we don't get `connectionId` from `onopen` callback on websocket. We only get 
connectionId from `onmessage` callback. So with existing implementation, if you want to rewatch/requery channels upon 
network recovery, you can't rely on health of websocket to do that. Because watching channels requires connectionId.

After the change, you can easily do following:

```js
client.on('connection.changed', (event) => {
  if (event.online) {
    // rewatch your channels
  }
})
```

- Introduced two aliases
  - `client.disconnectWebsocket` for `client.wsConnection.disconnect`
  - `client.reconnectWebsocket` for `client._setupConnection`

  This makes it easier for push notification handling - as mentioned in [caveats](https://github.com/GetStream/stream-chat-react-native/wiki/Cookbook-v3.0#caveats)

- Removed `client.connectionId` to avoid hassle of keeping it in sync with `client.wsConnection.connectionId`. Lets only access it from `client.wsConnection.connectionId` moving forward

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] The code changes follow best practices
- [ ] Code changes are tested (add some information if not applicable)

## Description of the pull request
