### PR TITLE
feat: add `cdn_expiration_seconds` to the App settings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -105,6 +105,7 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
     auto_translation_enabled?: boolean;
     before_message_send_hook_url?: string;
     campaign_enabled?: boolean;
+    cdn_expiration?: number;
     custom_action_handler_url?: string;
     disable_auth_checks?: boolean;
     disable_permissions_checks?: boolean;
@@ -1451,6 +1452,7 @@ export type AppSettings = {
   };
   async_url_enrich_enabled?: boolean;
   auto_translation_enabled?: boolean;
+  cdn_expiration?: number;
   custom_action_handler_url?: string;
   disable_auth_checks?: boolean;
   disable_permissions_checks?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,7 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
     auto_translation_enabled?: boolean;
     before_message_send_hook_url?: string;
     campaign_enabled?: boolean;
-    cdn_expiration?: number;
+    cdn_expiration_seconds?: number;
     custom_action_handler_url?: string;
     disable_auth_checks?: boolean;
     disable_permissions_checks?: boolean;
@@ -1452,7 +1452,7 @@ export type AppSettings = {
   };
   async_url_enrich_enabled?: boolean;
   auto_translation_enabled?: boolean;
-  cdn_expiration?: number;
+  cdn_expiration_seconds?: number;
   custom_action_handler_url?: string;
   disable_auth_checks?: boolean;
   disable_permissions_checks?: boolean;


### PR DESCRIPTION
## Changelog

- Add `cdn_expiration_seconds` to the App settings
