### PR TITLE
fixed conditions on window.removeEventListener to avoid breaking on react-native

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -704,22 +704,14 @@ export class StableWSConnection<
    *
    */
   _listenForConnectionChanges = () => {
-    if (
-      typeof window !== 'undefined' &&
-      window != null &&
-      window.addEventListener != null
-    ) {
+    if (window?.addEventListener && typeof window.addEventListener === 'function') {
       window.addEventListener('offline', this.onlineStatusChanged);
       window.addEventListener('online', this.onlineStatusChanged);
     }
   };
 
   _removeConnectionListeners = () => {
-    if (
-      typeof window !== 'undefined' &&
-      window != null &&
-      window.addEventListener != null
-    ) {
+    if (window?.removeEventListener && typeof window.removeEventListener === 'function') {
       window.removeEventListener('offline', this.onlineStatusChanged);
       window.removeEventListener('online', this.onlineStatusChanged);
     }


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

We have this function within js client's connection class:

```tsx
  _removeConnectionListeners = () => {
    if (
      typeof window !== 'undefined' &&
      window != null &&
      window.addEventListener != null
    ) {
      window.removeEventListener('offline', this.onlineStatusChanged);
      window.removeEventListener('online', this.onlineStatusChanged);
    }
  };

```

We call this function as part of disconnect logic. Although `window` is not a react-native thing, it just happens that some external dependencies can introduce it within global variable in react-native, causing our `if` checks to fail. Also clearly we are checking `window.addEventListener` before executing `removeEventListener`, which is a false check.

E.g., following piece of code within react-native replicates the issue.

```tsx
global.window = {
  addEventListener: () => null,
  removeEventListener: null,
};

```

## Changelog

- Fixed the empty check on window.addEventListener and window.removeEventListener
