### PR TITLE
Support new pinned messages endpoint

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -47,6 +47,8 @@ import {
   UpdateChannelAPIResponse,
   UserFilters,
   UserResponse,
+  PinnedMessagePaginationOptions,
+  PinnedMessagesSort,
 } from './types';
 import { Role } from './permissions';
 
@@ -839,6 +841,28 @@ export class Channel<
     }
 
     return data;
+  }
+
+  /**
+   * getPinnedMessages - List list pinned messages of the channel
+   *
+   * @param {PinnedMessagePaginationOptions & { user?: UserResponse<UserType>; user_id?: string }} options Pagination params, ie {limit:10, id_lte: 10}
+   * @param {PinnedMessagesSort} sort defines sorting direction of pinned messages
+   *
+   * @return {Promise<GetRepliesAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>>} A response with a list of messages
+   */
+  async getPinnedMessages(
+    options: PinnedMessagePaginationOptions & { user?: UserResponse<UserType>; user_id?: string },
+    sort: PinnedMessagesSort = [],
+  ) {
+    return await this.getClient().get<
+      GetRepliesAPIResponse<AttachmentType, ChannelType, CommandType, MessageType, ReactionType, UserType>
+    >(this.getClient().baseURL + `/channels/${this.type}/${this.id}/pinned_messages`, {
+      payload: {
+        ...options,
+        sort: normalizeQuerySort(sort),
+      },
+    });
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -2339,7 +2339,7 @@ export class StreamChat<
    * @param {undefined|null|number|string|Date} timeoutOrExpirationDate expiration date or timeout. Use number type to set timeout in seconds, string or Date to set exact expiration date
    */
   _normalizeExpiration(timeoutOrExpirationDate?: null | number | string | Date) {
-    let pinExpires: undefined | string;
+    let pinExpires: null | string = null;
     if (typeof timeoutOrExpirationDate === 'number') {
       const now = new Date();
       now.setSeconds(now.getSeconds() + timeoutOrExpirationDate);
@@ -2374,12 +2374,14 @@ export class StreamChat<
    * pinMessage - pins the message
    * @param {string | { id: string }} messageOrMessageId message object or message id
    * @param {undefined|null|number|string|Date} timeoutOrExpirationDate expiration date or timeout. Use number type to set timeout in seconds, string or Date to set exact expiration date
-   * @param {string | { id: string }} [userId]
+   * @param {undefined|string | { id: string }} [pinnedBy] who will appear as a user who pinned a message. Only for server-side use. Provide `undefined` when pinning message client-side
+   * @param {undefined|number|string|Date} pinnedAt date when message should be pinned. It affects the order of pinned messages. Use negative number to set relative time in the past, string or Date to set exact date of pin
    */
   pinMessage(
     messageOrMessageId: string | { id: string },
     timeoutOrExpirationDate?: null | number | string | Date,
-    userId?: string | { id: string },
+    pinnedBy?: string | { id: string },
+    pinnedAt?: number | string | Date,
   ) {
     const messageId = this._validateAndGetMessageId(
       messageOrMessageId,
@@ -2391,9 +2393,10 @@ export class StreamChat<
         set: {
           pinned: true,
           pin_expires: this._normalizeExpiration(timeoutOrExpirationDate),
+          pinned_at: this._normalizeExpiration(pinnedAt),
         },
       },
-      userId,
+      pinnedBy,
     );
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -840,6 +840,21 @@ export type MessagePaginationOptions = PaginationOptions & {
   id_around?: string;
 };
 
+export type PinnedMessagePaginationOptions = {
+  id_around?: string;
+  id_gt?: string;
+  id_gte?: string;
+  id_lt?: string;
+  id_lte?: string;
+  limit?: number;
+  offset?: number;
+  pinned_at_after?: string | Date;
+  pinned_at_after_or_equal?: string | Date;
+  pinned_at_around?: string | Date;
+  pinned_at_before?: string | Date;
+  pinned_at_before_or_equal?: string | Date;
+};
+
 export type QueryMembersOptions = {
   limit?: number;
   offset?: number;
@@ -1236,6 +1251,9 @@ export type ChannelSortBase<ChannelType = UR> = Sort<ChannelType> & {
   unread_count?: AscDesc;
   updated_at?: AscDesc;
 };
+
+export type PinnedMessagesSort = PinnedMessagesSortBase | Array<PinnedMessagesSortBase>;
+export type PinnedMessagesSortBase = { pinned_at?: AscDesc };
 
 export type Sort<T> = {
   [P in keyof T]?: AscDesc;
@@ -1664,7 +1682,9 @@ export type MessageBase<AttachmentType = UR, MessageType = UR, UserType = UR> = 
   html?: string;
   mml?: string;
   parent_id?: string;
+  pin_expires?: string;
   pinned?: boolean;
+  pinned_at?: string;
   quoted_message_id?: string;
   show_in_channel?: boolean;
   text?: string;


### PR DESCRIPTION
This PR adds support for new `getPinnedMessages` endpoint as well as enables to update `pinned_at` of the message.