### PR TITLE
CHAT-1828: clean pinned messages after channel truncation

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -768,5 +768,6 @@ export class ChannelState<
 
   clearMessages() {
     this.messages = [];
+    this.pinnedMessages = [];
   }
 }


### PR DESCRIPTION
This is the client-side fix to retained pinned messages after a channel is truncated