### PR TITLE
fix: prevent own_capabilities and hidden set to undefined

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1319,8 +1319,8 @@ export class Channel<
         if (event.channel) {
           channel.data = {
             ...event.channel,
-            own_capabilities: channel.data?.own_capabilities,
-            hidden: channel.data?.hidden,
+            hidden: event.channel?.hidden ?? channel.data?.hidden,
+            own_capabilities: event.channel?.own_capabilities ?? channel.data?.own_capabilities,
           };
         }
         break;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1317,7 +1317,11 @@ export class Channel<
         break;
       case 'channel.updated':
         if (event.channel) {
-          channel.data = event.channel;
+          channel.data = {
+            ...event.channel,
+            own_capabilities: channel.data?.own_capabilities,
+            hidden: channel.data?.hidden,
+          };
         }
         break;
       case 'reaction.new':


### PR DESCRIPTION
prevent own_capabilities and hidden from being set to undefined after a channel.updated event is fired


link to issue: https://github.com/GetStream/stream-chat-react/issues/1310