### PR TITLE
fix(types): added support for thumb_url for video attachments in send file response

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -593,7 +593,9 @@ export type SearchWarning = {
   warning_code: number;
   warning_description: string;
 };
-export type SendFileAPIResponse = APIResponse & { file: string };
+
+// Thumb URL(thumb_url) is added considering video attachments as the backend will return the thumbnail in the response.
+export type SendFileAPIResponse = APIResponse & { file: string; thumb_url?: string };
 
 export type SendMessageAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
   message: MessageResponse<StreamChatGenerics>;


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why, and How?

This PR adds the type of `thumb_url` for the response returned when a video file is uploaded to Stream CDN. The `thumb_url` is the URL of the thumbnail of the video generated and sent by the backend.

## Changelog

- Added `thumb_url` to `SendFileAPIResponse` types.
