### PR TITLE
feat!: separate local events and server events

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,7 +16,7 @@ import {
   DeleteChannelAPIResponse,
   Event,
   EventAPIResponse,
-  EventHandler,
+  EventHandlerInferred,
   EventTypes,
   FormatMessageResponse,
   GetMultipleMessagesAPIResponse,
@@ -65,7 +65,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics> | undefined;
   _data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics>;
   cid: string;
-  listeners: { [key: string]: (string | EventHandler<StreamChatGenerics>)[] };
+  listeners: { [key: string]: (string | ((event: Event<StreamChatGenerics>) => void))[] };
   state: ChannelState<StreamChatGenerics>;
   initialized: boolean;
   lastKeyStroke?: Date;
@@ -1099,11 +1099,11 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {EventHandler<StreamChatGenerics> | EventTypes} callbackOrString  The event type to listen for (optional)
    * @param {EventHandler<StreamChatGenerics>} [callbackOrNothing] The callback to call
    */
-  on(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on(
-    callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
-    callbackOrNothing?: EventHandler<StreamChatGenerics>,
+  on<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): { unsubscribe: () => void };
+  on<T extends Event['type']>(callback: EventHandlerInferred<T>): { unsubscribe: () => void };
+  on<T extends Event['type']>(
+    callbackOrString: EventHandlerInferred<T> | T,
+    callbackOrNothing?: EventHandlerInferred<T>,
   ): { unsubscribe: () => void } {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
@@ -1119,7 +1119,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       channel: this,
     });
 
-    this.listeners[key].push(callback);
+    this.listeners[key].push(callback as string | ((event: Event<StreamChatGenerics>) => void));
 
     return {
       unsubscribe: () => {
@@ -1137,13 +1137,13 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * off - Remove the event handler
    *
    */
-  off(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): void;
-  off(callback: EventHandler<StreamChatGenerics>): void;
-  off(
-    callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
-    callbackOrNothing?: EventHandler<StreamChatGenerics>,
+  off<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): void;
+  off<T extends Event['type']>(callback: EventHandlerInferred<T>): void;
+  off<T extends Event['type']>(
+    callbackOrString: EventHandlerInferred<T> | EventTypes,
+    callbackOrNothing?: EventHandlerInferred<T>,
   ): void {
-    const key = callbackOrNothing ? (callbackOrString as string) : 'all';
+    const key = callbackOrNothing ? (callbackOrString as T) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1106,7 +1106,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {EventHandler<StreamChatGenerics> | EventTypes} callbackOrString  The event type to listen for (optional)
    * @param {EventHandler<StreamChatGenerics>} [callbackOrNothing] The callback to call
    */
-  on<EventType extends Event['type']>(
+  on<EventType extends Event<StreamChatGenerics>['type']>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): { unsubscribe: () => void };
@@ -1147,7 +1147,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * off - Remove the event handler
    *
    */
-  off<EventType extends Event['type']>(
+  off<EventType extends Event<StreamChatGenerics>['type']>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): void;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1099,7 +1099,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {EventHandler<StreamChatGenerics> | EventTypes} callbackOrString  The event type to listen for (optional)
    * @param {EventHandler<StreamChatGenerics>} [callbackOrNothing] The callback to call
    */
-  on(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
+  on<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+    eventType: EventType,
+    callback: (event: InferredEvent) => void,
+  ): { unsubscribe: () => void };
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
   on(
     callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
@@ -1138,7 +1141,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    *
    */
   off(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): void;
-  off(callback: EventHandler<StreamChatGenerics>): void;
+  off<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+    eventType: EventType,
+    callback: (event: InferredEvent) => void,
+  ): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1147,11 +1147,11 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * off - Remove the event handler
    *
    */
-  off(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): void;
   off<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
     eventType: EventType,
     callback: (event: InferredEvent) => void,
   ): void;
+  off(callback: EventHandler<StreamChatGenerics>): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,
@@ -1468,6 +1468,13 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   _extendEventWithOwnReactions(event: Event<StreamChatGenerics>) {
+    if (
+      event.type === 'connection.changed' ||
+      event.type === 'connection.recovered' ||
+      event.type === 'transport.changed'
+    ) {
+      return;
+    }
     if (!event.message) {
       return;
     }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,6 +1,6 @@
 import { ChannelState } from './channel_state';
 import { isValidEventType } from './events';
-import { logChatPromiseExecution, normalizeQuerySort } from './utils';
+import { isLocalEvent, logChatPromiseExecution, normalizeQuerySort } from './utils';
 import { StreamChat } from './client';
 import {
   APIResponse,
@@ -1342,12 +1342,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     }
 
     // any event can send over the online count
-    if (
-      event.type !== 'connection.changed' &&
-      event.type !== 'connection.recovered' &&
-      event.type !== 'transport.changed' &&
-      event.watcher_count
-    ) {
+    if (!isLocalEvent(event) && event.watcher_count) {
       channel.state.watcher_count = event.watcher_count;
     }
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1466,11 +1466,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   _extendEventWithOwnReactions(event: Event<StreamChatGenerics>) {
-    if (
-      event.type === 'connection.changed' ||
-      event.type === 'connection.recovered' ||
-      event.type === 'transport.changed'
-    ) {
+    if (isLocalEvent(event)) {
       return;
     }
     if (!event.message) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1327,7 +1327,12 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     }
 
     // any event can send over the online count
-    if (event.watcher_count !== undefined) {
+    if (
+      event.type !== 'connection.changed' &&
+      event.type !== 'connection.recovered' &&
+      event.type !== 'transport.changed' &&
+      event.watcher_count
+    ) {
       channel.state.watcher_count = event.watcher_count;
     }
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,7 +16,7 @@ import {
   DeleteChannelAPIResponse,
   Event,
   EventAPIResponse,
-  EventHandlerInferred,
+  EventHandler,
   EventTypes,
   FormatMessageResponse,
   GetMultipleMessagesAPIResponse,
@@ -65,7 +65,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics> | undefined;
   _data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics>;
   cid: string;
-  listeners: { [key: string]: (string | ((event: Event<StreamChatGenerics>) => void))[] };
+  listeners: { [key: string]: (string | EventHandler<StreamChatGenerics>)[] };
   state: ChannelState<StreamChatGenerics>;
   initialized: boolean;
   lastKeyStroke?: Date;
@@ -1099,11 +1099,11 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {EventHandler<StreamChatGenerics> | EventTypes} callbackOrString  The event type to listen for (optional)
    * @param {EventHandler<StreamChatGenerics>} [callbackOrNothing] The callback to call
    */
-  on<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): { unsubscribe: () => void };
-  on<T extends Event['type']>(callback: EventHandlerInferred<T>): { unsubscribe: () => void };
-  on<T extends Event['type']>(
-    callbackOrString: EventHandlerInferred<T> | T,
-    callbackOrNothing?: EventHandlerInferred<T>,
+  on(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
+  on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
+  on(
+    callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
+    callbackOrNothing?: EventHandler<StreamChatGenerics>,
   ): { unsubscribe: () => void } {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
@@ -1119,7 +1119,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       channel: this,
     });
 
-    this.listeners[key].push(callback as string | ((event: Event<StreamChatGenerics>) => void));
+    this.listeners[key].push(callback);
 
     return {
       unsubscribe: () => {
@@ -1137,13 +1137,13 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * off - Remove the event handler
    *
    */
-  off<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): void;
-  off<T extends Event['type']>(callback: EventHandlerInferred<T>): void;
-  off<T extends Event['type']>(
-    callbackOrString: EventHandlerInferred<T> | EventTypes,
-    callbackOrNothing?: EventHandlerInferred<T>,
+  off(eventType: EventTypes, callback: EventHandler<StreamChatGenerics>): void;
+  off(callback: EventHandler<StreamChatGenerics>): void;
+  off(
+    callbackOrString: EventHandler<StreamChatGenerics> | EventTypes,
+    callbackOrNothing?: EventHandler<StreamChatGenerics>,
   ): void {
-    const key = callbackOrNothing ? (callbackOrString as T) : 'all';
+    const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1106,9 +1106,9 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {EventHandler<StreamChatGenerics> | EventTypes} callbackOrString  The event type to listen for (optional)
    * @param {EventHandler<StreamChatGenerics>} [callbackOrNothing] The callback to call
    */
-  on<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+  on<EventType extends Event['type']>(
     eventType: EventType,
-    callback: (event: InferredEvent) => void,
+    callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): { unsubscribe: () => void };
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
   on(
@@ -1147,9 +1147,9 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * off - Remove the event handler
    *
    */
-  off<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+  off<EventType extends Event['type']>(
     eventType: EventType,
-    callback: (event: InferredEvent) => void,
+    callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): void;
   off(callback: EventHandler<StreamChatGenerics>): void;
   off(

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -24,7 +24,7 @@ type ChannelReadStatus<StreamChatGenerics extends ExtendableGenerics = DefaultGe
 export class ChannelState<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> {
   _channel: Channel<StreamChatGenerics>;
   watcher_count: number;
-  typing: Record<string, Event<StreamChatGenerics>>;
+  typing: Record<string, Event<StreamChatGenerics, 'typing.start'>>;
   read: ChannelReadStatus<StreamChatGenerics>;
   pinnedMessages: Array<ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>>;
   pending_messages: Array<PendingMessageResponse<StreamChatGenerics>>;

--- a/src/client.ts
+++ b/src/client.ts
@@ -840,7 +840,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off(eventType: string, callback: EventHandler<StreamChatGenerics>): void;
+  off<E extends Event>(eventType: Event['type'], callback: (event: E) => void): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -23,6 +23,7 @@ import {
   sleep,
   retryInterval,
   isOnline,
+  isLocalEvent,
 } from './utils';
 
 import {
@@ -1019,12 +1020,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   dispatchEvent = (event: Event<StreamChatGenerics>) => {
     if (!event.received_at) event.received_at = new Date();
     let channel: Channel<StreamChatGenerics> | undefined = undefined;
-    if (
-      event.type !== 'connection.changed' &&
-      event.type !== 'connection.recovered' &&
-      event.type !== 'transport.changed' &&
-      event.cid
-    ) {
+
+    if (!isLocalEvent(event) && event.cid) {
       channel = this.activeChannels[event.cid];
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,7 +57,7 @@ import {
   Device,
   EndpointName,
   Event,
-  EventHandler,
+  EventHandlerInferred,
   ExportChannelOptions,
   ExportChannelRequest,
   ExportChannelResponse,
@@ -144,6 +144,7 @@ import {
   GetCallTokenResponse,
   APIErrorResponse,
   ErrorFromResponse,
+  EventInferred,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -810,23 +811,23 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    * @return {{ unsubscribe: () => void }} Description
    */
-  on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<E extends Event>(eventType: E['type'], callback: (event: E) => void): { unsubscribe: () => void };
-  on(
-    callbackOrString: EventHandler<StreamChatGenerics> | string,
-    callbackOrNothing?: EventHandler<StreamChatGenerics>,
+  on<T extends Event['type']>(callback: EventHandlerInferred<T>): { unsubscribe: () => void };
+  on<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): { unsubscribe: () => void };
+  on<T extends Event['type']>(
+    callbackOrString: EventHandlerInferred<T> | Event['type'],
+    callbackOrNothing?: EventHandlerInferred<T>,
   ): { unsubscribe: () => void } {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);
     }
-    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandler<StreamChatGenerics>);
+    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandlerInferred<T>);
     if (!(key in this.listeners)) {
       this.listeners[key] = [];
     }
     this.logger('info', `Attaching listener for ${key} event`, { tags: ['event', 'client'] });
-    this.listeners[key].push(callback);
+    this.listeners[key].push(callback as (event: Event<StreamChatGenerics>) => void);
     return {
       unsubscribe: () => {
         this.logger('info', `Removing listener for ${key} event`, { tags: ['event', 'client'] });
@@ -839,18 +840,18 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * off - Remove the event handler
    *
    */
-  off(callback: EventHandler<StreamChatGenerics>): void;
-  off<E extends Event>(eventType: E['type'], callback: (event: E) => void): void;
-  off(
-    callbackOrString: EventHandler<StreamChatGenerics> | string,
-    callbackOrNothing?: EventHandler<StreamChatGenerics>,
+  off<T extends Event['type']>(callback: EventHandlerInferred<T>): void;
+  off<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): void;
+  off<T extends Event['type']>(
+    callbackOrString: EventHandlerInferred<T> | T,
+    callbackOrNothing?: EventHandlerInferred<T>,
   ) {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);
     }
-    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandler<StreamChatGenerics>);
+    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandlerInferred<T>);
     if (!(key in this.listeners)) {
       this.listeners[key] = [];
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -811,7 +811,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<E extends Event>(eventType: Event['type'], callback: (event: E) => void): { unsubscribe: () => void };
+  on<E extends Event>(eventType: E['type'], callback: (event: E) => void): { unsubscribe: () => void };
   on(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,
@@ -840,7 +840,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<E extends Event>(eventType: Event['type'], callback: (event: E) => void): void;
+  off<E extends Event>(eventType: E['type'], callback: (event: E) => void): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -811,7 +811,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<E extends Event>(eventType: E['type'], callback: (event: E) => void): { unsubscribe: () => void };
+  on<EventType extends Event["type"], InferredEvent extends Extract<Event, { type: EventType }>>(eventType: EventType, callback: (event: InferredEvent) => void): { unsubscribe: () => void };
   on(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,
@@ -840,7 +840,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<E extends Event>(eventType: E['type'], callback: (event: E) => void): void;
+  off<EventType extends Event["type"], InferredEvent extends Extract<Event, { type: EventType }>>(eventType: EventType, callback: (event: InferredEvent) => void): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -813,9 +813,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+  on<EventType extends Event['type']>(
     eventType: EventType,
-    callback: (event: InferredEvent) => void,
+    callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): { unsubscribe: () => void };
   on(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
@@ -845,9 +845,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+  off<EventType extends Event['type']>(
     eventType: EventType,
-    callback: (event: InferredEvent) => void,
+    callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | string,

--- a/src/client.ts
+++ b/src/client.ts
@@ -811,7 +811,10 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<EventType extends Event["type"], InferredEvent extends Extract<Event, { type: EventType }>>(eventType: EventType, callback: (event: InferredEvent) => void): { unsubscribe: () => void };
+  on<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+    eventType: EventType,
+    callback: (event: InferredEvent) => void,
+  ): { unsubscribe: () => void };
   on(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,
@@ -840,7 +843,10 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<EventType extends Event["type"], InferredEvent extends Extract<Event, { type: EventType }>>(eventType: EventType, callback: (event: InferredEvent) => void): void;
+  off<EventType extends Event['type'], InferredEvent extends Extract<Event, { type: EventType }>>(
+    eventType: EventType,
+    callback: (event: InferredEvent) => void,
+  ): void;
   off(
     callbackOrString: EventHandler<StreamChatGenerics> | string,
     callbackOrNothing?: EventHandler<StreamChatGenerics>,

--- a/src/client.ts
+++ b/src/client.ts
@@ -147,6 +147,7 @@ import {
   ErrorFromResponse,
   SyncOptions,
   SyncResponse,
+  ServerEvent,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -814,7 +815,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<EventType extends Event<StreamChatGenerics>['type']>(
+  on<EventType extends Event<StreamChatGenerics>['type'] | 'all'>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): { unsubscribe: () => void };
@@ -846,7 +847,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<EventType extends Event<StreamChatGenerics>['type']>(
+  off<EventType extends Event<StreamChatGenerics>['type'] | 'all'>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): void;
@@ -1030,13 +1031,13 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
     // channel event handlers
     if (channel) {
-      channel._handleChannelEvent(event);
+      channel._handleChannelEvent(event as ServerEvent<StreamChatGenerics>);
     }
 
     this._callClientListeners(event);
 
     if (channel) {
-      channel._callChannelListeners(event);
+      channel._callChannelListeners(event as ServerEvent<StreamChatGenerics>);
     }
 
     postListenerCallbacks.forEach((c) => c());

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,7 +57,7 @@ import {
   Device,
   EndpointName,
   Event,
-  EventHandlerInferred,
+  EventHandler,
   ExportChannelOptions,
   ExportChannelRequest,
   ExportChannelResponse,
@@ -144,7 +144,6 @@ import {
   GetCallTokenResponse,
   APIErrorResponse,
   ErrorFromResponse,
-  EventInferred,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -811,23 +810,23 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    * @return {{ unsubscribe: () => void }} Description
    */
-  on<T extends Event['type']>(callback: EventHandlerInferred<T>): { unsubscribe: () => void };
-  on<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): { unsubscribe: () => void };
-  on<T extends Event['type']>(
-    callbackOrString: EventHandlerInferred<T> | Event['type'],
-    callbackOrNothing?: EventHandlerInferred<T>,
+  on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
+  on<E extends Event>(eventType: E['type'], callback: (event: E) => void): { unsubscribe: () => void };
+  on(
+    callbackOrString: EventHandler<StreamChatGenerics> | string,
+    callbackOrNothing?: EventHandler<StreamChatGenerics>,
   ): { unsubscribe: () => void } {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);
     }
-    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandlerInferred<T>);
+    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandler<StreamChatGenerics>);
     if (!(key in this.listeners)) {
       this.listeners[key] = [];
     }
     this.logger('info', `Attaching listener for ${key} event`, { tags: ['event', 'client'] });
-    this.listeners[key].push(callback as (event: Event<StreamChatGenerics>) => void);
+    this.listeners[key].push(callback);
     return {
       unsubscribe: () => {
         this.logger('info', `Removing listener for ${key} event`, { tags: ['event', 'client'] });
@@ -840,18 +839,18 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * off - Remove the event handler
    *
    */
-  off<T extends Event['type']>(callback: EventHandlerInferred<T>): void;
-  off<T extends Event['type']>(eventType: T, callback: EventHandlerInferred<T>): void;
-  off<T extends Event['type']>(
-    callbackOrString: EventHandlerInferred<T> | T,
-    callbackOrNothing?: EventHandlerInferred<T>,
+  off(callback: EventHandler<StreamChatGenerics>): void;
+  off<E extends Event>(eventType: E['type'], callback: (event: E) => void): void;
+  off(
+    callbackOrString: EventHandler<StreamChatGenerics> | string,
+    callbackOrNothing?: EventHandler<StreamChatGenerics>,
   ) {
     const key = callbackOrNothing ? (callbackOrString as string) : 'all';
     const valid = isValidEventType(key);
     if (!valid) {
       throw Error(`Invalid event type ${key}`);
     }
-    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandlerInferred<T>);
+    const callback = callbackOrNothing ? callbackOrNothing : (callbackOrString as EventHandler<StreamChatGenerics>);
     if (!(key in this.listeners)) {
       this.listeners[key] = [];
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -814,7 +814,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ unsubscribe: () => void }} Description
    */
   on(callback: EventHandler<StreamChatGenerics>): { unsubscribe: () => void };
-  on<EventType extends Event['type']>(
+  on<EventType extends Event<StreamChatGenerics>['type']>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): { unsubscribe: () => void };
@@ -846,7 +846,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    *
    */
   off(callback: EventHandler<StreamChatGenerics>): void;
-  off<EventType extends Event['type']>(
+  off<EventType extends Event<StreamChatGenerics>['type']>(
     eventType: EventType,
     callback: (event: Event<StreamChatGenerics, EventType>) => void,
   ): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,4 +10,4 @@ export * from './signing';
 export * from './token_manager';
 export * from './insights';
 export * from './types';
-export { isOwnUser, chatCodes, logChatPromiseExecution } from './utils';
+export { isOwnUser, chatCodes, logChatPromiseExecution, isLocalEvent, isServerEvent } from './utils';

--- a/src/types.ts
+++ b/src/types.ts
@@ -975,8 +975,6 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   | (StreamChatGenerics['eventType'] & ServerEvent<StreamChatGenerics>)
   | (LocalEvent & { received_at?: string | Date });
 
-export type EventInferred<T extends Event['type']> = Event & { type: T };
-
 export type UserCustomEvent<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = StreamChatGenerics['eventType'] & {
@@ -986,7 +984,6 @@ export type UserCustomEvent<
 export type EventHandler<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = (
   event: Event<StreamChatGenerics>,
 ) => void;
-export type EventHandlerInferred<T extends Event['type']> = (event: EventInferred<T>) => void;
 
 export type EventTypes = 'all' | keyof typeof EVENT_MAP;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -969,7 +969,7 @@ type TransportChangedLocalEvent = {
 export type LocalEvent = ConnectionChangedLocalEvent | ConnectionRecoveredLocalEvent | TransportChangedLocalEvent;
 
 export type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
-  type: Exclude<EventTypes, LocalEvent['type']>;
+  type: Exclude<EventTypes, LocalEvent['type'] | 'all'>;
   channel?: ChannelResponse<StreamChatGenerics>;
   channel_id?: string;
   channel_type?: string;
@@ -1013,11 +1013,22 @@ export type Event<
     >
   : T extends ServerEvent['type']
   ? ServerEvent<StreamChatGenerics>
+  : T extends 'all'
+  ?
+      | ServerEvent<StreamChatGenerics>
+      | (LocalEvent & {
+          received_at?: string | Date;
+        })
   : UserCustomEvent<StreamChatGenerics>;
 
-export type EventHandler<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = (
-  event: Event<StreamChatGenerics>,
+export type ServerEventHandler<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = (
+  event: ServerEvent<StreamChatGenerics>,
 ) => void;
+
+export type EventHandler<
+  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics,
+  T extends string = EventTypes
+> = (event: Event<StreamChatGenerics, T>) => void;
 
 export type EventTypes = 'all' | keyof typeof EVENT_MAP;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -975,6 +975,8 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   | (StreamChatGenerics['eventType'] & ServerEvent<StreamChatGenerics>)
   | (LocalEvent & { received_at?: string | Date });
 
+export type EventInferred<T extends Event['type']> = Event & { type: T };
+
 export type UserCustomEvent<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = StreamChatGenerics['eventType'] & {
@@ -984,6 +986,7 @@ export type UserCustomEvent<
 export type EventHandler<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = (
   event: Event<StreamChatGenerics>,
 ) => void;
+export type EventHandlerInferred<T extends Event['type']> = (event: EventInferred<T>) => void;
 
 export type EventTypes = 'all' | keyof typeof EVENT_MAP;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -966,9 +966,9 @@ type TransportChangedLocalEvent = {
   type: 'transport.changed';
 };
 
-type LocalEvent = ConnectionChangedLocalEvent | ConnectionRecoveredLocalEvent | TransportChangedLocalEvent;
+export type LocalEvent = ConnectionChangedLocalEvent | ConnectionRecoveredLocalEvent | TransportChangedLocalEvent;
 
-type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
+export type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   type: Exclude<EventTypes, LocalEvent['type']>;
   channel?: ChannelResponse<StreamChatGenerics>;
   channel_id?: string;
@@ -994,6 +994,7 @@ type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
   watcher_count?: number;
 };
 
+// either a local-event or a server-event or a user-custom-event
 export type Event<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics,
   T extends string = EventTypes

--- a/src/types.ts
+++ b/src/types.ts
@@ -929,13 +929,24 @@ export type UserOptions = {
  * Event Types
  */
 
-export type ConnectionChangeEvent = {
-  type: EventTypes;
-  online?: boolean;
+type ConnectionChangedLocalEvent = {
+  online: boolean;
+  type: 'connection.changed';
 };
 
-export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = StreamChatGenerics['eventType'] & {
-  type: EventTypes;
+type ConnectionRecoveredLocalEvent = {
+  type: 'connection.recovered';
+};
+
+type TransportChangedLocalEvent = {
+  mode: 'ws' | 'longpoll';
+  type: 'transport.changed';
+};
+
+type LocalEvent = ConnectionChangedLocalEvent | ConnectionRecoveredLocalEvent | TransportChangedLocalEvent;
+
+type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
+  type: Exclude<EventTypes, LocalEvent['type']>;
   channel?: ChannelResponse<StreamChatGenerics>;
   channel_id?: string;
   channel_type?: string;
@@ -948,7 +959,6 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   me?: OwnUserResponse<StreamChatGenerics>;
   member?: ChannelMemberResponse<StreamChatGenerics>;
   message?: MessageResponse<StreamChatGenerics>;
-  online?: boolean;
   parent_id?: string;
   reaction?: ReactionResponse<StreamChatGenerics>;
   received_at?: string | Date;
@@ -960,6 +970,10 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   user_id?: string;
   watcher_count?: number;
 };
+
+export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
+  | (StreamChatGenerics['eventType'] & ServerEvent<StreamChatGenerics>)
+  | (LocalEvent & { received_at?: string | Date });
 
 export type UserCustomEvent<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics

--- a/src/types.ts
+++ b/src/types.ts
@@ -994,9 +994,21 @@ type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
   watcher_count?: number;
 };
 
-export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
-  | (StreamChatGenerics['eventType'] & ServerEvent<StreamChatGenerics>)
-  | (LocalEvent & { received_at?: string | Date });
+export type Event<
+  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics,
+  T extends string = EventTypes
+> = T extends LocalEvent['type']
+  ? Extract<
+      LocalEvent & {
+        received_at?: string | Date;
+      },
+      { type: T }
+    >
+  : T extends ServerEvent['type']
+  ? ServerEvent<StreamChatGenerics>
+  : StreamChatGenerics['eventType'] & {
+      type: T;
+    };
 
 export type UserCustomEvent<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics

--- a/src/types.ts
+++ b/src/types.ts
@@ -994,6 +994,12 @@ export type ServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultG
   watcher_count?: number;
 };
 
+export type UserCustomEvent<
+  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
+> = StreamChatGenerics['eventType'] & {
+  type: string;
+};
+
 // either a local-event or a server-event or a user-custom-event
 export type Event<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics,
@@ -1007,15 +1013,7 @@ export type Event<
     >
   : T extends ServerEvent['type']
   ? ServerEvent<StreamChatGenerics>
-  : StreamChatGenerics['eventType'] & {
-      type: T;
-    };
-
-export type UserCustomEvent<
-  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
-> = StreamChatGenerics['eventType'] & {
-  type: string;
-};
+  : UserCustomEvent<StreamChatGenerics>;
 
 export type EventHandler<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = (
   event: Event<StreamChatGenerics>,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function isLocalEvent<StreamChatGenerics extends ExtendableGenerics = Def
   event: StreamEvent<StreamChatGenerics>,
 ): event is StreamEvent<StreamChatGenerics, StreamLocalEvent['type']> {
   return (
-    event.type !== 'connection.changed' && event.type !== 'connection.recovered' && event.type !== 'transport.changed'
+    event.type === 'connection.changed' || event.type === 'connection.recovered' || event.type === 'transport.changed'
   );
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
   UserResponse,
   Event as StreamEvent,
   LocalEvent as StreamLocalEvent,
+  ServerEvent,
 } from './types';
 
 /**
@@ -75,6 +76,12 @@ export function isLocalEvent<StreamChatGenerics extends ExtendableGenerics = Def
   return (
     event.type === 'connection.changed' || event.type === 'connection.recovered' || event.type === 'transport.changed'
   );
+}
+
+export function isServerEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics>(
+  event: StreamEvent<StreamChatGenerics>,
+): event is StreamEvent<StreamChatGenerics, ServerEvent['type']> {
+  return !isLocalEvent(event);
 }
 
 function isBlobWebAPI(uri: unknown): uri is Blob {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,14 @@
 import FormData from 'form-data';
-import { AscDesc, ExtendableGenerics, DefaultGenerics, OwnUserBase, OwnUserResponse, UserResponse } from './types';
+import {
+  AscDesc,
+  ExtendableGenerics,
+  DefaultGenerics,
+  OwnUserBase,
+  OwnUserResponse,
+  UserResponse,
+  Event as StreamEvent,
+  LocalEvent as StreamLocalEvent,
+} from './types';
 
 /**
  * logChatPromiseExecution - utility function for logging the execution of a promise..
@@ -58,6 +67,14 @@ export function isOwnUser<StreamChatGenerics extends ExtendableGenerics = Defaul
   user?: OwnUserResponse<StreamChatGenerics> | UserResponse<StreamChatGenerics>,
 ): user is OwnUserResponse<StreamChatGenerics> {
   return (user as OwnUserResponse<StreamChatGenerics>)?.total_unread_count !== undefined;
+}
+
+export function isLocalEvent<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics>(
+  event: StreamEvent<StreamChatGenerics>,
+): event is StreamEvent<StreamChatGenerics, StreamLocalEvent['type']> {
+  return (
+    event.type !== 'connection.changed' && event.type !== 'connection.recovered' && event.type !== 'transport.changed'
+  );
 }
 
 function isBlobWebAPI(uri: unknown): uri is Blob {

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -197,7 +197,6 @@ const event: Event<StreamTypes> = {
   member: { user_id: 'john' },
   user: { id: 'john', online: true },
   unread_count: 3,
-  online: true,
 };
 voidReturn = client.dispatchEvent(event);
 voidPromise = client.recoverState();


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why, and How?
When supplying event callbacks, this PR helps with stricter typing.

For example,
```
client.on('connection.changed', (event) => console.log(event.online));
// only `online` will be shown by the IDE for code-completion
```
### Breaking change

Clients of the SDK cannot use the fields directly in if statements,
For example,
```
function func(event: Event<StreamChatGenerics>) {
  // this would error out, as TS would complain that event doesn't have online field
  if (event.online) {
    console.log(event.online);
  }
  // the correct way
  if (event.type === 'connection.changed') {
    console.log(event.online)
  }
}
```
