### PR TITLE
Add permission migration types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1470,7 +1470,7 @@ export type AppSettings = {
   image_upload_config?: FileUploadConfig;
   migrate_permissions_to_v2?: boolean;
   multi_tenant_enabled?: boolean;
-  permission_version?: string;
+  permission_version?: 'v1' | 'v2';
   push_config?: {
     offline_only?: boolean;
     version?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1468,7 +1468,9 @@ export type AppSettings = {
   };
   image_moderation_enabled?: boolean;
   image_upload_config?: FileUploadConfig;
+  migrate_permissions_to_v2?: boolean;
   multi_tenant_enabled?: boolean;
+  permission_version?: string;
   push_config?: {
     offline_only?: boolean;
     version?: string;


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] Code changes are tested

## Description of the changes, What, Why and How?

Add support for migrating from legacy permissions (v1) to v2 as per the [Migrating from Legacy docs](https://getstream.io/chat/docs/node/migrating_from_legacy/?language=javascript)

## Changelog

- fix: add types to support for setting `permission_version` and `migrate_permissions_to_v2` parameters
