### PR TITLE
[CHAT-2260] Change Permission.Condition type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -875,7 +875,7 @@ export type CustomPermissionOptions = {
   action: string;
   id: string;
   name: string;
-  condition?: string;
+  condition?: object;
   description?: string;
   owner?: boolean;
   same_team?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -873,9 +873,9 @@ export type CreateCommandOptions<CommandType extends string = LiteralStringForUn
 
 export type CustomPermissionOptions = {
   action: string;
+  condition: object;
   id: string;
   name: string;
-  condition?: object;
   description?: string;
   owner?: boolean;
   same_team?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1907,6 +1907,7 @@ export type PartialMessageUpdate<MessageType = UnknownType> = {
 
 export type PermissionAPIObject = {
   action?: string;
+  condition?: object
   custom?: boolean;
   description?: string;
   id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1907,7 +1907,7 @@ export type PartialMessageUpdate<MessageType = UnknownType> = {
 
 export type PermissionAPIObject = {
   action?: string;
-  condition?: object
+  condition?: object;
   custom?: boolean;
   description?: string;
   id?: string;

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -366,10 +366,10 @@ async function updatePermission() {
 module.exports = {
 	banUsers,
 	createBlockList,
-	createPermission,
+	// createPermission,
 	createRole,
 	deleteBlockList,
-	deletePermission,
+	// deletePermission,
 	deleteRole,
 	flagMessage,
 	flagUser,
@@ -384,7 +384,7 @@ module.exports = {
 	unflagUser,
 	unmuteUser,
 	updateBlockList,
-	updatePermission,
+	// updatePermission,
 	shadowBan,
 	removeShadowBan,
 };

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -1,5 +1,6 @@
 const { v4: uuidv4 } = require('uuid');
 const utils = require('../utils');
+const { sleep } = require('../utils');
 
 async function cleanupBucketList(client, name) {
 	try {
@@ -92,6 +93,7 @@ async function deletePermission() {
 			},
 		},
 	});
+	await sleep(2500);
 	return await authClient.deletePermission('test-delete-permission');
 }
 
@@ -99,6 +101,7 @@ async function deleteRole() {
 	const name = uuidv4();
 	const authClient = await utils.getTestClient(true);
 	await authClient.createRole(name);
+	await sleep(2500);
 	return await authClient.deleteRole(name);
 }
 
@@ -201,6 +204,7 @@ async function getPermission() {
 			},
 		},
 	});
+	await sleep(2500);
 	return await authClient.getPermission('test-get-permission');
 }
 
@@ -216,23 +220,12 @@ async function listBlockLists() {
 
 async function listPermissions() {
 	const authClient = await utils.getTestClient(true);
-	await authClient.createPermission({
-		id: 'test-list-permissions',
-		name: 'TestListPermissions',
-		action: 'ReadChannel',
-		condition: {
-			'$subject.magic_custom_field': {
-				$eq: 'magic_custom_value',
-			},
-		},
-	});
 	return await authClient.listPermissions();
 }
 
 async function listRoles() {
 	const authClient = await utils.getTestClient(true);
-	await authClient.createRole('TestListRole');
-	authClient.listRoles();
+	await authClient.listRoles();
 }
 
 async function muteUser() {
@@ -382,6 +375,7 @@ async function updatePermission() {
 			},
 		},
 	});
+	await sleep(2500);
 	return await authClient.updatePermission('test-update-permission', {
 		name: 'TestUpdatePermissionUpdated',
 		action: 'DeleteChannel',

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -384,10 +384,10 @@ async function updatePermission() {
 module.exports = {
 	banUsers,
 	createBlockList,
-	// createPermission,
+	createPermission,
 	createRole,
 	deleteBlockList,
-	// deletePermission,
+	deletePermission,
 	deleteRole,
 	flagMessage,
 	flagUser,
@@ -402,7 +402,7 @@ module.exports = {
 	unflagUser,
 	unmuteUser,
 	updateBlockList,
-	// updatePermission,
+	updatePermission,
 	shadowBan,
 	removeShadowBan,
 };

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -195,6 +195,11 @@ async function getPermission() {
 		id: 'test-get-permission',
 		name: 'TestGetPermission',
 		action: 'ReadChannel',
+		condition: {
+			'$subject.magic_custom_field': {
+				$eq: 'magic_custom_value',
+			},
+		},
 	});
 	return await authClient.getPermission('test-get-permission');
 }
@@ -215,6 +220,11 @@ async function listPermissions() {
 		id: 'test-list-permissions',
 		name: 'TestListPermissions',
 		action: 'ReadChannel',
+		condition: {
+			'$subject.magic_custom_field': {
+				$eq: 'magic_custom_value',
+			},
+		},
 	});
 	return await authClient.listPermissions();
 }

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -52,6 +52,11 @@ async function createPermission() {
 		id: 'test-create-permission',
 		name: 'TestCreatePermission',
 		action: 'ReadChannel',
+		condition: {
+			"$subject.magic_custom_field": {
+				"$eq": "magic_custom_value",
+			}
+		},
 	});
 }
 
