### PR TITLE
fix: handling of notification.mark_read event

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1195,7 +1195,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       this.mutedUsers = event.me.mutes;
     }
 
-    if (event.type === 'notification.mark_read') {
+    if (event.type === 'notification.mark_read' && event.unread_channels === 0) {
       const activeChannelKeys = Object.keys(this.activeChannels);
       activeChannelKeys.forEach((activeChannelKey) => (this.activeChannels[activeChannelKey].state.unreadCount = 0));
     }


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Add additional check before setting unread count for all active channels to 0. Check that the `notification.mark_read` event has `unread_channels: 0`. 

