### PR TITLE
change quoted_message type to not be recursive

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -138,7 +138,7 @@ export type ChannelResponse<
   id: string;
   type: string;
   auto_translation_enabled?: boolean;
-  auto_translation_language?: TranslationLanguages;
+  auto_translation_language?: TranslationLanguages | '';
   config?: ChannelConfigWithInfo<CommandType>;
   cooldown?: number;
   created_at?: string;
@@ -450,6 +450,31 @@ export type MessageResponse<
   MessageType = UnknownType,
   ReactionType = UnknownType,
   UserType = UnknownType
+> = MessageResponseBase<
+  AttachmentType,
+  ChannelType,
+  CommandType,
+  MessageType,
+  ReactionType,
+  UserType
+> & {
+  quoted_message?: MessageResponseBase<
+    AttachmentType,
+    ChannelType,
+    CommandType,
+    MessageType,
+    ReactionType,
+    UserType
+  >;
+};
+
+export type MessageResponseBase<
+  AttachmentType = UnknownType,
+  ChannelType = UnknownType,
+  CommandType extends string = LiteralStringForUnion,
+  MessageType = UnknownType,
+  ReactionType = UnknownType,
+  UserType = UnknownType
 > = MessageBase<AttachmentType, MessageType, UserType> & {
   args?: string;
   channel?: ChannelResponse<ChannelType, CommandType, UserType>;
@@ -467,17 +492,6 @@ export type MessageResponse<
   pin_expires?: string | null;
   pinned_at?: string | null;
   pinned_by?: UserResponse<UserType> | null;
-  quoted_message?: Omit<
-    MessageResponse<
-      AttachmentType,
-      ChannelType,
-      CommandType,
-      MessageType,
-      ReactionType,
-      UserType
-    >,
-    'quoted_message'
-  >;
   reaction_counts?: { [key: string]: number } | null;
   reaction_scores?: { [key: string]: number } | null;
   reply_count?: number;

--- a/test/typescript/index.js
+++ b/test/typescript/index.js
@@ -20,12 +20,6 @@ const executables = [
 			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['addDevice']>>",
 	},
 	{
-		f: rg.getDevices,
-		imports: ['StreamChat', 'Unpacked'],
-		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['getDevices']>>",
-	},
-	{
 		f: rg.addMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
@@ -44,12 +38,6 @@ const executables = [
 			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['banUser']>>",
 	},
 	{
-		f: rg.shadowBan,
-		imports: ['StreamChat', 'Unpacked'],
-		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['shadowBan']>>",
-	},
-	{
 		f: rg.channelSearch,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
@@ -60,6 +48,18 @@ const executables = [
 		imports: ['StreamChat', 'Unpacked'],
 		type:
 			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['connect']>>",
+	},
+	{
+		f: rg.connectAnonymousUser,
+		imports: ['StreamChat', 'Unpacked'],
+		type:
+			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['connectAnonymousUser']>>",
+	},
+	{
+		f: rg.connectUser,
+		imports: ['StreamChat', 'Unpacked'],
+		type:
+			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['connectUser']>>",
 	},
 	{
 		f: rg.create,
@@ -218,6 +218,12 @@ const executables = [
 		imports: ['Channel', 'Unpacked'],
 		type:
 			"Unpacked<ReturnType<Channel<{}, { description?: string }, string & {}, {}, {}, {}, {}>['getConfig']>>",
+	},
+	{
+		f: rg.getDevices,
+		imports: ['StreamChat', 'Unpacked'],
+		type:
+			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['getDevices']>>",
 	},
 	{
 		f: rg.getMessage,
@@ -431,22 +437,16 @@ const executables = [
 			"Unpacked<ReturnType<Channel<{}, { description?: string }, string & {}, {}, {}, {}, {}>['sendReaction']>>",
 	},
 	{
-		f: rg.connectAnonymousUser,
-		imports: ['StreamChat', 'Unpacked'],
-		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['connectAnonymousUser']>>",
-	},
-	{
 		f: rg.setGuestUser,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
 			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['setGuestUser']>>",
 	},
 	{
-		f: rg.connectUser,
+		f: rg.shadowBan,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['connectUser']>>",
+			"Unpacked<ReturnType<StreamChat<{}, {}, string & {}, {}, {}, {}, {}>['shadowBan']>>",
 	},
 	{
 		f: rg.show,


### PR DESCRIPTION
quoted_message had usage issues due to recursive referencing on the generics. This should fix that.
