### PR TITLE
Return unsubscribe handler from `channel.on`

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1380,7 +1380,7 @@ export class Channel<
       ReactionType,
       UserType
     >,
-  ): void;
+  ): { unsubscribe: () => void };
   on(
     callback: EventHandler<
       AttachmentType,
@@ -1391,7 +1391,7 @@ export class Channel<
       ReactionType,
       UserType
     >,
-  ): void;
+  ): { unsubscribe: () => void };
   on(
     callbackOrString:
       | EventHandler<
@@ -1413,7 +1413,7 @@ export class Channel<
       ReactionType,
       UserType
     >,
-  ): void {
+  ): { unsubscribe: () => void } {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
@@ -1433,6 +1433,12 @@ export class Channel<
     );
 
     this.listeners[key].push(callback);
+
+    return {
+      unsubscribe: () => {
+        this.listeners[key] = this.listeners[key].filter((el) => el !== callback);
+      },
+    };
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1436,6 +1436,12 @@ export class Channel<
 
     return {
       unsubscribe: () => {
+        this._client.logger(
+          'info',
+          `Removing listener for ${key} event from channel ${this.cid}`,
+          { tags: ['event', 'channel'], channel: this },
+        );
+
         this.listeners[key] = this.listeners[key].filter((el) => el !== callback);
       },
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -887,6 +887,10 @@ export class StreamChat<
     this.listeners[key].push(callback);
     return {
       unsubscribe: () => {
+        this.logger('info', `Removing listener for ${key} event`, {
+          tags: ['event', 'client'],
+        });
+
         this.listeners[key] = this.listeners[key].filter((el) => el !== callback);
       },
     };

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -5,6 +5,7 @@ import { generateChannel } from './test-utils/generateChannel';
 import { generateMember } from './test-utils/generateMember';
 import { generateMsg } from './test-utils/generateMessage';
 import { generateUser } from './test-utils/generateUser';
+import { getClientWithUser } from './test-utils/getClient';
 import { getOrCreateChannelApi } from './test-utils/getOrCreateChannelApi';
 
 import { StreamChat } from '../../src/client';
@@ -394,5 +395,22 @@ describe('Ensure single channel per cid on client activeChannels state', () => {
 		await channelVish_copy2.watch();
 
 		expect(channelVish_copy1).to.be.equal(channelVish_copy2);
+	});
+});
+
+describe.only('event subscription and unsubscription', () => {
+	it('channel.on should return unsubscribe handler', async () => {
+		const client = await getClientWithUser();
+		const channel = client.channel('messaging', uuidv4());
+
+		const { unsubscribe: unsubscribe1 } = channel.on('message.new', () => {});
+		const { unsubscribe: unsubscribe2 } = channel.on(() => {});
+
+		expect(Object.values(channel.listeners).length).to.be.equal(2);
+
+		unsubscribe1();
+		expect(channel.listeners['message.new'].length).to.be.equal(0);
+		unsubscribe2();
+		expect(channel.listeners['all'].length).to.be.equal(0);
 	});
 });


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

- Slack discussion: https://getstream.slack.com/archives/C01FT5767AS/p1616153988038900

## Changelog

- Added access to unsubscribe handler from `channel.on` function.
