### PR TITLE
refactor: add file_size and mime_type keys to attachment type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1475,9 +1475,11 @@ export type Attachment<T = UR> = T & {
   color?: string;
   fallback?: string;
   fields?: Field[];
+  file_size?: number | string;
   footer?: string;
   footer_icon?: string;
   image_url?: string;
+  mime_type?: string;
   og_scrape_url?: string;
   original_height?: number;
   original_width?: number;


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

This PR involves adding the `file_size` and `mime_type` as keys to the Attachment type.

## Changelog

- Adding the `file_size` and `mime_type` as keys to the Attachment type.
