### PR TITLE
fix: multiple ws connections due to redundant openConnection calls

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -516,6 +516,14 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       throw Error('User is not set on client, use client.connectUser or client.connectAnonymousUser instead');
     }
 
+    if (this.wsConnection?.isConnecting) {
+      this.logger('info', 'client:openConnection() - connection already in progress', {
+        tags: ['connection', 'client'],
+      });
+
+      return Promise.resolve();
+    }
+
     if ((this.wsConnection?.isHealthy || this.wsFallback?.isHealthy()) && this._hasConnectionID()) {
       this.logger('info', 'client:openConnection() - openConnection called twice, healthy connection already exists', {
         tags: ['connection', 'client'],


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Issue

Back to back calls to `client.openConnection` without awaiting results into multiple websocket connections.

## How to reproduce

Reproducible scenario occurs within RN SDK:

- Add Chat component on multiple screens (channel list screen, channel screen, Thread screen etc)
- Chat component adds [AppState](https://reactnative.dev/docs/appstate) listener to app
    - [client.closeConnection](https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/Chat/hooks/useIsOnline.ts#L30) upon backgrounding the app
    - [client.openConnection](https://github.com/GetStream/stream-chat-react-native/blob/develop/package/src/components/Chat/hooks/useIsOnline.ts#L42) upon foregrounding the app
- Put the app in background and bring it back to foreground which results into AppState listeners being fired (backgrounding - foregrounding)
    - **[Android only]** Alternatively Open a file picker on channel screen, which also result into AppState listeners being fired (backgrounding - foregrounding)
- Notice multiple calls to `/connect` api

## Fix

Return existing promise from `client.openConnection()` if ws connection is already in progress
