### PR TITLE
[CHAT-1650] Add user, application level token revoke helpers and iat claim in tokens

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -863,7 +863,8 @@ export class StreamChat<
       extra.exp = exp;
     }
 
-    extra.iat = Math.round(new Date().getTime() / 1000);
+    // add iat claim for token revocation
+    extra.iat = Math.round(new Date().getTime() / 1000) - 1;
 
     return JWTUserToken(this.secret, userID, extra, {});
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -634,6 +634,11 @@ export class StreamChat<
     return await this.patch<APIResponse>(this.baseURL + '/app', options);
   }
 
+  _tokenRevokeEmptyStringError = () =>
+    new Error(
+      "Don't pass blank string for since, use null instead if resetting the token revoke",
+    );
+
   /**
    * Revokes all tokens on application level issued before given time
    */
@@ -647,9 +652,7 @@ export class StreamChat<
     }
 
     if (before === '') {
-      throw new Error(
-        "Don't pass blank string for since, use null instead if resetting the token revoke",
-      );
+      throw this._tokenRevokeEmptyStringError();
     }
 
     return await this.updateAppSettings({
@@ -677,9 +680,7 @@ export class StreamChat<
     }
 
     if (before === '') {
-      throw new Error(
-        "Don't pass blank string for since, use null instead if resetting the token revoke",
-      );
+      throw this._tokenRevokeEmptyStringError();
     }
 
     const users: PartialUserUpdate<UserType>[] = [];
@@ -864,7 +865,6 @@ export class StreamChat<
       extra.exp = exp;
     }
 
