### PR TITLE
Fix update message

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -116,6 +116,7 @@ import {
   DeleteUserOptions,
   DeleteChannelsResponse,
   TaskResponse,
+  ReservedMessageFields,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -2401,24 +2402,13 @@ export class StreamChat<
     const clonedMessage: Message = Object.assign({}, message);
     delete clonedMessage.id;
 
-    const reservedMessageFields: Array<
-      | 'command'
-      | 'created_at'
-      | 'html'
-      | 'latest_reactions'
-      | 'own_reactions'
-      | 'reaction_counts'
-      | 'reply_count'
-      | 'type'
-      | 'updated_at'
-      | 'user'
-      | '__html'
-    > = [
+    const reservedMessageFields: Array<ReservedMessageFields> = [
       'command',
       'created_at',
       'html',
       'latest_reactions',
       'own_reactions',
+      'quoted_message',
       'reaction_counts',
       'reply_count',
       'type',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1873,6 +1873,20 @@ export type TranslationLanguages =
 
 export type TypingStartEvent = Event;
 
+export type ReservedMessageFields =
+  | 'command'
+  | 'created_at'
+  | 'html'
+  | 'latest_reactions'
+  | 'own_reactions'
+  | 'quoted_message'
+  | 'reaction_counts'
+  | 'reply_count'
+  | 'type'
+  | 'updated_at'
+  | 'user'
+  | '__html';
+
 export type UpdatedMessage<
   AttachmentType = UR,
   ChannelType = UR,


### PR DESCRIPTION
## Description of the changes, What, Why and How?

This adds 'quoted_message' to the list of reserved fields and excludes it from the payload when updating a message.

## Changelog

- [fix] Fixes 400 API errors when updating messages with quoted messages.
