### PR TITLE
fix: added missing push and reminders related types 

### DIFF
--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -13,3 +13,8 @@ jobs:
       - uses: ./.github/actions/setup-node
       - name: Run API type definition tests
         run: yarn test-types
+        env:
+          API_KEY: ${{ secrets.TS_TEST_API_KEY }}
+          API_SECRET: ${{ secrets.TS_TEST_API_SECRET }}
+          MULTITENANCY_API_KEY: ${{ secrets.TS_TEST_MULTITENANCY_API_KEY }}
+          MULTITENANCY_API_SECRET: ${{ secrets.TS_TEST_MULTITENANCY_API_SECRET }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,8 +75,10 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
     channel_configs: Record<
       string,
       {
+        reminders: boolean;
         automod?: ChannelConfigAutomod;
         automod_behavior?: ChannelConfigAutomodBehavior;
+        automod_thresholds?: ChannelConfigAutomodThresholds;
         blocklist_behavior?: ChannelConfigAutomodBehavior;
         commands?: CommandVariants<StreamChatGenerics>[];
         connect_events?: boolean;
@@ -98,6 +100,7 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
         url_enrichment?: boolean;
       }
     >;
+    reminders_interval: number;
     async_url_enrich_enabled?: boolean;
     auto_translation_enabled?: boolean;
     before_message_send_hook_url?: string;
@@ -1542,8 +1545,10 @@ export type ChannelConfigAutomodThresholds = null | {
 };
 
 export type ChannelConfigFields = {
+  reminders: boolean;
   automod?: ChannelConfigAutomod;
   automod_behavior?: ChannelConfigAutomodBehavior;
+  automod_thresholds?: ChannelConfigAutomodThresholds;
   blocklist_behavior?: ChannelConfigAutomodBehavior;
   connect_events?: boolean;
   custom_events?: boolean;
@@ -1617,6 +1622,7 @@ export type CheckPushInput<StreamChatGenerics extends ExtendableGenerics = Defau
 export type PushProvider = 'apn' | 'firebase' | 'huawei' | 'xiaomi';
 
 export type PushProviderConfig = PushProviderCommon &
+  PushProviderID &
   PushProviderAPN &
   PushProviderFirebase &
   PushProviderHuawei &
@@ -1956,7 +1962,7 @@ export type Policy = {
   owner?: boolean;
   priority?: number;
   resources?: string[];
-  roles?: string[];
+  roles?: string[] | null;
   updated_at?: string;
 };
 

--- a/test/typescript/utils.js
+++ b/test/typescript/utils.js
@@ -1,10 +1,12 @@
 const { StreamChat } = require('../../dist');
-require('dotenv').config();
-const apiKey = '892s22ypvt6m';
-const apiSecret = '5cssrefv55rs3cnkk38kfjam2k7c2ykwn4h79dqh66ym89gm65cxy4h9jx4cypd6';
 
-const multiTenancySecret = 'pf8krbh9z3vc8d35dn65tq4xsa4jqmcbdgp5spuej2fprm6rqc5mtxuxghgxw43u';
-const multiTenancyKey = '2g3vcvcnmm5u';
+require('dotenv').config({ path: `${process.cwd()}/test/typescript/.env` });
+
+const apiKey = process.env.API_KEY;
+const apiSecret = process.env.API_SECRET;
+
+const multiTenancySecret = process.env.MULTITENANCY_API_SECRET;
+const multiTenancyKey = process.env.MULTITENANCY_API_KEY;
 
 module.exports = {
 	createMultiTenancyUsers: async function createMultiTenancyUsers(userIDs, teams = [], additionalInfo) {


### PR DESCRIPTION
## Changelog

- Fixed the typescript for push config
- Added missing types for `automod_threshold`
- Added missing types for `reminders `
- Move the api keys and secrets for typescript test to github secret