@@ -81,6 +86,11 @@ async function deletePermission() {
 		id: 'test-delete-permission',
 		name: 'TestDeletePermission',
 		action: 'ReadChannel',
+		condition: {
+			"$subject.magic_custom_field": {
+				"$eq": "magic_custom_value",
+			}
+		},
 	});
 	return await authClient.deletePermission('test-delete-permission');
 }
@@ -356,10 +366,18 @@ async function updatePermission() {
 		id: 'test-update-permission',
 		name: 'TestUpdatePermission',
 		action: 'ReadChannel',
+		condition: {
+			"$subject.magic_custom_field": {
+				"$eq": "magic_custom_value",
+			}
+		},
 	});
 	return await authClient.updatePermission('test-update-permission', {
 		name: 'TestUpdatePermissionUpdated',
 		action: 'DeleteChannel',
+		condition: {
+			"$subject.magic_custom_field": "magic_custom_value",
+		},
 	});
 }
 

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -53,9 +53,9 @@ async function createPermission() {
 		name: 'TestCreatePermission',
 		action: 'ReadChannel',
 		condition: {
-			"$subject.magic_custom_field": {
-				"$eq": "magic_custom_value",
-			}
+			'$subject.magic_custom_field': {
+				$eq: 'magic_custom_value',
+			},
 		},
 	});
 }
@@ -87,9 +87,9 @@ async function deletePermission() {
 		name: 'TestDeletePermission',
 		action: 'ReadChannel',
 		condition: {
-			"$subject.magic_custom_field": {
-				"$eq": "magic_custom_value",
-			}
+			'$subject.magic_custom_field': {
+				$eq: 'magic_custom_value',
+			},
 		},
 	});
 	return await authClient.deletePermission('test-delete-permission');
@@ -367,16 +367,16 @@ async function updatePermission() {
 		name: 'TestUpdatePermission',
 		action: 'ReadChannel',
 		condition: {
-			"$subject.magic_custom_field": {
-				"$eq": "magic_custom_value",
-			}
+			'$subject.magic_custom_field': {
+				$eq: 'magic_custom_value',
+			},
 		},
 	});
 	return await authClient.updatePermission('test-update-permission', {
 		name: 'TestUpdatePermissionUpdated',
 		action: 'DeleteChannel',
 		condition: {
-			"$subject.magic_custom_field": "magic_custom_value",
+			'$subject.magic_custom_field': 'magic_custom_value',
 		},
 	});
 }


### PR DESCRIPTION
On the backend we are implementing proper support for `condition` field for custom permissions. This PR aims to synchronize API with the new version.

This is a breaking change, but since permissions v2 is yet to be released and `condition` feature for custom permissions is undocumented, I suggest we only bump minor version with appropriate release note