### PR TITLE
fix: pinnedMesages truncated_at aware

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1265,6 +1265,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
               if (truncatedAt > +createdAt) channelState.removeMessage({ id, messageSetIndex });
             });
           });
+
+          channelState.pinnedMessages.forEach(({ id, created_at: createdAt }) => {
+            if (truncatedAt > +createdAt) channelState.removePinnedMessage({ id });
+          });
         } else {
           channelState.clearMessages();
         }

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -264,6 +264,30 @@ describe('Channel _handleChannelEvent', function () {
 		expect(channel.state.messages.length).to.be.equal(2);
 	});
 
+	it('message.truncate removes pinned messages up to specified date', function () {
+		const messages = [
+			{ created_at: '2021-01-01T00:01:00', pinned: true, pinned_at: new Date('2021-01-01T00:01:01.010Z') },
+			{ created_at: '2021-01-01T00:02:00' },
+			{ created_at: '2021-01-01T00:03:00', pinned: true, pinned_at: new Date('2021-01-01T00:02:02.011Z') },
+		].map(generateMsg);
+
+		channel.state.addMessagesSorted(messages);
+		channel.state.addPinnedMessages(messages.filter((m) => m.pinned));
+		expect(channel.state.messages.length).to.be.equal(3);
+		expect(channel.state.pinnedMessages.length).to.be.equal(2);
+
+		channel._handleChannelEvent({
+			type: 'channel.truncated',
+			user: { id: 'id' },
+			channel: {
+				truncated_at: messages[1].created_at,
+			},
+		});
+
+		expect(channel.state.messages.length).to.be.equal(2);
+		expect(channel.state.pinnedMessages.length).to.be.equal(1);
+	});
+
 	it('message.delete removes quoted messages references', function () {
 		const originalMessage = generateMsg({ silent: true });
 		channel._handleChannelEvent({


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Extends #991 `truncated_at` functionality for `pinnedMessages`.