### PR TITLE
[CHAT-1814] Updates to message search

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -332,7 +332,7 @@ export class Channel<
     } = {},
   ) {
     // Return a list of channels
-    const { sort: sort_value, ...options_without_sort } = { ...options };
+    const { sort, ...optionsWithoutSort } = { ...options };
     const payload: SearchPayload<
       AttachmentType,
       ChannelType,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -331,7 +331,7 @@ export class Channel<
     } = {},
   ) {
     // Return a list of channels
-    const { sort, ...options_without_sort } = { ...options };
+    const { sort: sort_value, ...options_without_sort } = { ...options };
     const payload: SearchPayload<
       AttachmentType,
       ChannelType,
@@ -355,8 +355,8 @@ export class Channel<
       throw Error(`Invalid type ${typeof query} for query parameter`);
     }
 
-    if (sort) {
-      payload.sort = normalizeQuerySort(sort);
+    if (sort_value) {
+      payload.sort = normalizeQuerySort(sort_value);
     }
     // Make sure we wait for the connect promise if there is a pending one
     await this.getClient().wsPromise;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -44,7 +44,7 @@ import {
   UserFilters,
   UserResponse,
   UserSort,
-  SearchMessageSort,
+  SearchMessageSortBase,
 } from './types';
 import { Role } from './permissions';
 
@@ -350,7 +350,9 @@ export class Channel<
         UserType
       >,
       ...options,
-      sort: options.sort ? normalizeQuerySort<SearchMessageSort<MessageType>>(options.sort) : undefined,
+      sort: options.sort
+        ? normalizeQuerySort<SearchMessageSortBase<MessageType>>(options.sort)
+        : undefined,
     };
     if (typeof query === 'string') {
       payload.query = query;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -346,7 +346,7 @@ export class Channel<
         CommandType,
         UserType
       >,
-      ...options_without_sort,
+      ...optionsWithoutSort,
     };
     if (typeof query === 'string') {
       payload.query = query;
@@ -356,8 +356,8 @@ export class Channel<
       throw Error(`Invalid type ${typeof query} for query parameter`);
     }
 
