### PR TITLE
fix: catch tokenProvider rejection

### DIFF
--- a/src/token_manager.ts
+++ b/src/token_manager.ts
@@ -105,13 +105,17 @@ export class TokenManager<StreamChatGenerics extends ExtendableGenerics = Defaul
   // In case of static token, it will simply resolve to static token.
   loadToken = () => {
     // eslint-disable-next-line no-async-promise-executor
-    this.loadTokenPromise = new Promise(async (resolve) => {
+    this.loadTokenPromise = new Promise(async (resolve, reject) => {
       if (this.type === 'static') {
         return resolve(this.token as string);
       }
 
       if (this.tokenProvider && typeof this.tokenProvider !== 'string') {
-        this.token = await this.tokenProvider();
+        try {
+          this.token = await this.tokenProvider();
+        } catch (e) {
+          return reject(new Error(`Call to tokenProvider failed with message: ${e}`));
+        }
         resolve(this.token);
       }
     });

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -44,6 +44,18 @@ describe('connection', function () {
 
 	after(() => wss.close());
 
+	describe('Connection tokenProvider', () => {
+		it('should handle token provider rejection ', async () => {
+			const client = new StreamChat('apiKey', {
+				allowServerSideConnect: true,
+				baseURL: 'http://localhost:9999', // invalid base url
+			});
+			client.defaultWSTimeout = 20;
+			const tokenProvider = () => Promise.reject(new Error('network failure'));
+			await expect(client.connectUser({ id: 'amin' }, tokenProvider)).to.be.rejectedWith(/tokenProvider failed/);
+		});
+	});
+
 	describe('Connection _buildUrl', function () {
 		const device = { id: 'device_id', push_provider: 'firebase' };
 		const client = newStreamChat();

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -48,7 +48,6 @@ describe('connection', function () {
 		it('should handle token provider rejection ', async () => {
 			const client = new StreamChat('apiKey', {
 				allowServerSideConnect: true,
-				baseURL: 'http://localhost:9999', // invalid base url
 			});
 			client.defaultWSTimeout = 20;
 			const tokenProvider = () => Promise.reject(new Error('network failure'));


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

When providing a `tokenProvider` function to `connectUser`, if the `tokenProvider` promise is rejected this will result in an uncaught promise rejection.

This fix adds a `try/catch` around the `await`ing of the user provided `tokenProvider` function as to gracefully handle the error.

## Changelog
- fix: catch tokenProvider rejection
