### PR TITLE
feat: changes to support offline feature

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1375,7 +1375,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   };
 
   _checkInitialized() {
-    if (!this.initialized && !this.getClient()._isUsingServerAuth()) {
+    if (!this.initialized && !this.staticState && !this.getClient()._isUsingServerAuth()) {
       throw Error(
         `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve`,
       );

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -52,6 +52,7 @@ import {
   MessagePaginationOptions,
   CreateCallOptions,
   CreateCallResponse,
+  QueryChannelAPIResponse,
 } from './types';
 import { Role } from './permissions';
 
@@ -724,7 +725,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    *
    * @param {ChannelQueryOptions<StreamChatGenerics>} options additional options for the query endpoint
    *
-   * @return {Promise<ChannelAPIResponse<StreamChatGenerics>>} The server response
+   * @return {Promise<QueryChannelAPIResponse<StreamChatGenerics>>} The server response
    */
   async watch(options?: ChannelQueryOptions<StreamChatGenerics>) {
     const defaultOptions = {
@@ -923,7 +924,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   /**
    * create - Creates a new channel
    *
-   * @return {Promise<ChannelAPIResponse<StreamChatGenerics>>} The Server Response
+   * @return {Promise<QueryChannelAPIResponse<StreamChatGenerics>>} The Server Response
    */
   create = async () => {
     const options = {
@@ -940,7 +941,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {ChannelQueryOptions<StreamChatGenerics>} options The query options
    * @param {MessageSetType} messageSetToAddToIfDoesNotExist It's possible to load disjunct sets of a channel's messages into state, use `current` to load the initial channel state or if you want to extend the currently displayed messages, use `latest` if you want to load/extend the latest messages, `new` is used for loading a specific message and it's surroundings
    *
-   * @return {Promise<ChannelAPIResponse<StreamChatGenerics>>} Returns a query response
+   * @return {Promise<QueryChannelAPIResponse<StreamChatGenerics>>} Returns a query response
    */
   async query(
     options: ChannelQueryOptions<StreamChatGenerics>,
@@ -954,7 +955,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       queryURL += `/${this.id}`;
     }
 
-    const state = await this.getClient().post<ChannelAPIResponse<StreamChatGenerics>>(queryURL + '/query', {
+    const state = await this.getClient().post<QueryChannelAPIResponse<StreamChatGenerics>>(queryURL + '/query', {
       data: this._data,
       state: true,
       ...options,
@@ -1278,7 +1279,8 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           });
 
           channelState.pinnedMessages.forEach(({ id, created_at: createdAt }) => {
-            if (truncatedAt > +createdAt) channelState.removePinnedMessage({ id });
+            if (truncatedAt > +createdAt)
+              channelState.removePinnedMessage({ id } as MessageResponse<StreamChatGenerics>);
           });
         } else {
           channelState.clearMessages();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -83,7 +83,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * Indicates weather channel has been initialized by manually populating the state with some messages, members etc.
    * Static state indicates that channel exists on backend, but is not being watched yet.
    */
-  staticState: boolean;
+  offlineMode: boolean;
   lastKeyStroke?: Date;
   lastTypingEvent: Date | null;
   isTyping: boolean;
@@ -127,7 +127,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     // perhaps the state variable should be private
     this.state = new ChannelState<StreamChatGenerics>(this);
     this.initialized = false;
-    this.staticState = false;
+    this.offlineMode = false;
     this.lastTypingEvent = null;
     this.isTyping = false;
     this.disconnected = false;
@@ -1398,7 +1398,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   };
 
   _checkInitialized() {
-    if (!this.initialized && !this.staticState && !this.getClient()._isUsingServerAuth()) {
+    if (!this.initialized && !this.offlineMode && !this.getClient()._isUsingServerAuth()) {
       throw Error(
         `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve`,
       );

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -66,9 +66,23 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics> | undefined;
   _data: ChannelData<StreamChatGenerics> | ChannelResponse<StreamChatGenerics>;
   cid: string;
+  /**  */
   listeners: { [key: string]: (string | EventHandler<StreamChatGenerics>)[] };
   state: ChannelState<StreamChatGenerics>;
+  /**
+   * This boolean is a vague indication of weather the channel exists on chat backend.
+   *
+   * If the value is true, then that means the channel has been initialized by either calling
+   * channel.create() or channel.query() or channel.watch().
+   *
+   * If the value is false, then channel may or may not exist on the backend. The only way to ensure
+   * is by calling channel.create() or channel.query() or channel.watch().
+   */
   initialized: boolean;
+  /**
+   * Indicates weather channel has been initialized by manually populating the state with some messages, members etc.
+   * Static state indicates that channel exists on backend, but is not being watched yet.
+   */
   staticState: boolean;
   lastKeyStroke?: Date;
   lastTypingEvent: Date | null;
@@ -113,7 +127,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     // perhaps the state variable should be private
     this.state = new ChannelState<StreamChatGenerics>(this);
     this.initialized = false;
-    this.staticState = true;
+    this.staticState = false;
     this.lastTypingEvent = null;
     this.isTyping = false;
     this.disconnected = false;

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -241,6 +241,10 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
         this.threads[parentID] = threadMessages;
       }
     }
+
+    return {
+      messageSet: this.messageSets[targetMessageSetIndex],
+    };
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1511,12 +1511,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     for (const channelState of channelsFromApi) {
       const c = this.channel(channelState.channel.type, channelState.channel.id);
       c.data = channelState.channel;
-
-      if (staticState) {
-        c.staticState = true;
-      } else {
-        c.initialized = true;
-      }
+      c.staticState = staticState;
+      c.initialized = !staticState;
 
       if (skipInitialization === undefined) {
         c._initializeState(channelState, 'latest');

--- a/src/client.ts
+++ b/src/client.ts
@@ -144,6 +144,7 @@ import {
   GetCallTokenResponse,
   APIErrorResponse,
   ErrorFromResponse,
+  QueryChannelsAPIResponse,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 
@@ -1482,10 +1483,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       ...options,
     };
 
-    const data = await this.post<{ channels: ChannelAPIResponse<StreamChatGenerics>[] }>(
-      this.baseURL + '/channels',
-      payload,
-    );
+    const data = await this.post<QueryChannelsAPIResponse<StreamChatGenerics>>(this.baseURL + '/channels', payload);
 
     this.dispatchEvent({
       type: 'channels.queried',

--- a/src/client.ts
+++ b/src/client.ts
@@ -159,6 +159,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     [key: string]: Channel<StreamChatGenerics>;
   };
   anonymous: boolean;
+  persistUserOnConnectionFailure?: boolean;
   axiosInstance: AxiosInstance;
   baseURL?: string;
   browser: boolean;
@@ -277,6 +278,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     // mapping between channel groups and configs
     this.configs = {};
     this.anonymous = false;
+    this.persistUserOnConnectionFailure = this.options?.persistUserOnConnectionFailure;
 
     // If its a server-side client, then lets initialize the tokenManager, since token will be
     // generated from secret.
@@ -458,8 +460,12 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     try {
       return await this.setUserPromise;
     } catch (err) {
-      // cleanup client to allow the user to retry connectUser again
-      this.disconnectUser();
+      if (this.persistUserOnConnectionFailure) {
+        // cleanup client to allow the user to retry connectUser again
+        this.closeConnection();
+      } else {
+        this.disconnectUser();
+      }
       throw err;
     }
   };
@@ -485,6 +491,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
      * It contains reserved properties and own user properties which are not present in `this._user`.
      */
     this.user = user;
+    this.userID = user.id;
     // this one is actually used for requests. This is a copy of current user provided to `connectUser` function.
     this._user = { ...user };
   }
@@ -702,7 +709,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     for (const channel of Object.values(this.activeChannels)) {
       channel._disconnect();
     }
-
     // ensure we no longer return inactive channels
     this.activeChannels = {};
     // reset client state
@@ -1459,7 +1465,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     options: ChannelOptions = {},
     stateOptions: ChannelStateOptions = {},
   ) {
-    const { skipInitialization } = stateOptions;
     const defaultOptions: ChannelOptions = { state: true, watch: true, presence: false };
 
     // Make sure we wait for the connect promise if there is a pending one
@@ -1482,17 +1487,34 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       payload,
     );
 
-    const channels: Channel<StreamChatGenerics>[] = [];
+    this.dispatchEvent({
+      type: 'channels.queried',
+      queriedChannels: {
+        channels: data.channels,
+        isLatestMessageSet: true,
+      },
+    });
 
-    // update our cache of the configs
-    for (const channelState of data.channels) {
+    return this.hydrateActiveChannels(data.channels, stateOptions);
+  }
+
+  hydrateActiveChannels(
+    channelsFromApi: ChannelAPIResponse<StreamChatGenerics>[] = [],
+    stateOptions: ChannelStateOptions = {},
+  ) {
+    const { skipInitialization, staticState = false } = stateOptions;
+
+    for (const channelState of channelsFromApi) {
       this._addChannelConfig(channelState);
     }
 
-    for (const channelState of data.channels) {
+    const channels: Channel<StreamChatGenerics>[] = [];
+
+    for (const channelState of channelsFromApi) {
       const c = this.channel(channelState.channel.type, channelState.channel.id);
       c.data = channelState.channel;
       c.initialized = true;
+      c.staticState = staticState;
 
       if (skipInitialization === undefined) {
         c._initializeState(channelState, 'latest');
@@ -1503,6 +1525,18 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
       channels.push(c);
     }
+
+    if (!staticState) {
+      // If the channels are coming from server, then clear out the
+      // previously help offline channels.
+      for (const key in this.activeChannels) {
+        const channel = this.activeChannels[key];
+        if (channel.staticState) {
+          delete this.activeChannels[key];
+        }
+      }
+    }
+
     return channels;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1513,8 +1513,12 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     for (const channelState of channelsFromApi) {
       const c = this.channel(channelState.channel.type, channelState.channel.id);
       c.data = channelState.channel;
-      c.initialized = true;
-      c.staticState = staticState;
+
+      if (staticState) {
+        c.staticState = true;
+      } else {
+        c.initialized = true;
+      }
 
       if (skipInitialization === undefined) {
         c._initializeState(channelState, 'latest');

--- a/src/client.ts
+++ b/src/client.ts
@@ -1506,7 +1506,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     channelsFromApi: ChannelAPIResponse<StreamChatGenerics>[] = [],
     stateOptions: ChannelStateOptions = {},
   ) {
-    const { skipInitialization, staticState = false } = stateOptions;
+    const { skipInitialization, offlineMode = false } = stateOptions;
 
     for (const channelState of channelsFromApi) {
       this._addChannelConfig(channelState);
@@ -1517,8 +1517,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     for (const channelState of channelsFromApi) {
       const c = this.channel(channelState.channel.type, channelState.channel.id);
       c.data = channelState.channel;
-      c.staticState = staticState;
-      c.initialized = !staticState;
+      c.offlineMode = offlineMode;
+      c.initialized = !offlineMode;
 
       if (skipInitialization === undefined) {
         c._initializeState(channelState, 'latest');
@@ -1530,12 +1530,12 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       channels.push(c);
     }
 
-    if (!staticState) {
+    if (!offlineMode) {
       // If the channels are coming from server, then clear out the
       // previously help offline channels.
       for (const key in this.activeChannels) {
         const channel = this.activeChannels[key];
-        if (channel.staticState) {
+        if (channel.offlineMode) {
           delete this.activeChannels[key];
         }
       }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -253,7 +253,7 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
    * @return {ConnectAPIResponse<ChannelType, CommandType, UserType>} Promise that completes once the first health check message is received
    */
   async _connect() {
-    if (this.isConnecting || this.isDisconnected) return; // simply ignore _connect if it's currently trying to connect
+    if (this.isConnecting || (this.isDisconnected && this.client.options.enableWSFallback)) return; // simply ignore _connect if it's currently trying to connect
     this.isConnecting = true;
     this.requestID = randomId();
     this.client.insightMetrics.connectionStartTimestamp = new Date().getTime();
@@ -329,7 +329,7 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
       return;
     }
 
-    if (this.isDisconnected) {
+    if (this.isDisconnected && this.client.options.enableWSFallback) {
       this._log('_reconnect() - Abort (3) since disconnect() is called');
       return;
     }

--- a/src/events.ts
+++ b/src/events.ts
@@ -42,6 +42,7 @@ export const EVENT_MAP = {
   'user.watching.stop': true,
 
   // local events
+  'channels.queried': true,
   'connection.changed': true,
   'connection.recovered': true,
   'transport.changed': true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,7 +266,7 @@ export type ChannelResponse<
   updated_at?: string;
 };
 
-export type ChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
+export type ChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   channel: ChannelResponse<StreamChatGenerics>;
   members: ChannelMemberResponse<StreamChatGenerics>[];
   messages: MessageResponse<StreamChatGenerics>[];
@@ -494,6 +494,7 @@ export type MessageResponse<
 export type MessageResponseBase<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = MessageBase<StreamChatGenerics> & {
+  type: MessageLabel;
   args?: string;
   channel?: ChannelResponse<StreamChatGenerics>;
   cid?: string;
@@ -517,7 +518,6 @@ export type MessageResponseBase<
   silent?: boolean;
   status?: string;
   thread_participants?: UserResponse<StreamChatGenerics>[];
-  type?: MessageLabel;
   updated_at?: string;
 };
 
@@ -574,6 +574,7 @@ export type ReactionResponse<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = Reaction<StreamChatGenerics> & {
   created_at: string;
+  message_id: string;
   updated_at: string;
 };
 
@@ -722,6 +723,7 @@ export type ChannelQueryOptions<StreamChatGenerics extends ExtendableGenerics = 
 
 export type ChannelStateOptions = {
   skipInitialization?: string[];
+  staticState?: boolean;
 };
 
 export type CreateChannelOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
@@ -885,6 +887,7 @@ export type StreamChatOptions = AxiosRequestConfig & {
   /** experimental feature, please contact support if you want this feature enabled for you */
   enableWSFallback?: boolean;
   logger?: Logger;
+  persistUserOnConnectionFailure?: boolean;
   /**
    * When network is recovered, we re-query the active channels on client. But in single query, you can recover
    * only 30 channels. So its not guaranteed that all the channels in activeChannels object have updated state.
@@ -951,8 +954,13 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   me?: OwnUserResponse<StreamChatGenerics>;
   member?: ChannelMemberResponse<StreamChatGenerics>;
   message?: MessageResponse<StreamChatGenerics>;
+  mode?: string;
   online?: boolean;
   parent_id?: string;
+  queriedChannels?: {
+    channels: ChannelAPIResponse<StreamChatGenerics>[];
+    isLatestMessageSet?: boolean;
+  };
   reaction?: ReactionResponse<StreamChatGenerics>;
   received_at?: string | Date;
   team?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -741,8 +741,8 @@ export type ChannelQueryOptions<StreamChatGenerics extends ExtendableGenerics = 
 };
 
 export type ChannelStateOptions = {
+  offlineMode?: boolean;
   skipInitialization?: string[];
-  staticState?: boolean;
 };
 
 export type CreateChannelOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -266,6 +266,13 @@ export type ChannelResponse<
   updated_at?: string;
 };
 
+export type QueryChannelsAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
+  channels: Omit<ChannelAPIResponse<StreamChatGenerics>, keyof APIResponse>[];
+};
+
+export type QueryChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse &
+  ChannelAPIResponse<StreamChatGenerics>;
+
 export type ChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   channel: ChannelResponse<StreamChatGenerics>;
   members: ChannelMemberResponse<StreamChatGenerics>[];


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Purpose of this PR is to add changes to make it possible for UI SDKs to implement offline support.

## Changelog

- Added support for `persistUserOnConnectionFailure` option on client. Current we unset user and userId property if `client.connectUser` call fails and we expect customer to call connectUser again to retry. To implement offline support for UI SDKs, we need to persist user and userId even if connectUser fails.
- Added `staticState` option for Channel constructor, which represents if the channel has been initialized using static set of messages, members, read etc.
- A new local event has been introduced 'channels.queried', to let UI sdks know that one or more channels have been queried. This event will be emitted from `client.queryChannels()` and `channel.query()` calls. Payload of this event contains following two properties:
    - `channels` channels received from api call
    - `isLatestMessageSet` boolean weather latest message set has been queries or some historical one.
- Refactored some typescript around `ChannelAPIResponse`.