### PR TITLE
fixed response test for frozen update channel

### DIFF
--- a/test/typescript/response-generators/channel.js
+++ b/test/typescript/response-generators/channel.js
@@ -222,7 +222,6 @@ async function updateChannelFromOriginal() {
 	await channel.watch();
 	await channel.update({
 		...channel.data,
-		frozen: true,
 		description: 'Updating original data',
 	});
 	return await channel.update({


### PR DESCRIPTION
This "fixes" a test that started failing recently, due to a backend change. However, I'm not sure what the intent of the test was and if it's still valid like this.

Tagging you @nhannah since you were the author of the test
