### PR TITLE
fix: thread reply preview not added to channel state

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -170,9 +170,12 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
       if (isFromShadowBannedUser) {
         continue;
       }
-      const isMerging = messagesToAdd[i].created_at instanceof Date;
+      // If message is already formatted we can skip the tasks below
+      // This will be true for messages that are already present at the state -> this happens when we perform merging of message sets
+      // This will be also true for message previews used by some SDKs
+      const isMessageFormatted = messagesToAdd[i].created_at instanceof Date;
       let message: ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>;
-      if (isMerging) {
+      if (isMessageFormatted) {
         message = messagesToAdd[i] as ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>;
       } else {
         message = this.formatMessage(messagesToAdd[i] as MessageResponse<StreamChatGenerics>);
@@ -226,7 +229,7 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
        * message is "oldest" message, and newer messages are therefore not loaded.
        * This can also occur if an old thread message is updated.
        */
-      if (parentID && !initializing && !isMerging) {
+      if (parentID && !initializing) {
         const thread = this.threads[parentID] || [];
         const threadMessages = this._addToMessageList(
           thread,

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -396,6 +396,32 @@ describe('ChannelState addMessagesSorted', function () {
 		expect(state.pinnedMessages[2].id).to.be.equal('2');
 	});
 
+	it('should add message preview', async function () {
+		// these message previews are used UI SDKs
+		const messagePreview = generateMsg({ id: '1', date: new Date('2020-01-01T00:00:00.001Z') });
+		const state = new ChannelState();
+		state.addMessageSorted(messagePreview);
+
+		expect(state.messages[0].id).to.be.equal('1');
+	});
+
+	it('should add thread reply preview', async function () {
+		// these message previews are used by UI SDKs
+		const parentMessage = generateMsg({ id: 'parent_id', date: '2020-01-01T00:00:00.001Z' });
+		const threadReplyPreview = generateMsg({
+			id: '2',
+			date: new Date('2020-01-01T00:00:00.001Z'),
+			parent_id: 'parent_id',
+		});
+		const state = new ChannelState();
+		state.addMessageSorted(parentMessage);
+		state.addMessageSorted(threadReplyPreview);
+		const thread = state.threads[parentMessage.id];
+
+		expect(thread.length).to.be.equal(1);
+		expect(thread[0].id).to.be.equal(threadReplyPreview.id);
+	});
+
 	describe('merges overlapping message sets', () => {
 		it('when new messages overlap with latest messages', () => {
 			const state = new ChannelState();


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] Code changes are tested

## Description of the changes, What, Why and How?

UI SDKs (for example Angular and React) create a message preview before sending a message request to the API and display those message previews in the message list while the message is being sent. There was a bug in the channel state where thread reply preview messages weren't added to the channel state. This was due to the recent jump to message functionality.

## Changelog

- fix: thread reply preview not added to channel state
