### PR TITLE
refactor: add type for general error API response format

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: "off" */
 /* global process */
 
-import axios, { AxiosRequestConfig, AxiosInstance, AxiosResponse } from 'axios';
+import axios, { AxiosRequestConfig, AxiosInstance, AxiosResponse, AxiosError } from 'axios';
 import https from 'https';
 import WebSocket from 'isomorphic-ws';
 
@@ -12,7 +12,7 @@ import { isValidEventType } from './events';
 import { JWTUserToken, DevToken, CheckSignature } from './signing';
 import { TokenManager } from './token_manager';
 import { WSConnectionFallback } from './connection_fallback';
-import { isWSFailure } from './errors';
+import { isErrorResponse, isWSFailure } from './errors';
 import {
   isFunction,
   isOwnUserBaseProperty,
@@ -141,6 +141,8 @@ import {
   FlagsPaginationOptions,
   FlagsResponse,
   TestCampaignResponse,
+  APIErrorResponse,
+  ErrorFromResponse,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -940,7 +942,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
         }
         return this.handleResponse(e.response);
       } else {
-        throw e;
+        throw e as AxiosError<APIErrorResponse>;
       }
     }
   };
@@ -985,9 +987,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     });
   }
 
-  errorFromResponse<T>(response: AxiosResponse<T & { code?: number; message?: string }>) {
-    let err: Error & { code?: number; response?: AxiosResponse<T>; status?: number };
-    err = new Error(`StreamChat error HTTP code: ${response.status}`);
+  errorFromResponse(response: AxiosResponse<APIErrorResponse>): ErrorFromResponse<APIErrorResponse> {
+    let err: ErrorFromResponse<APIErrorResponse>;
+    err = new ErrorFromResponse(`StreamChat error HTTP code: ${response.status}`);
     if (response.data && response.data.code) {
       err = new Error(`StreamChat error code ${response.data.code}: ${response.data.message}`);
       err.code = response.data.code;
@@ -999,8 +1001,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
   handleResponse<T>(response: AxiosResponse<T>) {
     const data = response.data;
-    if ((response.status + '')[0] !== '2') {
-      throw this.errorFromResponse<T>(response);
+    if (isErrorResponse(response)) {
+      throw this.errorFromResponse(response);
     }
     return data;
   }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -61,5 +61,5 @@ export function isWSFailure(err: APIError): boolean {
 }
 
 export function isErrorResponse(res: AxiosResponse<unknown>): res is AxiosResponse<APIErrorResponse> {
-  return (res.status + '')[0] !== '2';
+  return !res.status || res.status < 200 || 300 <= res.status;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,6 @@
+import { AxiosResponse } from 'axios';
+import { APIErrorResponse } from './types';
+
 export const APIErrorCodes: Record<string, { name: string; retryable: boolean }> = {
   '-1': { name: 'InternalSystemError', retryable: true },
   '2': { name: 'AccessKeyError', retryable: false },
@@ -55,4 +58,8 @@ export function isWSFailure(err: APIError): boolean {
   } catch (_) {
     return false;
   }
+}
+
+export function isErrorResponse(res: AxiosResponse<unknown>): res is AxiosResponse<APIErrorResponse> {
+  return (res.status + '')[0] !== '2';
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig } from 'axios';
+import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { EVENT_MAP } from './events';
 import { Role } from './permissions';
 
@@ -2319,3 +2319,17 @@ export type PushProviderUpsertResponse = {
 export type PushProviderListResponse = {
   push_providers: PushProvider[];
 };
+
+export type APIErrorResponse = {
+  code: number;
+  duration: string;
+  message: string;
+  more_info: string;
+  StatusCode: number;
+};
+
+export class ErrorFromResponse<T> extends Error {
+  code?: number;
+  response?: AxiosResponse<T>;
+  status?: number;
+}

--- a/test/unit/errors.js
+++ b/test/unit/errors.js
@@ -1,0 +1,20 @@
+import chai from 'chai';
+import { isErrorResponse } from '../../src/errors';
+
+const expect = chai.expect;
+
+describe('error response', () => {
+	it('is response with no status attribute', () => {
+		expect(isErrorResponse({})).to.be.true;
+	});
+	it('is response with status code other than 2xx', () => {
+		expect(isErrorResponse({ status: 100 })).to.be.true;
+		expect(isErrorResponse({ status: 300 })).to.be.true;
+		expect(isErrorResponse({ status: 400 })).to.be.true;
+		expect(isErrorResponse({ status: 500 })).to.be.true;
+	});
+	it('is not response with status code 2xx', () => {
+		expect(isErrorResponse({ status: 200 })).to.be.false;
+		expect(isErrorResponse({ status: 299 })).to.be.false;
+	});
+});


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] Code changes are tested

## Description of the changes, What, Why and How?
Add type definitions for error API response payload and for error generated and thrown on error response propagated from the chat client.

This is important for SDKs that use the stream-chat client in order to facilitate work with errors thrown by the client.