-    if (sort_value) {
-      payload.sort = normalizeQuerySort(sort_value);
+    if (sort) {
+      payload.sort = normalizeQuerySort(sort);
     }
     // Make sure we wait for the connect promise if there is a pending one
     await this.getClient().wsPromise;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -332,11 +332,10 @@ export class Channel<
       query?: string;
     } = {},
   ) {
-    if ('offset' in options && ('sort' in options || 'next' in options)) {
+    if (options.offset && (options.sort || options.next)) {
       throw Error(`Cannot specify offset with sort or next parameters`);
     }
     // Return a list of channels
-    const { sort: sortValue, ...optionsWithoutSort } = { ...options };
     const payload: SearchPayload<
       AttachmentType,
       ChannelType,
@@ -350,7 +349,8 @@ export class Channel<
         CommandType,
         UserType
       >,
-      ...optionsWithoutSort,
+      ...options,
+      sort: options.sort ? normalizeQuerySort<SearchMessageSort<MessageType>>(options.sort) : undefined,
     };
     if (typeof query === 'string') {
       payload.query = query;
@@ -358,9 +358,6 @@ export class Channel<
       payload.message_filter_conditions = query;
     } else {
       throw Error(`Invalid type ${typeof query} for query parameter`);
-    }
-    if (sortValue) {
-      payload.sort = normalizeQuerySort<SearchMessageSort<MessageType>>(sortValue);
     }
     // Make sure we wait for the connect promise if there is a pending one
     await this.getClient().wsPromise;

--- a/src/client.ts
+++ b/src/client.ts
@@ -77,7 +77,11 @@ import {
   ReactionResponse,
   SearchAPIResponse,
   SearchOptions,
-  SearchPayload,
+  SearchV1Payload,
+  SearchV2Options,
+  SearchV2APIResponse,
+  SearchV2Payload,
+  SearchMessageSort,
   SendFileAPIResponse,
   StreamChatOptions,
   TestPushDataInput,
@@ -1671,7 +1675,7 @@ export class StreamChat<
     options: SearchOptions = {},
   ) {
     // Return a list of channels
-    const payload: SearchPayload<
+    const payload: SearchV1Payload<
       AttachmentType,
       ChannelType,
       CommandType,
@@ -1703,6 +1707,69 @@ export class StreamChat<
         UserType
       >
     >(this.baseURL + '/search', {
+      payload,
+    });
+  }
+
+  /**
+   * search v2 - Query messages
+   *
+   * @param {ChannelFilters<ChannelType, CommandType, UserType>} filterConditions MongoDB style filter conditions
+   * @param {MessageFilters<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType> | string} query search query or object MongoDB style filters
+   * @param {SearchV2Options} [options] Option object, {user_id: 'tommaso'}
+   *
+   * @return {Promise<SearchV2APIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} search messages response
+   */
+  async searchv2(
+    filterConditions: ChannelFilters<ChannelType, CommandType, UserType>,
+    query:
+      | string
+      | MessageFilters<
+          AttachmentType,
+          ChannelType,
+          CommandType,
+          MessageType,
+          ReactionType,
+          UserType
+        >,
+    sort: SearchMessageSort = [],
+    options: SearchV2Options = {},
+  ) {
+    // Return a list of channels
+    const payload: SearchV2Payload<
+      AttachmentType,
+      ChannelType,
+      CommandType,
+      MessageType,
+      ReactionType,
+      UserType
+    > = {
+      filter_conditions: filterConditions,
+      ...options,
+    };
+    if (typeof query === 'string') {
+      payload.query = query;
+    } else if (typeof query === 'object') {
+      payload.message_filter_conditions = query;
+    } else {
+      throw Error(`Invalid type ${typeof query} for query parameter`);
+    }
+
+    payload.sort = normalizeQuerySort(sort);
+
+    // Make sure we wait for the connect promise if there is a pending one
+    await this.setUserPromise;
+
+    return await this.get<
+      SearchV2APIResponse<
+        AttachmentType,
+        ChannelType,
+        CommandType,
+        MessageType,
+        ReactionType,
+        UserType
+      >
+    >(this.baseURL + '/search/v2', {
       payload,
     });
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1772,7 +1772,7 @@ export class StreamChat<
         >,
     options: SearchOptions = {},
   ) {
-    const { sort, ...options_without_sort } = { ...options };
+    const { sort: sort_value, ...options_without_sort } = { ...options };
     const payload: SearchPayload<
       AttachmentType,
       ChannelType,
@@ -1791,8 +1791,8 @@ export class StreamChat<
     } else {
       throw Error(`Invalid type ${typeof query} for query parameter`);
     }
-    if (sort) {
-      payload.sort = normalizeQuerySort(sort);
+    if (sort_value) {
+      payload.sort = normalizeQuerySort(sort_value);
     }
 
     // Make sure we wait for the connect promise if there is a pending one

--- a/src/client.ts
+++ b/src/client.ts
@@ -1780,10 +1780,9 @@ export class StreamChat<
         >,
     options: SearchOptions<MessageType> = {},
   ) {
-    if ('offset' in options && ('sort' in options || 'next' in options)) {
+    if (options.offset && (options.sort || options.next)) {
       throw Error(`Cannot specify offset with sort or next parameters`);
     }
-    const { sort: sortValue, ...optionsWithoutSort } = { ...options };
     const payload: SearchPayload<
       AttachmentType,
       ChannelType,
@@ -1793,7 +1792,8 @@ export class StreamChat<
       UserType
     > = {
       filter_conditions: filterConditions,
-      ...optionsWithoutSort,
+      ...options,
+      sort: options.sort ? normalizeQuerySort<SearchMessageSort<MessageType>>(options.sort) : undefined,
     };
     if (typeof query === 'string') {
       payload.query = query;
@@ -1801,9 +1801,6 @@ export class StreamChat<
       payload.message_filter_conditions = query;
     } else {
       throw Error(`Invalid type ${typeof query} for query parameter`);
-    }
-    if (sortValue) {
-      payload.sort = normalizeQuerySort<SearchMessageSort<MessageType>>(sortValue);
     }
 
     // Make sure we wait for the connect promise if there is a pending one

--- a/src/client.ts
+++ b/src/client.ts
@@ -102,7 +102,7 @@ import {
   UserOptions,
   UserResponse,
   UserSort,
-  SearchMessageSort,
+  SearchMessageSortBase,
 } from './types';
 
 function isString(x: unknown): x is string {
@@ -1793,7 +1793,9 @@ export class StreamChat<
     > = {
       filter_conditions: filterConditions,
       ...options,
-      sort: options.sort ? normalizeQuerySort<SearchMessageSort<MessageType>>(options.sort) : undefined,
+      sort: options.sort
+        ? normalizeQuerySort<SearchMessageSortBase<MessageType>>(options.sort)
+        : undefined,
     };
     if (typeof query === 'string') {
       payload.query = query;

--- a/src/client.ts
+++ b/src/client.ts
@@ -79,13 +79,9 @@ import {
   PermissionAPIResponse,
   PermissionsAPIResponse,
   ReactionResponse,
-  SearchAPIResponse,
   SearchOptions,
-  SearchV1Payload,
-  SearchV2Options,
-  SearchV2APIResponse,
-  SearchV2Payload,
-  SearchMessageSort,
+  SearchPayload,
+  SearchAPIResponse,
   SendFileAPIResponse,
   StreamChatOptions,
   TestPushDataInput,
@@ -1759,8 +1755,8 @@ export class StreamChat<
         >,
     options: SearchOptions = {},
   ) {
-    // Return a list of channels
-    const payload: SearchV1Payload<
+    const { sort, ...options_without_sort } = { ...options };
+    const payload: SearchPayload<
       AttachmentType,
       ChannelType,
       CommandType,
@@ -1769,7 +1765,7 @@ export class StreamChat<
       UserType
     > = {
       filter_conditions: filterConditions,
-      ...options,
+      ...options_without_sort,
     };
     if (typeof query === 'string') {
       payload.query = query;
@@ -1777,6 +1773,9 @@ export class StreamChat<
       payload.message_filter_conditions = query;
     } else {
       throw Error(`Invalid type ${typeof query} for query parameter`);
+    }
+    if (sort) {
+      payload.sort = normalizeQuerySort(sort);
     }
 
     // Make sure we wait for the connect promise if there is a pending one
@@ -1792,69 +1791,6 @@ export class StreamChat<
         UserType
       >
     >(this.baseURL + '/search', {
-      payload,
-    });
-  }
-
-  /**
-   * search v2 - Query messages
-   *
-   * @param {ChannelFilters<ChannelType, CommandType, UserType>} filterConditions MongoDB style filter conditions
-   * @param {MessageFilters<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType> | string} query search query or object MongoDB style filters
-   * @param {SearchV2Options} [options] Option object, {user_id: 'tommaso'}
-   *
-   * @return {Promise<SearchV2APIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} search messages response
-   */
-  async searchv2(
-    filterConditions: ChannelFilters<ChannelType, CommandType, UserType>,
-    query:
-      | string
-      | MessageFilters<
-          AttachmentType,
-          ChannelType,
-          CommandType,
-          MessageType,
-          ReactionType,
-          UserType
-        >,
-    sort: SearchMessageSort = [],
-    options: SearchV2Options = {},
-  ) {
-    // Return a list of channels
-    const payload: SearchV2Payload<
-      AttachmentType,
-      ChannelType,
-      CommandType,
-      MessageType,
-      ReactionType,
-      UserType
-    > = {
-      filter_conditions: filterConditions,
-      ...options,
-    };
-    if (typeof query === 'string') {
-      payload.query = query;
-    } else if (typeof query === 'object') {
-      payload.message_filter_conditions = query;
-    } else {
-      throw Error(`Invalid type ${typeof query} for query parameter`);
-    }
-
-    payload.sort = normalizeQuerySort(sort);
-
-    // Make sure we wait for the connect promise if there is a pending one
-    await this.setUserPromise;
-
-    return await this.get<
-      SearchV2APIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this.baseURL + '/search/v2', {
       payload,
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1949,7 +1949,7 @@ export type SearchPayload<
   query?: string;
   sort?: Array<{
     direction: AscDesc;
-    field: Extract<keyof SearchMessageSortBase<MessageType>, string>;
+    field: keyof SearchMessageSortBase<MessageType>;
   }>;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -633,23 +633,6 @@ export type SearchAPIResponse<
       UserType
     >;
   }[];
-};
-
-export type SearchV2APIResponse<
-  AttachmentType = UnknownType,
-  ChannelType = UnknownType,
-  CommandType extends string = LiteralStringForUnion,
-  MessageType = UnknownType,
-  ReactionType = UnknownType,
-  UserType = UnknownType
-> = SearchAPIResponse<
-  AttachmentType,
-  ChannelType,
-  CommandType,
-  MessageType,
-  ReactionType,
-  UserType
-> & {
   next?: string;
   previous?: string;
   results_warning?: SearchWarning;
@@ -942,14 +925,17 @@ export type QueryMembersOptions = {
   user_id_lte?: string;
 };
 
-export type SearchOptions = {
+export type SearchOptions = LimitOffsetSearchOptions | NextSearchOptions;
+
+export type LimitOffsetSearchOptions = {
   limit?: number;
   offset?: number;
 };
 
-export type SearchV2Options = {
+export type NextSearchOptions = {
   limit?: number;
   next?: string;
+  sort?: SearchMessageSort;
 };
 
 export type StreamChatOptions = AxiosRequestConfig & {
@@ -1741,8 +1727,7 @@ export type EndpointName =
   | 'GetExportChannelsStatus'
   | 'CheckSQS'
   | 'GetRateLimits'
-  | 'MessageUpdatePartial'
-  | 'SearchV2';
+  | 'MessageUpdatePartial';
 
 export type ExportChannelRequest = {
   id: string;
@@ -1908,14 +1893,14 @@ export type Resource =
   | 'UpdateUser'
   | 'UploadAttachment';
 
-type BaseSearchPayload<
+export type SearchPayload<
   AttachmentType = UnknownType,
   ChannelType = UnknownType,
   CommandType extends string = LiteralStringForUnion,
   MessageType = UnknownType,
   ReactionType = UnknownType,
   UserType = UnknownType
-> = {
+> = Omit<SearchOptions, 'sort'> & {
   client_id?: string;
   connection_id?: string;
   filter_conditions?: ChannelFilters<ChannelType, CommandType, UserType>;
@@ -1928,45 +1913,11 @@ type BaseSearchPayload<
     UserType
   >;
   query?: string;
+  sort?: Array<{
+    direction: AscDesc;
+    field: string | number;
+  }>;
 };
-export type SearchV1Payload<
-  AttachmentType = UnknownType,
-  ChannelType = UnknownType,
-  CommandType extends string = LiteralStringForUnion,
-  MessageType = UnknownType,
-  ReactionType = UnknownType,
-  UserType = UnknownType
-> = BaseSearchPayload<
-  AttachmentType,
-  ChannelType,
-  CommandType,
-  MessageType,
-  ReactionType,
-  UserType
-> &
-  SearchOptions;
-
-export type SearchV2Payload<
-  AttachmentType = UnknownType,
-  ChannelType = UnknownType,
-  CommandType extends string = LiteralStringForUnion,
-  MessageType = UnknownType,
-  ReactionType = UnknownType,
-  UserType = UnknownType
-> = BaseSearchPayload<
-  AttachmentType,
-  ChannelType,
-  CommandType,
-  MessageType,
-  ReactionType,
-  UserType
-> &
-  SearchV2Options & {
-    sort?: Array<{
-      direction: AscDesc;
-      field: string | number;
-    }>;
-  };
 
 export type TestPushDataInput = {
   apnTemplate?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -944,8 +944,6 @@ export type QueryMembersOptions = {
   user_id_lte?: string;
 };
 
-export type SearchOptions = LimitOffsetSearchOptions | NextSearchOptions;
-
 export type LimitOffsetSearchOptions = {
   limit?: number;
   offset?: number;
@@ -956,6 +954,8 @@ export type NextSearchOptions = {
   next?: string;
   sort?: SearchMessageSort;
 };
+
+export type SearchOptions = LimitOffsetSearchOptions | NextSearchOptions;
 
 export type StreamChatOptions = AxiosRequestConfig & {
   /**
@@ -1426,18 +1426,24 @@ export type UserSort<UserType = UnknownType> =
 
 export type SearchRelevanceSort = { relevance?: AscDesc };
 
-export type SearchMessageSortBase =
+export type SearchMessageSortBase<MessageType = UnknownType> =
   | SearchRelevanceSort
-  | Sort<Message>
+  | Sort<MessageType>
   | { [field: string]: AscDesc };
 
-export type SearchMessageSort = SearchMessageSortBase | Array<SearchMessageSortBase>;
+export type SearchMessageSort<MessageType = UnknownType> =
+  | SearchMessageSortBase<MessageType>
+  | Array<SearchMessageSortBase<MessageType>>;
 
-export type QuerySort<ChannelType = UnknownType, UserType = UnknownType> =
+export type QuerySort<
+  ChannelType = UnknownType,
+  UserType = UnknownType,
+  MessageType = UnknownType
+> =
   | BannedUsersSort
   | ChannelSort<ChannelType>
-  | UserSort<UserType>
-  | SearchMessageSort;
+  | SearchMessageSort<MessageType>
+  | UserSort<UserType>;
 
 /**
  * Base Types

--- a/src/types.ts
+++ b/src/types.ts
@@ -944,18 +944,12 @@ export type QueryMembersOptions = {
   user_id_lte?: string;
 };
 
-export type LimitOffsetSearchOptions = {
-  limit?: number;
-  offset?: number;
-};
-
-export type NextSearchOptions = {
+export type SearchOptions<MessageType = UnknownType> = {
   limit?: number;
   next?: string;
-  sort?: SearchMessageSort;
+  offset?: number;
+  sort?: SearchMessageSort<MessageType>;
 };
-
-export type SearchOptions = LimitOffsetSearchOptions | NextSearchOptions;
 
 export type StreamChatOptions = AxiosRequestConfig & {
   /**
@@ -1424,12 +1418,21 @@ export type UserSort<UserType = UnknownType> =
   | Sort<UserResponse<UserType>>
   | Array<Sort<UserResponse<UserType>>>;
 
-export type SearchRelevanceSort = { relevance?: AscDesc };
-
-export type SearchMessageSortBase<MessageType = UnknownType> =
-  | SearchRelevanceSort
-  | Sort<MessageType>
-  | { [field: string]: AscDesc };
+export type SearchMessageSortBase<MessageType = UnknownType> = Sort<MessageType> & {
+  attachments?: AscDesc;
+  'attachments.type'?: AscDesc;
+  created_at?: AscDesc;
+  id?: AscDesc;
+  'mentioned_users.id'?: AscDesc;
+  parent_id?: AscDesc;
+  pinned?: AscDesc;
+  relevance?: AscDesc;
+  reply_count?: AscDesc;
+  text?: AscDesc;
+  type?: AscDesc;
+  updated_at?: AscDesc;
+  'user.id'?: AscDesc;
+};
 
 export type SearchMessageSort<MessageType = UnknownType> =
   | SearchMessageSortBase<MessageType>
@@ -1931,7 +1934,7 @@ export type SearchPayload<
   MessageType = UnknownType,
   ReactionType = UnknownType,
   UserType = UnknownType
-> = Omit<SearchOptions, 'sort'> & {
+> = Omit<SearchOptions<MessageType>, 'sort'> & {
   client_id?: string;
   connection_id?: string;
   filter_conditions?: ChannelFilters<ChannelType, CommandType, UserType>;
@@ -1946,7 +1949,7 @@ export type SearchPayload<
   query?: string;
   sort?: Array<{
     direction: AscDesc;
-    field: string | number;
+    field: Extract<keyof SearchMessageSortBase<MessageType>, string>;
   }>;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,6 +592,31 @@ export type SearchAPIResponse<
   }[];
 };
 
+export type SearchV2APIResponse<
+  AttachmentType = UnknownType,
+  ChannelType = UnknownType,
+  CommandType extends string = LiteralStringForUnion,
+  MessageType = UnknownType,
+  ReactionType = UnknownType,
+  UserType = UnknownType
+> = SearchAPIResponse<
+  AttachmentType,
+  ChannelType,
+  CommandType,
+  MessageType,
+  ReactionType,
+  UserType
+> & {
+  next?: string;
+  previous?: string;
+  results_warning?: SearchWarning;
+};
+
+export type SearchWarning = {
+  channel_search_cids: string[];
+  channel_search_count: number;
+  warning_description: string;
+};
 export type SendFileAPIResponse = APIResponse & { file: string };
 
 export type SendMessageAPIResponse<
@@ -870,6 +895,11 @@ export type QueryMembersOptions = {
 export type SearchOptions = {
   limit?: number;
   offset?: number;
+};
+
+export type SearchV2Options = {
+  limit?: number;
+  next?: string;
 };
 
 export type StreamChatOptions = AxiosRequestConfig & {
@@ -1309,10 +1339,20 @@ export type UserSort<UserType = UnknownType> =
   | Sort<UserResponse<UserType>>
   | Array<Sort<UserResponse<UserType>>>;
 
+export type SearchRelevanceSort = { relevance?: AscDesc };
+
+export type SearchMessageSortBase =
+  | SearchRelevanceSort
+  | Sort<Message>
+  | { [field: string]: AscDesc };
+
+export type SearchMessageSort = SearchMessageSortBase | Array<SearchMessageSortBase>;
+
 export type QuerySort<ChannelType = UnknownType, UserType = UnknownType> =
   | BannedUsersSort
   | ChannelSort<ChannelType>
-  | UserSort<UserType>;
+  | UserSort<UserType>
+  | SearchMessageSort;
 
 /**
  * Base Types
@@ -1620,7 +1660,8 @@ export type EndpointName =
   | 'ExportChannels'
   | 'GetExportChannelsStatus'
   | 'CheckSQS'
-  | 'GetRateLimits';
+  | 'GetRateLimits'
+  | 'SearchV2';
 
 export type ExportChannelRequest = {
   id: string;
@@ -1776,14 +1817,14 @@ export type Resource =
   | 'UpdateUser'
   | 'UploadAttachment';
 
-export type SearchPayload<
+type BaseSearchPayload<
   AttachmentType = UnknownType,
   ChannelType = UnknownType,
   CommandType extends string = LiteralStringForUnion,
   MessageType = UnknownType,
   ReactionType = UnknownType,
   UserType = UnknownType
-> = SearchOptions & {
+> = {
   client_id?: string;
   connection_id?: string;
   filter_conditions?: ChannelFilters<ChannelType, CommandType, UserType>;
@@ -1797,6 +1838,44 @@ export type SearchPayload<
   >;
   query?: string;
 };
+export type SearchV1Payload<
+  AttachmentType = UnknownType,
+  ChannelType = UnknownType,
+  CommandType extends string = LiteralStringForUnion,
+  MessageType = UnknownType,
+  ReactionType = UnknownType,
+  UserType = UnknownType
+> = BaseSearchPayload<
+  AttachmentType,
+  ChannelType,
+  CommandType,
+  MessageType,
+  ReactionType,
+  UserType
+> &
+  SearchOptions;
+
+export type SearchV2Payload<
+  AttachmentType = UnknownType,
+  ChannelType = UnknownType,
+  CommandType extends string = LiteralStringForUnion,
+  MessageType = UnknownType,
+  ReactionType = UnknownType,
+  UserType = UnknownType
+> = BaseSearchPayload<
+  AttachmentType,
+  ChannelType,
+  CommandType,
+  MessageType,
+  ReactionType,
+  UserType
+> &
+  SearchV2Options & {
+    sort?: Array<{
+      direction: AscDesc;
+      field: string | number;
+    }>;
+  };
 
 export type TestPushDataInput = {
   apnTemplate?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -102,7 +102,7 @@ export function normalizeQuerySort<T extends QuerySort>(sort: T) {
   const sortArr = Array.isArray(sort) ? sort : [sort];
   for (const item of sortArr) {
     const entries = (Object.entries(item) as unknown) as [
-      T extends (infer K)[] ? keyof K : keyof T,
+      T extends (infer K)[] ? Extract<keyof K, string> : Extract<keyof T, string>,
       AscDesc,
     ][];
     if (entries.length > 1) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,6 @@ import {
   AscDesc,
   LiteralStringForUnion,
   OwnUserResponse,
-  QuerySort,
   UnknownType,
   UserResponse,
 } from './types';
@@ -96,15 +95,13 @@ export function addFileToFormData(
 
   return data;
 }
-
-export function normalizeQuerySort<T extends QuerySort>(sort: T) {
-  const sortFields = [];
+export function normalizeQuerySort<T extends Record<string, AscDesc | undefined>>(
+  sort: T | T[],
+) {
+  const sortFields: Array<{ direction: AscDesc; field: keyof T }> = [];
   const sortArr = Array.isArray(sort) ? sort : [sort];
   for (const item of sortArr) {
-    const entries = (Object.entries(item) as unknown) as [
-      T extends (infer K)[] ? Extract<keyof K, string> : Extract<keyof T, string>,
-      AscDesc,
-    ][];
+    const entries = Object.entries(item) as [keyof T, AscDesc][];
     if (entries.length > 1) {
       console.warn(
         "client._buildSort() - multiple fields in a single sort object detected. Object's field order is not guaranteed",

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -425,3 +425,34 @@ describe('event subscription and unsubscription', () => {
 		expect(channel.listeners['all'].length).to.be.equal(0);
 	});
 });
+describe('Channel search', async () => {
+	const client = await getClientWithUser();
+	const channel = client.channel('messaging', uuidv4());
+
+	it('search with sorting by defined field', async () => {
+		client.get = (url, config) => {
+			expect(config.payload.sort).to.be.eql([
+				{ field: 'updated_at', direction: -1 },
+			]);
+		};
+		await channel.search('query', { sort: [{ updated_at: -1 }] });
+	});
+	it('search with sorting by custom field', async () => {
+		client.get = (url, config) => {
+			expect(config.payload.sort).to.be.eql([
+				{ field: 'custom_field', direction: -1 },
+			]);
+		};
+		await channel.search('query', { sort: [{ custom_field: -1 }] });
+	});
+	it('sorting and offset fails', async () => {
+		await expect(
+			channel.search('query', { offset: 1, sort: [{ custom_field: -1 }] }),
+		).to.be.rejectedWith(Error);
+	});
+	it('next and offset fails', async () => {
+		await expect(
+			channel.search('query', { offset: 1, next: 'next' }),
+		).to.be.rejectedWith(Error);
+	});
+});


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
Updates the `channel.search()` and `client.search()` endpoints to support pagination using a next value and sorting parameters. For example: 
```js
// get a page of sorted results
const page1 = await client.search(
{ cid: my_cid }, 
'search text', 
{ limit: 100, sort: [{ relevance: -1 }, { updated_at: 1 }, { my_custom_field: -1 }]  });

// Query the second page of results. The same sort order will be used as in your first query, so there's no need to include it
const page2 = await client.search(
{ cid: my_cid }, 
'search text', 
{ limit: 100, next: page1.next });

// Pagination backwards by using the returned `previous` value
const page1Again = await client.search(
{ cid: my_cid }, 
'search text', 
{ limit: 100, next: page2.previous });
```
## Changelog

-
