### PR TITLE
deprecate __html attribute on message

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -2,6 +2,7 @@ import { Channel } from './channel';
 import {
   ChannelMemberResponse,
   ChannelMembership,
+  FormatMessageResponse,
   Event,
   LiteralStringForUnion,
   MessageResponse,
@@ -174,9 +175,19 @@ export class ChannelState<
       ReactionType,
       UserType
     >,
-  ) {
+  ): FormatMessageResponse<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    MessageType,
+    ReactionType,
+    UserType
+  > {
     return {
       ...message,
+      /**
+       * @deprecated please use `html`
+       */
       __html: message.html,
       // parse the date..
       pinned_at: message.pinned_at ? new Date(message.pinned_at) : null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -330,21 +330,15 @@ export type FormatMessageResponse<
   ReactionType = UnknownType,
   UserType = UnknownType
 > = Omit<
-  MessageResponse<
-    AttachmentType,
-    ChannelType,
-    CommandType,
-    MessageType,
-    ReactionType,
-    UserType
-  >,
-  'created_at' | 'updated_at' | 'status'
-> & {
-  __html: string;
-  created_at: Date;
-  status: string;
-  updated_at: Date;
-};
+  MessageResponse<AttachmentType, ChannelType, CommandType, {}, ReactionType, UserType>,
+  'created_at' | 'pinned_at' | 'updated_at' | 'status'
+> &
+  MessageType & {
+    created_at: Date;
+    pinned_at: Date | null;
+    status: string;
+    updated_at: Date;
+  };
 
 export type GetChannelTypeResponse<
   CommandType extends string = LiteralStringForUnion


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- `message.__html` deprecated in favor of `message.html`

