### PR TITLE
Blacklist __html property in updateMessage

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2391,6 +2391,7 @@ export class StreamChat<
       | 'type'
       | 'updated_at'
       | 'user'
+      | '__html'
     > = [
       'command',
       'created_at',
@@ -2402,6 +2403,7 @@ export class StreamChat<
       'type',
       'updated_at',
       'user',
+      '__html',
     ];
 
     reservedMessageFields.forEach(function (item) {


### PR DESCRIPTION
This fields is leaks into `updateMessage` which causes stale data in messages