### PR TITLE
Fix ChannelState#clean() to handle received_at as Date type

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -620,10 +620,11 @@ export class ChannelState<
     const now = new Date();
     // prevent old users from showing up as typing
     for (const [userID, lastEvent] of Object.entries(this.typing)) {
-      const since =
-        typeof lastEvent.received_at === 'string' &&
-        now.getTime() - new Date(lastEvent.received_at).getTime();
-      if (since > 7000) {
+      const receivedAt =
+        typeof lastEvent.received_at === 'string'
+          ? new Date(lastEvent.received_at)
+          : lastEvent.received_at || new Date();
+      if (now.getTime() - receivedAt.getTime() > 7000) {
         delete this.typing[userID];
         this._channel.getClient().dispatchEvent({
           cid: this._channel.cid,


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Because the client sets `received_at` as a Date type (src/client.ts#L1168) and `ChannelState#clean()` was expecting a string, it hasn't been working at all. A better fix might be to restrict the Event typing to Date since it is never a string after being handled by the client, but in lieu of that we'll handle both types here and add a test.

## Changelog

- Fix ChannelState#clean() to properly clear stale typing events
