### PR TITLE
Add retry backoff on client API calls

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,7 @@ import {
   normalizeQuerySort,
   randomId,
   sleep,
+  retryInterval,
 } from './utils';
 
 import {
@@ -1119,7 +1120,7 @@ export class StreamChat<
           !this.tokenManager.isStatic()
         ) {
           if (this.consecutiveFailures > 1) {
-            await sleep(this._retryInterval());
+            await sleep(retryInterval(this.consecutiveFailures));
           }
           this.tokenManager.loadToken();
           return await this.doAxiosRequest<T>(type, url, data, options);
@@ -1129,13 +1130,6 @@ export class StreamChat<
         throw e;
       }
     }
-  };
-
-  _retryInterval = () => {
-    // try to reconnect in 0.25-25 seconds (random to spread out the load from failures)
-    const max = Math.min(500 + this.consecutiveFailures * 2000, 25000);
-    const min = Math.min(Math.max(250, (this.consecutiveFailures - 1) * 2000), 25000);
-    return Math.floor(Math.random() * (max - min) + min);
   };
 
   get<T>(url: string, params?: AxiosRequestConfig['params']) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1118,7 +1118,9 @@ export class StreamChat<
           e.response.data.code === chatCodes.TOKEN_EXPIRED &&
           !this.tokenManager.isStatic()
         ) {
-          await sleep(this._retryInterval());
+          if (this.consecutiveFailures > 1) {
+            await sleep(this._retryInterval());
+          }
           this.tokenManager.loadToken();
           return await this.doAxiosRequest<T>(type, url, data, options);
         }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -695,18 +695,6 @@ export class StableWSConnection<
   }
 
   /**
-   * _retryInterval - A retry interval which increases after consecutive failures
-   *
-   * @return {number} Duration to wait in milliseconds
-   */
-  _retryInterval = () => {
-    // try to reconnect in 0.25-25 seconds (random to spread out the load from failures)
-    const max = Math.min(500 + this.consecutiveFailures * 2000, 25000);
-    const min = Math.min(Math.max(250, (this.consecutiveFailures - 1) * 2000), 25000);
-    return Math.floor(Math.random() * (max - min) + min);
-  };
-
-  /**
    * _setupPromise - sets up the this.connectOpen promise
    */
   _setupConnectionPromise = () => {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import { chatCodes, sleep } from './utils';
+import { chatCodes, sleep, retryInterval } from './utils';
 import { TokenManager } from './token_manager';
 import {
   ConnectAPIResponse,
@@ -356,7 +356,7 @@ export class StableWSConnection<
     // also reconnect if the health check cycle fails
     let interval = options.interval;
     if (!interval) {
-      interval = this._retryInterval();
+      interval = retryInterval(this.consecutiveFailures);
     }
     // reconnect, or try again after a little while...
     await sleep(interval);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,6 +117,18 @@ export function normalizeQuerySort<T extends QuerySort>(sort: T) {
   return sortFields;
 }
 
+/**
+ * retryInterval - A retry interval which increases acc to number of failures
+ *
+ * @return {number} Duration to wait in milliseconds
+ */
+export function retryInterval(numberOfFailures: number) {
+  // try to reconnect in 0.25-25 seconds (random to spread out the load from failures)
+  const max = Math.min(500 + numberOfFailures * 2000, 25000);
+  const min = Math.min(Math.max(250, (numberOfFailures - 1) * 2000), 25000);
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
 /** adopted from https://github.com/ai/nanoid/blob/master/non-secure/index.js */
 const alphabet = 'ModuleSymbhasOwnPr0123456789ABCDEFGHNRVfgctiUvzKqYTJkLxpZXIjQW';
 export function randomId() {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
Adding a retry interval between two consecutive API calls, the logic is same as in case of web-socket connection retrial added the same kind of behaviour on API calls as well.

## Changelog

