### PR TITLE
[CHAT-1851] Add `assignRoles` method to Channel

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -646,12 +646,12 @@ export class Channel<
   /**
    * addMembers - add members to the channel
    *
-   * @param {string[]} members An array of member identifiers
+   * @param {{user_id: string, channel_role?: Role}[]} members An array of members to add to the channel
    * @param {Message<AttachmentType, MessageType, UserType>} [message] Optional message object for channel members notification
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
    */
   async addMembers(
-    members: string[],
+    members: string[] | { user_id: string; channel_role?: Role }[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
     return await this._update({
@@ -680,12 +680,12 @@ export class Channel<
   /**
    * assignRoles - sets member roles in a channel
    *
-   * @param {[userID: string]: string} roles An object with role assignments
+   * @param {{channel_role: Role, user_id: string}[]} roles List of role assignments
    * @param {Message<AttachmentType, MessageType, UserType>} [message] Optional message object for channel members notification
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
    */
   async assignRoles(
-    roles: { [userID: string]: Role },
+    roles: { channel_role: Role; user_id: string }[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
     return await this._update({
@@ -697,12 +697,12 @@ export class Channel<
   /**
    * inviteMembers - invite members to the channel
    *
-   * @param {string[]} members An array of member identifiers
+   * @param {{user_id: string, channel_role?: Role}[]} members An array of members to invite to the channel
    * @param {Message<AttachmentType, MessageType, UserType>} [message] Optional message object for channel members notification
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
    */
   async inviteMembers(
-    members: string[],
+    members: { user_id: string; channel_role?: Role }[] | string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
     return await this._update({

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -509,22 +509,11 @@ export class Channel<
       delete channelData[key];
     });
 
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       message: updateMessage,
       data: channelData,
       ...options,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -624,21 +613,10 @@ export class Channel<
       UserType
     > = {},
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       accept_invite: true,
       ...options,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -658,21 +636,10 @@ export class Channel<
       UserType
     > = {},
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       reject_invite: true,
       ...options,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -686,21 +653,10 @@ export class Channel<
     members: string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       add_members: members,
       message,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -714,21 +670,10 @@ export class Channel<
     members: string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       add_moderators: members,
       message,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -742,21 +687,10 @@ export class Channel<
     roles: { [userID: string]: string },
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       set_roles: roles,
       message,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -770,21 +704,10 @@ export class Channel<
     members: string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       invites: members,
       message,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -798,21 +721,10 @@ export class Channel<
     members: string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
-    const data = await this.getClient().post<
-      UpdateChannelAPIResponse<
-        AttachmentType,
-        ChannelType,
-        CommandType,
-        MessageType,
-        ReactionType,
-        UserType
-      >
-    >(this._channelURL(), {
+    return await this._update({
       remove_members: members,
       message,
     });
-    this.data = data.channel;
-    return data;
   }
 
   /**
@@ -826,6 +738,18 @@ export class Channel<
     members: string[],
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
+    return await this._update({
+      demote_moderators: members,
+      message,
+    });
+  }
+
+  /**
+   * _update - executes channel update request
+   * @param payload Object Update Channel payload
+   * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
+   */
+  async _update(payload: Object) {
     const data = await this.getClient().post<
       UpdateChannelAPIResponse<
         AttachmentType,
@@ -835,10 +759,7 @@ export class Channel<
         ReactionType,
         UserType
       >
-    >(this._channelURL(), {
-      demote_moderators: members,
-      message,
-    });
+    >(this._channelURL(), payload);
     this.data = data.channel;
     return data;
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -732,6 +732,34 @@ export class Channel<
   }
 
   /**
+   * setRoles - set member roles in a channel
+   *
+   * @param {[userID: string]: string} roles An object with role assignments
+   * @param {Message<AttachmentType, MessageType, UserType>} [message] Optional message object for channel members notification
+   * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
+   */
+  async setRoles(
+    roles: { [userID: string]: string },
+    message?: Message<AttachmentType, MessageType, UserType>,
+  ) {
+    const data = await this.getClient().post<
+      UpdateChannelAPIResponse<
+        AttachmentType,
+        ChannelType,
+        CommandType,
+        MessageType,
+        ReactionType,
+        UserType
+      >
+    >(this._channelURL(), {
+      set_roles: roles,
+      message,
+    });
+    this.data = data.channel;
+    return data;
+  }
+
+  /**
    * inviteMembers - invite members to the channel
    *
    * @param {string[]} members An array of member identifiers

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -678,18 +678,18 @@ export class Channel<
   }
 
   /**
-   * setRoles - set member roles in a channel
+   * assignRoles - sets member roles in a channel
    *
    * @param {[userID: string]: string} roles An object with role assignments
    * @param {Message<AttachmentType, MessageType, UserType>} [message] Optional message object for channel members notification
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
    */
-  async setRoles(
+  async assignRoles(
     roles: { [userID: string]: Role },
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
     return await this._update({
-      set_roles: roles,
+      assign_roles: roles,
       message,
     });
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -42,6 +42,7 @@ import {
   UserResponse,
   UserSort,
 } from './types';
+import { Role } from './permissions';
 
 /**
  * Channel - The Channel class manages it's own state.
@@ -684,7 +685,7 @@ export class Channel<
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
    */
   async setRoles(
-    roles: { [userID: string]: string },
+    roles: { [userID: string]: Role },
     message?: Message<AttachmentType, MessageType, UserType>,
   ) {
     return await this._update({
@@ -748,6 +749,7 @@ export class Channel<
    * _update - executes channel update request
    * @param payload Object Update Channel payload
    * @return {Promise<UpdateChannelAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} The server response
+   * TODO: introduce new type instead of Object in the next major update
    */
   async _update(payload: Object) {
     const data = await this.getClient().post<

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -56,6 +56,15 @@ export const DenyAll = new Permission(
   Deny,
 );
 
+export type Role =
+  | 'admin'
+  | 'user'
+  | 'guest'
+  | 'anonymous'
+  | 'channel_member'
+  | 'channel_moderator'
+  | string;
+
 export const BuiltinRoles = {
   Admin: 'admin',
   Anonymous: 'anonymous',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1532,6 +1532,7 @@ export type ChannelData<ChannelType = UnknownType> = ChannelType & {
 
 export type ChannelMembership<UserType = UnknownType> = {
   banned?: boolean;
+  channel_role?: string;
   created_at?: string;
   is_moderator?: boolean;
   role?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig } from 'axios';
+import { Role } from './permissions';
 
 /**
  * Utility Types
@@ -237,7 +238,7 @@ export type ChannelMemberAPIResponse<UserType = UnknownType> = APIResponse & {
 
 export type ChannelMemberResponse<UserType = UnknownType> = {
   banned?: boolean;
-  channel_role?: string;
+  channel_role?: Role;
   created_at?: string;
   invite_accepted_at?: string;
   invite_rejected_at?: string;
@@ -838,6 +839,7 @@ export type CustomPermissionOptions = {
   same_team?: boolean;
 };
 
+// TODO: rename to UpdateChannelOptions in the next major update and use it in channel._update and/or channel.update
 export type InviteOptions<
   AttachmentType = UnknownType,
   ChannelType = UnknownType,
@@ -956,6 +958,7 @@ export type UnBanUserOptions = {
   type?: string;
 };
 
+// TODO: rename to UpdateChannelTypeOptions in the next major update
 export type UpdateChannelOptions<
   CommandType extends string = LiteralStringForUnion
 > = Omit<CreateChannelOptions<CommandType>, 'name'> & {
@@ -1532,7 +1535,7 @@ export type ChannelData<ChannelType = UnknownType> = ChannelType & {
 
 export type ChannelMembership<UserType = UnknownType> = {
   banned?: boolean;
-  channel_role?: string;
+  channel_role?: Role;
   created_at?: string;
   is_moderator?: boolean;
   role?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -237,6 +237,7 @@ export type ChannelMemberAPIResponse<UserType = UnknownType> = APIResponse & {
 
 export type ChannelMemberResponse<UserType = UnknownType> = {
   banned?: boolean;
+  channel_role?: string;
   created_at?: string;
   invite_accepted_at?: string;
   invite_rejected_at?: string;


### PR DESCRIPTION
This PR adds support for new `setRoles` operation in `UpdateChannel` API.

Also, did some refactoring around repetitive UpdateChannel SDK calls

UPDATE: renamed `setRoles` to `assignRoles` after discussion with the Product Team
UPDATE 2: switched format of `assignRoles` to object-based