### PR TITLE
[CHAT-1558] Add sendUserCustomEvent method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2650,6 +2650,20 @@ export class StreamChat<
     });
   }
 
+  /**
+   * sendUserCustomEvent - Send a custom event to a user
+   *
+   * @param {string} userID target user id
+   * @param {Event<EventType, UserType>} event for example {type: 'friendship-request'}
+   *
+   * @return {Promise<APIResponse>} The Server Response
+   */
+  async sendUserCustomEvent(userID: string, event: Event<EventType, UserType>) {
+    return await this.post<APIResponse>(`${this.baseURL}/users/${userID}/event`, {
+      event,
+    });
+  }
+
   createBlockList(blockList: BlockList) {
     return this.post<APIResponse>(`${this.baseURL}/blocklists`, blockList);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -91,6 +91,7 @@ import {
   UpdateCommandResponse,
   UpdatedMessage,
   UpdateMessageAPIResponse,
+  UserCustomEvent,
   UserFilters,
   UserOptions,
   UserResponse,
@@ -2653,14 +2654,14 @@ export class StreamChat<
   /**
    * sendUserCustomEvent - Send a custom event to a user
    *
-   * @param {string} userID target user id
-   * @param {Event<EventType, UserType>} event for example {type: 'friendship-request'}
+   * @param {string} targetUserID target user id
+   * @param {UserCustomEvent} event for example {type: 'friendship-request'}
    *
    * @return {Promise<APIResponse>} The Server Response
    */
-  async sendUserCustomEvent(userID: string, event: Event<EventType, UserType>) {
-    return await this.post<APIResponse>(`${this.baseURL}/users/${userID}/event`, {
-      user_id: userID,
+  async sendUserCustomEvent(targetUserID: string, event: UserCustomEvent) {
+    return await this.post<APIResponse>(`${this.baseURL}/users/${targetUserID}/event`, {
+      target_user_id: targetUserID,
       event,
     });
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -2660,6 +2660,7 @@ export class StreamChat<
    */
   async sendUserCustomEvent(userID: string, event: Event<EventType, UserType>) {
     return await this.post<APIResponse>(`${this.baseURL}/users/${userID}/event`, {
+      user_id: userID,
       event,
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -972,6 +972,10 @@ export type Event<
   watcher_count?: number;
 };
 
+export type UserCustomEvent<EventType extends UnknownType = UnknownType> = EventType & {
+  type: string;
+};
+
 export type EventHandler<
   AttachmentType extends UnknownType = UnknownType,
   ChannelType extends UnknownType = UnknownType,


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
This PR adds a new method for sending custom event to a user. 
It also adds a new `UserCustomEvent` type which is used in the new method.

⚠️ This shouldn't be merge until the API integration

## Changelog

- Add `UserCustomEvent` type
- Add `sendUserCustomEvent` method
