### PR TITLE
Add retry backoff on client API calls

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'isomorphic-ws';
-import { chatCodes, sleep } from './utils';
+import { chatCodes, sleep, retryInterval } from './utils';
 import { TokenManager } from './token_manager';
 import {
   ConnectAPIResponse,
@@ -356,7 +356,7 @@ export class StableWSConnection<
     // also reconnect if the health check cycle fails
     let interval = options.interval;
     if (!interval) {
-      interval = this._retryInterval();
+      interval = retryInterval(this.consecutiveFailures);
     }
     // reconnect, or try again after a little while...
     await sleep(interval);
@@ -693,18 +693,6 @@ export class StableWSConnection<
       // we don't care
     }
   }
-
-  /**
-   * _retryInterval - A retry interval which increases after consecutive failures
-   *
-   * @return {number} Duration to wait in milliseconds
-   */
-  _retryInterval = () => {
-    // try to reconnect in 0.25-25 seconds (random to spread out the load from failures)
-    const max = Math.min(500 + this.consecutiveFailures * 2000, 25000);
-    const min = Math.min(Math.max(250, (this.consecutiveFailures - 1) * 2000), 25000);
-    return Math.floor(Math.random() * (max - min) + min);
-  };
 
   /**
    * _setupPromise - sets up the this.connectOpen promise

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,6 +117,18 @@ export function normalizeQuerySort<T extends QuerySort>(sort: T) {
   return sortFields;
 }
 
+/**
+ * retryInterval - A retry interval which increases acc to number of failures
+ *
+ * @return {number} Duration to wait in milliseconds
+ */
+export function retryInterval(numberOfFailures: number) {
+  // try to reconnect in 0.25-25 seconds (random to spread out the load from failures)
+  const max = Math.min(500 + numberOfFailures * 2000, 25000);
+  const min = Math.min(Math.max(250, (numberOfFailures - 1) * 2000), 25000);
+  return Math.floor(Math.random() * (max - min) + min);
+}
+
 /** adopted from https://github.com/ai/nanoid/blob/master/non-secure/index.js */
 const alphabet = 'ModuleSymbhasOwnPr0123456789ABCDEFGHNRVfgctiUvzKqYTJkLxpZXIjQW';
 export function randomId() {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
Adding a retry interval between two consecutive API calls, the logic is same as in case of web-socket connection retrial added the same kind of behaviour on API calls as well.

## Changelog

