### PR TITLE
fix: fixing connectUser error handling

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -346,6 +346,17 @@ export class StableWSConnection<
     this.logger('info', 'connection:_reconnect() - Initiating the reconnect', {
       tags: ['connection'],
     });
+    if (!this.isFirstConnectSuccesful) {
+      this.logger(
+        'info',
+        'connection:_reconnect() - Abort (0) since first call to "client.connectUser" never succeded',
+        {
+          tags: ['connection'],
+        },
+      );
+      return;
+    }
+
     // only allow 1 connection at the time
     if (this.isConnecting || this.isHealthy) {
       this.logger(
@@ -560,10 +571,7 @@ export class StableWSConnection<
         },
       );
 
-      // reconnect if its an abnormal failure
-      if (this.isFirstConnectSuccesful) {
-        this._reconnect();
-      }
+      this._reconnect();
     }
   };
 
@@ -580,10 +588,7 @@ export class StableWSConnection<
       event,
     });
 
-    // Don't call reconnect if the first connect call results into error.
-    if (this.isFirstConnectSuccesful) {
-      this._reconnect();
-    }
+    this._reconnect();
   };
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -561,9 +561,7 @@ export class StableWSConnection<
       );
 
       // reconnect if its an abnormal failure
-      if (this.isFirstConnectSuccesful) {
-        this._reconnect();
-      }
+      this._reconnect();
     }
   };
 
@@ -580,10 +578,7 @@ export class StableWSConnection<
       event,
     });
 
-    // Don't call reconnect if the first connect call results into error.
-    if (this.isFirstConnectSuccesful) {
-      this._reconnect();
-    }
+    this._reconnect();
   };
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -561,7 +561,9 @@ export class StableWSConnection<
       );
 
       // reconnect if its an abnormal failure
-      this._reconnect();
+      if (this.isFirstConnectSuccesful) {
+        this._reconnect();
+      }
     }
   };
 
@@ -578,7 +580,10 @@ export class StableWSConnection<
       event,
     });
 
-    this._reconnect();
+    // Don't call reconnect if the first connect call results into error.
+    if (this.isFirstConnectSuccesful) {
+      this._reconnect();
+    }
   };
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -85,7 +85,7 @@ export class StableWSConnection<
   pingInterval: number;
   healthCheckTimeoutRef?: NodeJS.Timeout;
   isConnecting: boolean;
-  isFirstConnectSuccesful: boolean;
+  isFirstConnectSuccessful: boolean;
   isHealthy: boolean;
   isResolved?: boolean;
   lastEvent: Date | null;
@@ -133,7 +133,7 @@ export class StableWSConnection<
     this.totalFailures = 0;
     /** We only make 1 attempt to reconnect at the same time.. */
     this.isConnecting = false;
-    this.isFirstConnectSuccesful = false;
+    this.isFirstConnectSuccessful = false;
     /** Boolean that indicates if we have a working connection to the server */
     this.isHealthy = false;
     /** Callback when the connection fails and recovers */
@@ -166,7 +166,7 @@ export class StableWSConnection<
     try {
       healthCheck = await this._connect();
       this.isConnecting = false;
-      this.isFirstConnectSuccesful = true;
+      this.isFirstConnectSuccessful = true;
       this.consecutiveFailures = 0;
 
       this.logger(
@@ -346,7 +346,7 @@ export class StableWSConnection<
     this.logger('info', 'connection:_reconnect() - Initiating the reconnect', {
       tags: ['connection'],
     });
-    if (!this.isFirstConnectSuccesful) {
+    if (!this.isFirstConnectSuccessful) {
       this.logger(
         'info',
         'connection:_reconnect() - Abort (0) since first call to "client.connectUser" never succeded',
@@ -560,7 +560,7 @@ export class StableWSConnection<
       this.totalFailures += 1;
       this._setHealth(false);
 
-      this.rejectPromise?.(this._errorFromWSEvent(event, this.isFirstConnectSuccesful));
+      this.rejectPromise?.(this._errorFromWSEvent(event, this.isFirstConnectSuccessful));
 
       this.logger(
         'info',
@@ -582,7 +582,7 @@ export class StableWSConnection<
     this.totalFailures += 1;
     this._setHealth(false);
 
-    this.rejectPromise?.(this._errorFromWSEvent(event, this.isFirstConnectSuccesful));
+    this.rejectPromise?.(this._errorFromWSEvent(event, this.isFirstConnectSuccessful));
     this.logger('info', `connection:onerror() - WS connection resulted into error`, {
       tags: ['connection'],
       event,


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- With our existing logic, in case of failure in call to `/connect` api (case of request never reached our server for example), we never threw an error. So `await client.connectUser()` would falsely get resolved. If also affected calls to `client.queryChannels`, `client.queryUsers` where we rely on result of promise returned by `connectUser` function. This issue has been fixed by throwing appropriate error.
- Disallow reconnect requests if first call to `connectUser` was never succesful. Basically when `client.connectUser` fails, the failures should be handled on app level instead of js client. This brings consistency with other LLCs (flutter, android) of Stream. Also if the call to connectUser was failed due to invalid config (apiKey, token etc), there is no point in making reconnect calls.

