### PR TITLE
fix: revert #914 (`notification.mark_read` event)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1195,11 +1195,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       this.mutedUsers = event.me.mutes;
     }
 
-    if (event.type === 'notification.mark_read') {
-      const activeChannelKeys = Object.keys(this.activeChannels);
-      activeChannelKeys.forEach((activeChannelKey) => (this.activeChannels[activeChannelKey].state.unreadCount = 0));
-    }
-
     if ((event.type === 'channel.deleted' || event.type === 'notification.channel_deleted') && event.cid) {
       client.state.deleteAllChannelReference(event.cid);
       this.activeChannels[event.cid]?._disconnect();

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -127,20 +127,6 @@ describe('Client userMuteStatus', function () {
 		expect(client.userMuteStatus('mute4')).not.to.be.ok;
 		expect(client.userMuteStatus('missingUser')).not.to.be.ok;
 	});
-
-	it('should update all active channel unread count to 0 when notification.mark_read event is called', function () {
-		client.activeChannels = { vish: { state: { unreadCount: 1 } }, vish2: { state: { unreadCount: 2 } } };
-		client.dispatchEvent({
-			type: 'notification.mark_read',
-		});
-
-		const unreadCountSum = Object.values(client.activeChannels).reduce(
-			(prevSum, currSum) => prevSum + currSum.state.unreadCount,
-			0,
-		);
-
-		expect(unreadCountSum).to.be.equal(0);
-	});
 });
 
 describe('Client connectUser', () => {


### PR DESCRIPTION
Revert "fix: channel unreadCount to be set as 0 when notification.mark_read event is dispatched [CRNS - 433] (#914)"