### PR TITLE
Fix tests for Permission related APIs

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1827,7 +1827,7 @@ export type PermissionAPIObject = {
   action?: string;
   custom?: boolean;
   description?: string;
-  id?: string
+  id?: string;
   name?: string;
   owner?: boolean;
   same_team?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1827,6 +1827,7 @@ export type PermissionAPIObject = {
   action?: string;
   custom?: boolean;
   description?: string;
+  id?: string
   name?: string;
   owner?: boolean;
   same_team?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -823,6 +823,7 @@ export type CreateChannelOptions<CommandType extends string = LiteralStringForUn
   connect_events?: boolean;
   connection_id?: string;
   custom_events?: boolean;
+  grants?: Record<string, string[]>;
   max_message_length?: number;
   message_retention?: string;
   mutes?: boolean;

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -49,8 +49,9 @@ async function createBlockList() {
 async function createPermission() {
 	const authClient = await utils.getTestClient(true);
 	return await authClient.createPermission({
+		id: 'test-create-permission',
 		name: 'TestCreatePermission',
-		resource: 'ReadChannel',
+		action: 'ReadChannel',
 	});
 }
 
@@ -77,10 +78,11 @@ async function deleteBlockList() {
 async function deletePermission() {
 	const authClient = await utils.getTestClient(true);
 	await authClient.createPermission({
+		id: 'test-delete-permission',
 		name: 'TestDeletePermission',
-		resource: 'DeleteChannel',
+		action: 'ReadChannel',
 	});
-	return await authClient.deletePermission('TestDeletePermission');
+	return await authClient.deletePermission('test-delete-permission');
 }
 
 async function deleteRole() {

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -182,10 +182,11 @@ async function getBlockList() {
 async function getPermission() {
 	const authClient = await utils.getTestClient(true);
 	await authClient.createPermission({
+		id: 'test-get-permission',
 		name: 'TestGetPermission',
-		resource: 'ReadChannel',
+		action: 'ReadChannel',
 	});
-	return await authClient.getPermission('TestGetPermission');
+	return await authClient.getPermission('test-get-permission');
 }
 
 async function listBlockLists() {
@@ -201,8 +202,9 @@ async function listBlockLists() {
 async function listPermissions() {
 	const authClient = await utils.getTestClient(true);
 	await authClient.createPermission({
+		id: 'test-list-permissions',
 		name: 'TestListPermissions',
-		resource: 'ReadChannel',
+		action: 'ReadChannel',
 	});
 	return await authClient.listPermissions();
 }
@@ -351,11 +353,13 @@ async function updateBlockList() {
 async function updatePermission() {
 	const authClient = await utils.getTestClient(true);
 	await authClient.createPermission({
+		id: 'test-update-permission',
 		name: 'TestUpdatePermission',
-		resource: 'ReadChannel',
+		action: 'ReadChannel',
 	});
-	return await authClient.updatePermission('TestUpdatePermission', {
-		resource: 'DeleteChannel',
+	return await authClient.updatePermission('test-update-permission', {
+		name: 'TestUpdatePermissionUpdated',
+		action: 'DeleteChannel',
 	});
 }
 


### PR DESCRIPTION
This PR updates type tests for permissions and also adds some missing fields to permission types