### PR TITLE
Ensure mentioned_users is array of user_ids. in updateMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## March 11, 2021 - 3.5.1
+
+Remove call to `channel._disconnect` from client.closeConnection. For end user this will fix the issue - `You can't use a channel after client.disconnect() was called` [#639](https://github.com/GetStream/stream-chat-js/pull/639)
+
 ## March 10, 2021 - 3.5.0
 
 - Deprecated `client.disconnect`. A new method has been introduced as alias - `client.disconnectUser`

--- a/src/client.ts
+++ b/src/client.ts
@@ -2422,24 +2422,15 @@ export class StreamChat<
 
     /**
      * Server always expects mentioned_users to be array of string. We are adding extra check, just in case
-     * SDK missed this conversation.
+     * SDK missed this conversion.
      */
     if (
       Array.isArray(clonedMessage.mentioned_users) &&
       !isString(clonedMessage.mentioned_users[0])
     ) {
-      /**
-       * We need to typecast mentioned_users first to unknown, to let typescript know that further typecasting is intentional.
-       *
-       * Error raised by ts:
-       * ```
-       * Conversion of type 'string[]' to type 'UserResponse<UserType>[]' may be a mistake because neither
-       * type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first
-       * ```
-       */
       clonedMessage.mentioned_users = ((clonedMessage.mentioned_users as unknown) as Array<
         UserResponse<UserType>
-      >)?.map((mu) => mu.id);
+      >)?.map((mu) => ((mu as unknown) as UserResponse).id);
     }
 
     return await this.post<

--- a/src/client.ts
+++ b/src/client.ts
@@ -2428,9 +2428,9 @@ export class StreamChat<
       Array.isArray(clonedMessage.mentioned_users) &&
       !isString(clonedMessage.mentioned_users[0])
     ) {
-      clonedMessage.mentioned_users = ((clonedMessage.mentioned_users as unknown) as Array<
-        UserResponse<UserType>
-      >)?.map((mu) => ((mu as unknown) as UserResponse).id);
+      clonedMessage.mentioned_users = clonedMessage.mentioned_users.map(
+        (mu) => ((mu as unknown) as UserResponse).id,
+      );
     }
 
     return await this.post<

--- a/src/client.ts
+++ b/src/client.ts
@@ -2417,6 +2417,29 @@ export class StreamChat<
         clonedMessage.user = { id: userId.id } as UserResponse<UserType>;
       }
     }
+
+    /**
+     * Server always expects mentioned_users to be array of string. We are adding extra check, just in case
+     * SDK missed this conversation.
+     */
+    if (
+      Array.isArray(clonedMessage.mentioned_users) &&
+      !isString(clonedMessage.mentioned_users[0])
+    ) {
+      /**
+       * We need to typecast mentioned_users first to unknown, to let typescript know that further typecasting is intentional.
+       *
+       * Error raised by ts:
+       * ```
+       * Conversion of type 'string[]' to type 'UserResponse<UserType>[]' may be a mistake because neither
+       * type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first
+       * ```
+       */
+      clonedMessage.mentioned_users = ((clonedMessage.mentioned_users as unknown) as Array<
+        UserResponse<UserType>
+      >)?.map((mu) => mu.id);
+    }
+
     return await this.post<
       UpdateMessageAPIResponse<
         AttachmentType,

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1,12 +1,14 @@
 import chai from 'chai';
-import { Channel } from '../../src/channel';
-import { StreamChat } from '../../src/client';
 import { v4 as uuidv4 } from 'uuid';
-import { generateMsg } from './test-utils/generateMessage';
+
+import { generateChannel } from './test-utils/generateChannel';
 import { generateMember } from './test-utils/generateMember';
+import { generateMsg } from './test-utils/generateMessage';
 import { generateUser } from './test-utils/generateUser';
 import { getOrCreateChannelApi } from './test-utils/getOrCreateChannelApi';
-import { generateChannel } from './test-utils/generateChannel';
+
+import { StreamChat } from '../../src/client';
+import { Channel } from '../../src/channel';
 
 const expect = chai.expect;
 

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -1,10 +1,12 @@
 import chai from 'chai';
-import { ChannelState, StreamChat, Channel } from '../../src';
-import { generateMsg } from './test-utils/generateMessage';
-import { generateChannel } from './test-utils/generateChannel';
-import { getOrCreateChannelApi } from './test-utils/getOrCreateChannelApi';
-import { getClientWithUser } from './test-utils/getClient';
 import { v4 as uuidv4 } from 'uuid';
+
+import { generateChannel } from './test-utils/generateChannel';
+import { generateMsg } from './test-utils/generateMessage';
+import { getClientWithUser } from './test-utils/getClient';
+import { getOrCreateChannelApi } from './test-utils/getOrCreateChannelApi';
+
+import { ChannelState, StreamChat, Channel } from '../../src';
 
 const expect = chai.expect;
 

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -219,7 +219,7 @@ describe('Detect node environment', () => {
 	});
 });
 
-describe.only('updateMessage should ensure sanity of `mentioned_users`', () => {
+describe('updateMessage should ensure sanity of `mentioned_users`', () => {
 	it('should convert mentioned_users from array of user objects to array of userIds', async () => {
 		const client = await getClientWithUser();
 		client.post = (url, config) => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Slack discussion - https://getstream.slack.com/archives/C01FT5767AS/p1615968119001100

Updating pinned message fails, if there is mentioned_users in message. This is something missed in react sdk, (to ensure conversion of array of user objects to user ids). I think its better we handle it on js client as well.

## Changelog

- Extra check to see if `message.mentioned_users` is array of string or objects
- Convert array of user objects to array of user ids.
- Unit tests for the change