-    // add iat claim for token revocation
     if (iat) {
       extra.iat = iat;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -661,26 +661,7 @@ export class StreamChat<
    * Revokes token for a user issued before given time
    */
   async revokeUserToken(userID: string, before?: Date | string | null) {
-    if (before === undefined) {
-      before = new Date().toISOString();
-    }
-
-    if (before instanceof Date) {
-      before = before.toISOString();
-    }
-
-    if (before === '') {
-      throw new Error(
-        "Don't pass blank string for since, use null instead if resetting the token revoke",
-      );
-    }
-
-    return await this.partialUpdateUser({
-      id: userID,
-      set: <Partial<UserResponse<UserType>>>{
-        revoke_tokens_issued_before: before,
-      },
-    });
+    return await this.revokeUsersToken([userID], before);
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -635,41 +635,41 @@ export class StreamChat<
   }
 
   /**
-   * Revokes all tokens upto current timestamp on application level
+   * Revokes all tokens on application level issued before given time
    */
-  async revokeTokens(since?: Date | string | null) {
-    if (since === undefined) {
-      since = new Date().toISOString();
+  async revokeTokens(before?: Date | string | null) {
+    if (before === undefined) {
+      before = new Date().toISOString();
     }
 
-    if (since instanceof Date) {
-      since = since.toISOString();
+    if (before instanceof Date) {
+      before = before.toISOString();
     }
 
-    if (since === '') {
+    if (before === '') {
       throw new Error(
         "Don't pass blank string for since, use null instead if resetting the token revoke",
       );
     }
 
     return await this.updateAppSettings({
-      revoke_tokens_issued_before: since,
+      revoke_tokens_issued_before: before,
     });
   }
 
   /**
-   * Revokes token for a user
+   * Revokes token for a user issued before given time
    */
-  async revokeUserToken(userID: string, since?: Date | string | null) {
-    if (since === undefined) {
-      since = new Date().toISOString();
+  async revokeUserToken(userID: string, before?: Date | string | null) {
+    if (before === undefined) {
+      before = new Date().toISOString();
     }
 
-    if (since instanceof Date) {
-      since = since.toISOString();
+    if (before instanceof Date) {
+      before = before.toISOString();
     }
 
-    if (since === '') {
+    if (before === '') {
       throw new Error(
         "Don't pass blank string for since, use null instead if resetting the token revoke",
       );
@@ -678,24 +678,24 @@ export class StreamChat<
     return await this.partialUpdateUser({
       id: userID,
       set: <Partial<UserResponse<UserType>>>{
-        revoke_tokens_issued_before: since,
+        revoke_tokens_issued_before: before,
       },
     });
   }
 
   /**
-   * Revokes tokens for a list of users
+   * Revokes tokens for a list of users issued before given time
    */
-  async revokeUsersToken(userIDs: string[], since?: Date | string) {
-    if (since === undefined) {
-      since = new Date().toISOString();
+  async revokeUsersToken(userIDs: string[], before?: Date | string | null) {
+    if (before === undefined) {
+      before = new Date().toISOString();
     }
 
-    if (since instanceof Date) {
-      since = since.toISOString();
+    if (before instanceof Date) {
+      before = before.toISOString();
     }
 
-    if (since === '') {
+    if (before === '') {
       throw new Error(
         "Don't pass blank string for since, use null instead if resetting the token revoke",
       );
@@ -706,7 +706,7 @@ export class StreamChat<
       users.push({
         id: userID,
         set: <Partial<UserResponse<UserType>>>{
-          revoke_tokens_issued_before: since,
+          revoke_tokens_issued_before: before,
         },
       });
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -637,13 +637,21 @@ export class StreamChat<
   /**
    * Revokes all tokens upto current timestamp on application level
    */
-  async revokeTokens(since?: Date | string) {
+  async revokeTokens(since?: Date | string | null) {
     if (since === undefined) {
       since = new Date().toISOString();
     }
+
     if (since instanceof Date) {
       since = since.toISOString();
     }
+
+    if (since === '') {
+      throw new Error(
+        "Don't pass blank string for since, use null instead if resetting the token revoke",
+      );
+    }
+
     return await this.updateAppSettings({
       revoke_tokens_issued_before: since,
     });
@@ -652,13 +660,19 @@ export class StreamChat<
   /**
    * Revokes token for a user
    */
-  async revokeUserToken(userID: string, since?: Date | string) {
+  async revokeUserToken(userID: string, since?: Date | string | null) {
     if (since === undefined) {
       since = new Date().toISOString();
     }
 
     if (since instanceof Date) {
       since = since.toISOString();
+    }
+
+    if (since === '') {
+      throw new Error(
+        "Don't pass blank string for since, use null instead if resetting the token revoke",
+      );
     }
 
     return await this.partialUpdateUser({
@@ -679,6 +693,12 @@ export class StreamChat<
 
     if (since instanceof Date) {
       since = since.toISOString();
+    }
+
+    if (since === '') {
+      throw new Error(
+        "Don't pass blank string for since, use null instead if resetting the token revoke",
+      );
     }
 
     const users: PartialUserUpdate<UserType>[] = [];

--- a/src/client.ts
+++ b/src/client.ts
@@ -638,7 +638,7 @@ export class StreamChat<
     return await this.patch<APIResponse>(this.baseURL + '/app', options);
   }
 
-  _revokeTokensCheckDate = (before: Date | string | null | undefined): string | null => {
+  _normalizeDate = (before: Date | string | null | undefined): string | null => {
     if (before === undefined) {
       before = new Date().toISOString();
     }
@@ -661,7 +661,7 @@ export class StreamChat<
    */
   async revokeTokens(before?: Date | string | null) {
     return await this.updateAppSettings({
-      revoke_tokens_issued_before: this._revokeTokensCheckDate(before),
+      revoke_tokens_issued_before: this._normalizeDate(before),
     });
   }
 
@@ -676,7 +676,7 @@ export class StreamChat<
    * Revokes tokens for a list of users issued before given time
    */
   async revokeUsersToken(userIDs: string[], before?: Date | string | null) {
-    before = this._revokeTokensCheckDate(before);
+    before = this._normalizeDate(before);
 
     const users: PartialUserUpdate<UserType>[] = [];
     for (const userID of userIDs) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -853,7 +853,7 @@ export class StreamChat<
    *
    * @return {string} Returns a token
    */
-  createToken(userID: string, exp?: number) {
+  createToken(userID: string, exp?: number, iat?: number) {
     if (this.secret == null) {
       throw Error(`tokens can only be created server-side using the API Secret`);
     }
@@ -864,7 +864,9 @@ export class StreamChat<
     }
 
     // add iat claim for token revocation
-    extra.iat = Math.round(new Date().getTime() / 1000) - 1;
+    if (iat) {
+      extra.iat = iat;
+    }
 
     return JWTUserToken(this.secret, userID, extra, {});
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -702,7 +702,7 @@ export class StreamChat<
     }
 
     const users: PartialUserUpdate<UserType>[] = [];
-    for (const userID in userIDs) {
+    for (const userID of userIDs) {
       users.push({
         id: userID,
         set: <Partial<UserResponse<UserType>>>{

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -37,9 +37,13 @@ export function JWTUserToken(
   }
 
   const opts: SignOptions = Object.assign(
-    { algorithm: 'HS256', noTimestamp: false },
+    { algorithm: 'HS256', noTimestamp: true },
     jwtOptions,
   );
+
+  if (payload.iat) {
+    opts.noTimestamp = false;
+  }
   return jwt.sign(payload, apiSecret, opts);
 }
 

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -37,7 +37,7 @@ export function JWTUserToken(
   }
 
   const opts: SignOptions = Object.assign(
-    { algorithm: 'HS256', noTimestamp: true },
+    { algorithm: 'HS256', noTimestamp: false },
     jwtOptions,
   );
   return jwt.sign(payload, apiSecret, opts);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1371,7 +1371,7 @@ export type AppSettings = {
   push_config?: {
     version?: string;
   };
-  revoke_tokens_issued_before?: string;
+  revoke_tokens_issued_before?: string | null;
   sqs_key?: string;
   sqs_secret?: string;
   sqs_url?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,7 @@ export type AppSettingsAPIResponse<
       apn?: APNConfig;
       firebase?: FirebaseConfig;
     };
+    revoke_tokens_issued_before?: string;
     sqs_key?: string;
     sqs_secret?: string;
     sqs_url?: string;
@@ -691,6 +692,7 @@ export type UserResponse<UserType = UnknownType> = User<UserType> & {
   language?: TranslationLanguages | '';
   last_active?: string;
   online?: boolean;
+  revoke_tokens_issued_before?: string;
   shadow_banned?: boolean;
   updated_at?: string;
 };
@@ -1369,6 +1371,7 @@ export type AppSettings = {
   push_config?: {
     version?: string;
   };
+  revoke_tokens_issued_before?: string;
   sqs_key?: string;
   sqs_secret?: string;
   sqs_url?: string;


### PR DESCRIPTION

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- `createToken` add support to have `iat` claim while generating tokens.
- added `revokeTokens()` method to revoke/unrevoke tokens on an application level.
- added `revokeUserToken()` method to revoke/unrevoke tokens on user level.
- added `revokenUsersToken()` method to revoke/unrevoke tokens for multiple users at once.
