### PR TITLE
[Campaign] Hide resumeCampaign method

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2783,17 +2783,18 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     return campaign;
   }
 
-  /**
-   * resumeCampaign - Resume a Campaign
-   *
-   * @param {string} id Campaign ID
-   *
-   * @return {Campaign} Resumed Campaign
-   */
-  async resumeCampaign(id: string) {
-    const { campaign } = await this.patch<{ campaign: Campaign }>(this.baseURL + `/campaigns/${id}/resume`);
-    return campaign;
-  }
+  // This is commented because feature is not supported for now.
+  // /**
+  //  * resumeCampaign - Resume a Campaign
+  //  *
+  //  * @param {string} id Campaign ID
+  //  *
+  //  * @return {Campaign} Resumed Campaign
+  //  */
+  // async resumeCampaign(id: string) {
+  //   const { campaign } = await this.patch<{ campaign: Campaign }>(this.baseURL + `/campaigns/${id}/resume`);
+  //   return campaign;
+  // }
 
   /**
    * testCampaign - Test a Campaign

--- a/src/types.ts
+++ b/src/types.ts
@@ -1853,7 +1853,7 @@ export type EndpointName =
   | 'DeleteCampaign'
   | 'ScheduleCampaign'
   | 'StopCampaign'
-  | 'ResumeCampaign'
+  // | 'ResumeCampaign'
   | 'TestCampaign'
   | 'GetOG'
   | 'GetTask'


### PR DESCRIPTION
This PR hides `resumeCampaign` method as it is not supported for now.