### PR TITLE
Pass endpoints as comma-separated values

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1613,7 +1613,7 @@ export class StreamChat<
       web,
       android,
       ios,
-      endpoints,
+      endpoints: endpoints ? endpoints.join(',') : undefined,
     });
   }
 


### PR DESCRIPTION
This PR follows from https://github.com/GetStream/stream-chat-js/pull/631 updating the way endpoints are passed via query params, as a list of comma-separated values on the same key.