### PR TITLE
update type for enforce_unique_usernames

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,7 @@ export type AppSettingsAPIResponse<
     custom_action_handler_url?: string;
     disable_auth_checks?: boolean;
     disable_permissions_checks?: boolean;
-    enforce_unique_usernames?: string;
+    enforce_unique_usernames?: 'no' | 'app' | 'team';
     file_upload_config?: FileUploadConfig;
     image_moderation_enabled?: boolean;
     image_upload_config?: FileUploadConfig;


### PR DESCRIPTION
Match the setting and return type for field enforce_unique_usernames to a union type instead if string.
