### PR TITLE
fix: include unread_messages for all message events

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1260,6 +1260,7 @@ export class Channel<
             // because in client.ts the handleEvent call that flows to this sets this `event.received_at = new Date();`
             last_read: event.received_at as Date,
             user: event.user,
+            unread_messages: 0,
           };
 
           if (event.user?.id === this.getClient().user?.id) {
@@ -1308,6 +1309,7 @@ export class Channel<
             channelState.read[event.user.id] = {
               last_read: new Date(event.created_at as string),
               user: event.user,
+              unread_messages: 0,
             };
           } else if (this._countMessageAsUnread(event.message)) {
             channelState.unreadCount = channelState.unreadCount + 1;
@@ -1472,6 +1474,7 @@ export class Channel<
         this.state.read[user.id] = {
           user,
           last_read,
+          unread_messages: 0,
         };
       }
     }
@@ -1479,10 +1482,14 @@ export class Channel<
     // apply read state if part of the state
     if (state.read) {
       for (const read of state.read) {
-        const parsedRead = { ...read, last_read: new Date(read.last_read) };
-        this.state.read[read.user.id] = parsedRead;
-        if (read.user.id === user?.id && typeof parsedRead.unread_messages === 'number') {
-          this.state.unreadCount = parsedRead.unread_messages;
+        this.state.read[read.user.id] = {
+          last_read: new Date(read.last_read),
+          unread_messages: read.unread_messages ?? 0,
+          user: read.user,
+        };
+
+        if (read.user.id === user?.id) {
+          this.state.unreadCount = this.state.read[read.user.id].unread_messages;
         }
       }
     }

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -11,7 +11,10 @@ import {
   UserResponse,
 } from './types';
 
-type ChannelReadStatus<UserType> = Record<string, { last_read: Date; user: UserResponse<UserType> }>;
+type ChannelReadStatus<UserType> = Record<
+  string,
+  { last_read: Date; unread_messages: number; user: UserResponse<UserType> }
+>;
 
 /**
  * ChannelState - A container class for the channel state.

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -11,6 +11,8 @@ import {
   UserResponse,
 } from './types';
 
+type ChannelReadStatus<UserType> = Record<string, { last_read: Date; user: UserResponse<UserType> }>;
+
 /**
  * ChannelState - A container class for the channel state.
  */
@@ -29,7 +31,7 @@ export class ChannelState<
     string,
     Event<AttachmentType, ChannelType, CommandType, EventType, MessageType, ReactionType, UserType>
   >;
-  read: Record<string, { last_read: Date; user: UserResponse<UserType> }>;
+  read: ChannelReadStatus<UserType>;
   messages: Array<
     ReturnType<
       ChannelState<

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -208,6 +208,68 @@ describe('Channel _handleChannelEvent', function () {
 
 		expect(channel.state.messages.find((msg) => msg.id === quotingMessage.id).quoted_message.deleted_at).to.be.ok;
 	});
+
+	it('should include unread_messages for message events from another user', () => {
+		const channel = client.channel('messaging', 'id');
+		channel.initialized = true;
+		channel.state.read['id'] = {
+			unread_messages: 2,
+		};
+
+		const message = generateMsg();
+
+		const events = [
+			'message.read',
+			'message.deleted',
+			'message.new',
+			'message.updated',
+			'member.added',
+			'member.updated',
+			'member.removed',
+		];
+
+		for (const event of events) {
+			channel.state.read['id'].unread_messages = 2;
+			channel._handleChannelEvent({
+				type: event,
+				user: { id: 'id' },
+				message,
+			});
+			expect(channel.state.read['id'].unread_messages, `${event} should not be undefined`).not.to.be.undefined;
+		}
+	});
+
+	it('should include unread_messages for message events from the current user', () => {
+		const channel = client.channel('messaging', 'id');
+
+		channel.initialized = true;
+		channel.state.read[client.user.id] = {
+			unread_messages: 2,
+		};
+
+		const message = generateMsg({ user: { id: client.userID } });
+
+		const events = [
+			'message.read',
+			'message.deleted',
+			'message.new',
+			'message.updated',
+			'member.added',
+			'member.updated',
+			'member.removed',
+		];
+
+		for (const event of events) {
+			channel.state.read['id'].unread_messages = 2;
+			channel._handleChannelEvent({
+				type: event,
+				user: { id: client.user.id },
+				message,
+			});
+			expect(channel.state.read[client.user.id].unread_messages, `${event} should not be undefined`).not.to.be
+				.undefined;
+		}
+	});
 });
 
 describe('Channels - Constructor', function () {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Currently, we unset `channel.state.read.userId.unread_messages` on `message.read` and `message.new` if the message is sent by the current user. This PR adds `unread_messages` as 0 for both of those events to keep consistency in the read state object.

It also adds typing of `unread_mesages`.

## Changelog

- `unread_messages` will now be set to `0` rather than omitted following the `message.read` event, and the `message.new` event when the message is sent by the current user.
