### PR TITLE
refactor: add image type to ChannelResponse, ChannelData and UserResponse

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -67,6 +67,7 @@ export class Channel<
   _client: StreamChat<AttachmentType, ChannelType, CommandType, EventType, MessageType, ReactionType, UserType>;
   type: string;
   id: string | undefined;
+  image?: string;
   data: ChannelData<ChannelType> | ChannelResponse<ChannelType, CommandType, UserType> | undefined;
   _data: ChannelData<ChannelType> | ChannelResponse<ChannelType, CommandType, UserType>;
   cid: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1475,9 +1475,11 @@ export type Attachment<T = UR> = T & {
   color?: string;
   fallback?: string;
   fields?: Field[];
+  file_size?: number | string;
   footer?: string;
   footer_icon?: string;
   image_url?: string;
+  mime_type?: string;
   og_scrape_url?: string;
   original_height?: number;
   original_width?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,7 @@ export type ChannelResponse<
   created_by_id?: string;
   deleted_at?: string;
   hidden?: boolean;
+  image?: string;
   invites?: string[];
   last_message_at?: string;
   member_count?: number;
@@ -717,6 +718,7 @@ export type UserResponse<UserType = UR> = User<UserType> & {
   created_at?: string;
   deactivated_at?: string;
   deleted_at?: string;
+  image?: string;
   language?: TranslationLanguages | '';
   last_active?: string;
   online?: boolean;
@@ -1519,6 +1521,7 @@ export type ChannelConfigWithInfo<CommandType extends string = LiteralStringForU
   };
 
 export type ChannelData<ChannelType = UR> = ChannelType & {
+  image?: string;
   members?: string[];
   name?: string;
 };


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why, and How?

This PR introduces the `image` key with `string | undefined` as a type to the ChannelResponse, ChannelData, and UserResponse. This was done to solve the typescript issues in the React native SDK.

## Changelog

- Introduces the `image` key with `string | undefined` as a type to the ChannelResponse, ChannelData, and UserResponse.
