### PR TITLE
fix(Channel): add "truncated_at" to "channel.truncated" event handler 

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1245,7 +1245,17 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         }
         break;
       case 'channel.truncated':
-        channelState.clearMessages();
+        if (event.channel && event.channel.truncated_at) {
+          const truncated_at = event.channel.truncated_at;
+          channelState.messageSets
+            .flatMap((ms) => ms.messages)
+            .forEach((m) => {
+              if (+new Date(truncated_at) > +m.created_at) channelState.removeMessage({ id: m.id });
+            });
+        } else {
+          channelState.clearMessages();
+        }
+
         channelState.unreadCount = 0;
         // system messages don't increment unread counts
         if (event.message) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1245,12 +1245,13 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         }
         break;
       case 'channel.truncated':
-        if (event.channel && event.channel.truncated_at) {
-          const truncated_at = event.channel.truncated_at;
+        if (event.channel?.truncated_at) {
+          const truncatedAt = +new Date(event.channel.truncated_at);
+
           channelState.messageSets
             .flatMap((ms) => ms.messages)
-            .forEach((m) => {
-              if (+new Date(truncated_at) > +m.created_at) channelState.removeMessage({ id: m.id });
+            .forEach(({ created_at: createdAt, id }) => {
+              if (truncatedAt > +createdAt) channelState.removeMessage({ id });
             });
         } else {
           channelState.clearMessages();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1248,11 +1248,11 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         if (event.channel?.truncated_at) {
           const truncatedAt = +new Date(event.channel.truncated_at);
 
-          channelState.messageSets
-            .flatMap((ms) => ms.messages)
-            .forEach(({ created_at: createdAt, id }) => {
-              if (truncatedAt > +createdAt) channelState.removeMessage({ id });
+          channelState.messageSets.forEach((messageSet, messageSetIndex) => {
+            messageSet.messages.forEach(({ created_at: createdAt, id }) => {
+              if (truncatedAt > +createdAt) channelState.removeMessage({ id, messageSetIndex });
             });
+          });
         } else {
           channelState.clearMessages();
         }

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -495,7 +495,7 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
    *
    * @return {boolean} Returns if the message was removed
    */
-  removeMessage(messageToRemove: { id: string; parent_id?: string }) {
+  removeMessage(messageToRemove: { id: string; messageSetIndex?: number; parent_id?: string }) {
     let isRemoved = false;
     if (messageToRemove.parent_id && this.threads[messageToRemove.parent_id]) {
       const { removed, result: threadMessages } = this.removeMessageFromArray(
@@ -506,7 +506,7 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
       this.threads[messageToRemove.parent_id] = threadMessages;
       isRemoved = removed;
     } else {
-      const messageSetIndex = this.findMessageSetIndex(messageToRemove);
+      const messageSetIndex = messageToRemove.messageSetIndex ?? this.findMessageSetIndex(messageToRemove);
       if (messageSetIndex !== -1) {
         const { removed, result: messages } = this.removeMessageFromArray(
           this.messageSets[messageSetIndex].messages,

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -161,13 +161,17 @@ describe('Channel count unread', function () {
 
 describe('Channel _handleChannelEvent', function () {
 	const user = { id: 'user' };
-	const client = new StreamChat('apiKey');
-	client.user = user;
-	client.userID = user.id;
-	client.userMuteStatus = (targetId) => targetId.startsWith('mute');
+	let client;
+	let channel;
 
-	const channel = client.channel('messaging', 'id');
-	channel.initialized = true;
+	beforeEach(() => {
+		client = new StreamChat('apiKey');
+		client.user = user;
+		client.userID = user.id;
+		client.userMuteStatus = (targetId) => targetId.startsWith('mute');
+		channel = client.channel('messaging', 'id');
+		channel.initialized = true;
+	});
 
 	it('message.new reset the unreadCount for current user messages', function () {
 		channel.state.unreadCount = 100;
@@ -218,6 +222,48 @@ describe('Channel _handleChannelEvent', function () {
 		expect(channel.state.unreadCount).to.be.equal(30);
 	});
 
+	it('message.truncate removes all messages if "truncated_at" is "now"', function () {
+		const messages = [
+			{ created_at: '2021-01-01T00:01:00' },
+			{ created_at: '2021-01-01T00:02:00' },
+			{ created_at: '2021-01-01T00:03:00' },
+		].map(generateMsg);
+
+		channel.state.addMessagesSorted(messages);
+		expect(channel.state.messages.length).to.be.equal(3);
+
+		channel._handleChannelEvent({
+			type: 'channel.truncated',
+			user: { id: 'id' },
+			channel: {
+				truncated_at: new Date().toISOString(),
+			},
+		});
+
+		expect(channel.state.messages.length).to.be.equal(0);
+	});
+
+	it('message.truncate removes messages up to specified date', function () {
+		const messages = [
+			{ created_at: '2021-01-01T00:01:00' },
+			{ created_at: '2021-01-01T00:02:00' },
+			{ created_at: '2021-01-01T00:03:00' },
+		].map(generateMsg);
+
+		channel.state.addMessagesSorted(messages);
+		expect(channel.state.messages.length).to.be.equal(3);
+
+		channel._handleChannelEvent({
+			type: 'channel.truncated',
+			user: { id: 'id' },
+			channel: {
+				truncated_at: messages[1].created_at,
+			},
+		});
+
+		expect(channel.state.messages.length).to.be.equal(2);
+	});
+
 	it('message.delete removes quoted messages references', function () {
 		const originalMessage = generateMsg({ silent: true });
 		channel._handleChannelEvent({
@@ -248,8 +294,6 @@ describe('Channel _handleChannelEvent', function () {
 	});
 
 	it('should include unread_messages for message events from another user', () => {
-		const channel = client.channel('messaging', 'id');
-		channel.initialized = true;
 		channel.state.read['id'] = {
 			unread_messages: 2,
 		};
@@ -278,9 +322,6 @@ describe('Channel _handleChannelEvent', function () {
 	});
 
 	it('should include unread_messages for message events from the current user', () => {
-		const channel = client.channel('messaging', 'id');
-
-		channel.initialized = true;
 		channel.state.read[client.user.id] = {
 			unread_messages: 2,
 		};
@@ -298,7 +339,10 @@ describe('Channel _handleChannelEvent', function () {
 		];
 
 		for (const event of events) {
-			channel.state.read['id'].unread_messages = 2;
+			channel.state.read['id'] = {
+				unread_messages: 2,
+			};
+
 			channel._handleChannelEvent({
 				type: event,
 				user: { id: client.user.id },


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Calling `channel.truncate` with `truncated_at` option would remove all of the messages within the channel state completely disregarding this option - added fix which removes messages up to specified timestamp as stated [in the documentation](https://getstream.io/chat/docs/node/truncate_channel/?language=javascript).
