### PR TITLE
Allow results_warning to be null

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -651,7 +651,7 @@ export type SearchAPIResponse<
   }[];
   next?: string;
   previous?: string;
-  results_warning?: SearchWarning;
+  results_warning?: SearchWarning | null;
 };
 
 export type SearchWarning = {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
Fix typing for results_warning, which can be null

## Changelog

-
