### PR TITLE
types: add isErrorResponse type to APIErrorResponse

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2322,12 +2322,18 @@ export type PushProviderListResponse = {
   push_providers: PushProvider[];
 };
 
+type ErrorResponseDetails = {
+  code: number;
+  messages: string[];
+};
+
 export type APIErrorResponse = {
   code: number;
   duration: string;
   message: string;
   more_info: string;
   StatusCode: number;
+  details?: ErrorResponseDetails;
 };
 
 export class ErrorFromResponse<T> extends Error {


### PR DESCRIPTION
## Goal

Add type definition to NNBB related field `details` on error response.
