### PR TITLE
fix: add TestCampaignResponse type

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -140,6 +140,7 @@ import {
   FlagsFilters,
   FlagsPaginationOptions,
   FlagsResponse,
+  TestCampaignResponse,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -2785,12 +2786,12 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    * @param {string} id Campaign ID
    * @param {{users: string[]}} params Test params
-   * @return {Campaign} Test Campaign
+   *
+   * @return {TestCampaignResponse} Test campaign response
    */
   async testCampaign(id: string, params: { users: string[] }) {
     const { users } = params;
-    const { campaign } = await this.post<{ campaign: Campaign }>(this.baseURL + `/campaigns/${id}/test`, { users });
-    return campaign;
+    return await this.post<APIResponse & TestCampaignResponse>(this.baseURL + `/campaigns/${id}/test`, { users });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2241,6 +2241,11 @@ export type Campaign = {
 } & CampaignData &
   CampaignStatus;
 
+export type TestCampaignResponse = {
+  campaign?: Campaign;
+  invalid_users?: Record<string, string>;
+};
+
 export type TaskStatus = {
   created_at: string;
   status: string;


### PR DESCRIPTION
This PR adds a new type `TestCampaignResponse` to expose either the campaign (on success) or invalid user if there is any.

