### PR TITLE
fix: message update event overrides own reactions

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -469,13 +469,20 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
 
     // message already exists and not filtered due to timestampChanged, update and return
     if (!timestampChanged && message.id) {
+      let messageIndex;
       if (messageArr[left] && message.id === messageArr[left].id) {
-        messageArr[left] = message;
-        return [...messageArr];
+        messageIndex = left;
       }
 
       if (messageArr[left - 1] && message.id === messageArr[left - 1].id) {
-        messageArr[left - 1] = message;
+        messageIndex = left - 1;
+      }
+
+      if (messageIndex !== undefined) {
+        // own_reactions always be [] in WS events -> ignore for message updates
+        const own_reactions = messageArr[messageIndex].own_reactions;
+        message.own_reactions = own_reactions;
+        messageArr[messageIndex] = message;
         return [...messageArr];
       }
     }

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -422,6 +422,22 @@ describe('ChannelState addMessagesSorted', function () {
 		expect(thread[0].id).to.be.equal(threadReplyPreview.id);
 	});
 
+	it('should ignore own_reactions for message update', () => {
+		const state = new ChannelState();
+		state.addMessagesSorted([
+			generateMsg({
+				id: '0',
+				own_reactions: [
+					{ created_at: new Date().toISOString(), updated_at: new Date().toISOString(), type: 'wow' },
+				],
+			}),
+		]);
+		// Simulate message.update event -> own_reactions always will be an empty array
+		state.addMessageSorted({ ...state.messages[0], text: 'update', own_reactions: [] }, false, false);
+
+		expect(state.messages[0].own_reactions.length).to.be.equal(1);
+	});
+
 	describe('merges overlapping message sets', () => {
 		it('when new messages overlap with latest messages', () => {
 			const state = new ChannelState();


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

`own_reactions` isn't populated inside WS events, currently if we receive a `message.updated` event the JS client will override the existing `own_reactions` array of the message. This PR fixes that.

## Changelog

-
