### PR TITLE
fix: unread count to not increment if channel has read_events off

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -923,6 +923,10 @@ export class Channel<
     if (message.user?.id && this.getClient().userMuteStatus(message.user.id)) return false;
     if (message.type === 'system') return false;
 
+    // Return false if channel doesn't allow read events.
+    if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read_events'))
+      return false;
+
     if (this.muteStatus().muted) return false;
 
     return true;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -924,7 +924,7 @@ export class Channel<
     if (message.type === 'system') return false;
 
     // Return false if channel doesn't allow read events.
-    if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read_events'))
+    if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read-events'))
       return false;
 
     if (this.muteStatus().muted) return false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1475,9 +1475,11 @@ export type Attachment<T = UR> = T & {
   color?: string;
   fallback?: string;
   fields?: Field[];
+  file_size?: number | string;
   footer?: string;
   footer_icon?: string;
   image_url?: string;
+  mime_type?: string;
   og_scrape_url?: string;
   original_height?: number;
   original_width?: number;

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -65,6 +65,11 @@ describe('Channel count unread', function () {
 		expect(channel._countMessageAsUnread({ user: { id: 'mute1' } })).not.to.be.ok;
 	});
 
+	it('_countMessageAsUnread should return false for channel with read_events off', function () {
+		const channel = client.channel('messaging', { members: ['tommaso'], own_capabilities: [] });
+		expect(channel._countMessageAsUnread({ user: { id: 'random' } })).not.to.be.ok;
+	});
+
 	it('_countMessageAsUnread should return true for unmuted user', function () {
 		expect(channel._countMessageAsUnread({ user: { id: 'unmute' } })).to.be.ok;
 	});


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

If the read events are turned off on the application, then the unread count shouldn’t show up on the channel list component. Currently, when a new message comes in, we increment the unread count for a particular channel. But this increment works even if read events are turned off, which leads to confusing behavior.

## Changelog

- Add the logic for not incrementing channel unread count if the read_events are off. 
