### PR TITLE
Allow to override https agent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -236,7 +236,7 @@ export class StreamChat<
       ...inputOptions,
     };
 
-    if (this.node) {
+    if (this.node && !this.options.httpsAgent) {
       this.options.httpsAgent = new https.Agent({
         keepAlive: true,
         keepAliveMsecs: 3000,


### PR DESCRIPTION
It is not currently possible to set custom https agent, although documentation of `StreamChat` constructor says otherwise:

```ts
   * @param {httpsAgent} [options.httpsAgent] - custom httpsAgent, in node it's default to https.agent()
```

