### PR TITLE
fix: moving channel._disconnect call from closeConnection to disconnectUser

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -556,10 +556,6 @@ export class StreamChat<
       this.cleaningIntervalRef = undefined;
     }
 
-    for (const channel of Object.values(this.activeChannels)) {
-      channel._disconnect();
-    }
-
     if (!this.wsConnection) {
       return Promise.resolve();
     }
@@ -705,6 +701,10 @@ export class StreamChat<
     this.anonymous = false;
 
     const closePromise = this.closeConnection(timeout);
+
+    for (const channel of Object.values(this.activeChannels)) {
+      channel._disconnect();
+    }
 
     // ensure we no longer return inactive channels
     this.activeChannels = {};


### PR DESCRIPTION

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

`channel._disconnect` should only happen in `disconnectUser`, and not `closeConnection`. Because once you call channel._disconnect, it will be completely blocked of all the functionality. This issue was introduced in latest minor version. We need to think a bit more about this disconnect functionality, but for now to unblock react/react-native SDKs. This should fix it. 
