### PR TITLE
build: rerun PR title lint when PR is edited

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 name: Lint
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 concurrency: 
   group: ${{ github.workflow }}-${{ github.head_ref }}


### PR DESCRIPTION
According to the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), `on: [pull_request]` is triggered on `opened`, `synchronize` and `reopened`. This adds `edited`, so it can rerun if you edit the title of your PR

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Changelog

-
