### PR TITLE
fix: added attribute `pendingDisconnect`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -696,6 +696,15 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
     this.anonymous = false;
 
+    // causes duplicate connections (implement canceling?)
+    // happens when switching between users is done fast enough
+    // (while calling disconnectUser before each new connection)
+    // React's useEffect
+    if (this.pendingDisconnect) {
+      // cancel pending connections
+      return this.pendingDisconnect;
+    }
+
     const closePromise = this.closeConnection(timeout);
 
     for (const channel of Object.values(this.activeChannels)) {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Whenever `disconnectUser` got called in a "cleaning" function of a React component (let's say user got switched) the developer had to store the return value of this method (a Promise object) to be then awaited before new connection could be established - without the said await the effect would attempt to establish a new connection right after cleaning function finished running which resulted in a warning and a connection error:

![image](https://user-images.githubusercontent.com/43254280/153451739-a08d3b3d-61a8-4d1a-b638-1bde714c1a33.png)
![image](https://user-images.githubusercontent.com/43254280/153452115-87bf78a9-8dfd-4ddd-ba74-ae53328da49a.png)

This PR adds this "await" functionality to the SDK so the user does not have to do it themselves.
Third parameter could be added to the `connectUser` - `skipDisconnectAwait` to prevent possible breaking changes but I'd expect this to be a default behaviour.

Without the fix:
```ts
const disconnectReference = useRef(Promise.resolve());

useEffect(() => {
	if (!user) return;

	disconnectReference.current.then(() => {
		chatAPIClient.connectUser({ id: user.id }, user.token);
	});

	return () => {
		disconnectReference.current = chatAPIClient.disconnectUser();
	};
}, [user]);
```
With the fix:
```ts
useEffect(() => {
	if (!user) return;

	chatAPIClient.connectUser({ id: user.id }, user.token);

	return () => {
		chatAPIClient.disconnectUser();
	};
}, [user]);
```


## Changelog
- added attribute `pendingDisconnect` to the `StreamChat` class
