### PR TITLE
fix: channel unreadCount to be set as 0 when notification.mark_read event is dispatched [CRNS - 433]

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1186,7 +1186,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
     if (event.type === 'notification.mark_read') {
       const activeChannelKeys = Object.keys(this.activeChannels);
-      activeChannelKeys.map((activeChannelKey) => (this.activeChannels[activeChannelKey].state.unreadCount = 0));
+      activeChannelKeys.forEach((activeChannelKey) => (this.activeChannels[activeChannelKey].state.unreadCount = 0));
     }
 
     if ((event.type === 'channel.deleted' || event.type === 'notification.channel_deleted') && event.cid) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1184,6 +1184,11 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       this.mutedUsers = event.me.mutes;
     }
 
+    if (event.type === 'notification.mark_read') {
+      const activeChannelKeys = Object.keys(this.activeChannels);
+      activeChannelKeys.map((activeChannelKey) => (this.activeChannels[activeChannelKey].state.unreadCount = 0));
+    }
+
     if ((event.type === 'channel.deleted' || event.type === 'notification.channel_deleted') && event.cid) {
       client.state.deleteAllChannelReference(event.cid);
       this.activeChannels[event.cid]?._disconnect();

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -127,6 +127,20 @@ describe('Client userMuteStatus', function () {
 		expect(client.userMuteStatus('mute4')).not.to.be.ok;
 		expect(client.userMuteStatus('missingUser')).not.to.be.ok;
 	});
+
+	it('should update all active channel unread count to 0 when notification.mark_read event is called', function () {
+		client.activeChannels = { vish: { state: { unreadCount: 1 } }, vish2: { state: { unreadCount: 2 } } };
+		client.dispatchEvent({
+			type: 'notification.mark_read',
+		});
+
+		const unreadCountSum = Object.values(client.activeChannels).reduce(
+			(prevSum, currSum) => prevSum + currSum.state.unreadCount,
+			0,
+		);
+
+		expect(unreadCountSum).to.be.equal(0);
+	});
 });
 
 describe('Client connectUser', () => {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why, and How?

When we use the markAllRead method, we get the event notification.mark_read, which updates the total_unread_count, but not the channel.state.unreadCount. This PR solved the above issue.

## Changelog

- Added the logic to set the activeChannel state's unreadCount to 0.
- Added tests for the same.
