### PR TITLE
Clear text in export

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3057,7 +3057,10 @@ export class StreamChat<
     return this.delete<APIResponse>(`${this.baseURL}/blocklists/${name}`);
   }
 
-  exportChannels(request: Array<ExportChannelRequest>, options?: ExportChannelOptions) {
+  exportChannels(
+    request: Array<ExportChannelRequest>,
+    options: ExportChannelOptions = {},
+  ) {
     const payload = {
       channels: request,
       ...options,

--- a/src/client.ts
+++ b/src/client.ts
@@ -56,6 +56,7 @@ import {
   EndpointName,
   Event,
   EventHandler,
+  ExportChannelOptions,
   ExportChannelRequest,
   ExportChannelResponse,
   ExportChannelStatusResponse,
@@ -3056,9 +3057,10 @@ export class StreamChat<
     return this.delete<APIResponse>(`${this.baseURL}/blocklists/${name}`);
   }
 
-  exportChannels(request: Array<ExportChannelRequest>) {
+  exportChannels(request: Array<ExportChannelRequest>, options?: ExportChannelOptions) {
     const payload = {
       channels: request,
+      ...options,
     };
     return this.post<APIResponse & ExportChannelResponse>(
       `${this.baseURL}/export_channels`,
@@ -3066,8 +3068,8 @@ export class StreamChat<
     );
   }
 
-  exportChannel(request: ExportChannelRequest) {
-    return this.exportChannels([request]);
+  exportChannel(request: ExportChannelRequest, options?: ExportChannelOptions) {
+    return this.exportChannels([request], options);
   }
 
   getExportChannelStatus(id: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1798,7 +1798,7 @@ export type ExportChannelRequest = {
 };
 
 export type ExportChannelOptions = {
-  clear_delete_message_text?: boolean;
+  clear_deleted_message_text?: boolean;
 };
 
 export type Field = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1797,6 +1797,10 @@ export type ExportChannelRequest = {
   messages_until?: Date;
 };
 
+export type ExportChannelOptions = {
+  clear_delete_message_text?: boolean;
+};
+
 export type Field = {
   short?: boolean;
   title?: string;


### PR DESCRIPTION
optional flags for export channels: this one requests delete message text to be overwritten (by default).