### PR TITLE
Remove target user id from payload on sendUserCustomEvent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2944,7 +2944,6 @@ export class StreamChat<
    */
   async sendUserCustomEvent(targetUserID: string, event: UserCustomEvent) {
     return await this.post<APIResponse>(`${this.baseURL}/users/${targetUserID}/event`, {
-      target_user_id: targetUserID,
       event,
     });
   }


### PR DESCRIPTION
We already have the information in the route, we can remove it from the payload.