### PR TITLE
fix: race of query channels and ws connection

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -523,12 +523,11 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       throw Error('User is not set on client, use client.connectUser or client.connectAnonymousUser instead');
     }
 
-    if (this.wsConnection?.isConnecting) {
+    if (this.wsConnection?.isConnecting && this.wsPromise) {
       this.logger('info', 'client:openConnection() - connection already in progress', {
         tags: ['connection', 'client'],
       });
-
-      return Promise.resolve();
+      return this.wsPromise;
     }
 
     if ((this.wsConnection?.isHealthy || this.wsFallback?.isHealthy()) && this._hasConnectionID()) {
@@ -1315,9 +1314,14 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     if (!this.wsConnection && (this.options.warmUp || this.options.enableInsights)) {
       this._sayHi();
     }
-
     // The StableWSConnection handles all the reconnection logic.
-    this.wsConnection = new StableWSConnection<StreamChatGenerics>({ client: this });
+    if (this.options.wsConnection && this.node) {
+      // Intentionally avoiding adding ts generics on wsConnection in options since its only useful for unit test purpose.
+      ((this.options.wsConnection as unknown) as StableWSConnection<StreamChatGenerics>).setClient(this);
+      this.wsConnection = (this.options.wsConnection as unknown) as StableWSConnection<StreamChatGenerics>;
+    } else {
+      this.wsConnection = new StableWSConnection<StreamChatGenerics>({ client: this });
+    }
 
     try {
       // if fallback is used before, continue using it instead of waiting for WS to fail
@@ -1381,7 +1385,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     };
 
     // Make sure we wait for the connect promise if there is a pending one
-    await this.setUserPromise;
+    await this.wsPromise;
 
     if (!this._hasConnectionID()) {
       defaultOptions.presence = false;
@@ -1466,8 +1470,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     const defaultOptions: ChannelOptions = { state: true, watch: true, presence: false };
 
     // Make sure we wait for the connect promise if there is a pending one
-    await this.setUserPromise;
-
+    await this.wsPromise;
     if (!this._hasConnectionID()) {
       defaultOptions.watch = false;
     }
@@ -1540,7 +1543,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     }
 
     // Make sure we wait for the connect promise if there is a pending one
-    await this.setUserPromise;
+    await this.wsPromise;
 
     return await this.get<SearchAPIResponse<StreamChatGenerics>>(this.baseURL + '/search', { payload });
   }

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -92,6 +92,10 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
     this.client.logger(level, 'connection:' + msg, { tags: ['connection'], ...extra });
   }
 
+  setClient(client: StreamChat<StreamChatGenerics>) {
+    this.client = client;
+  }
+
   /**
    * connect - Connect to the WS URL
    * the default 15s timeout allows between 2~3 tries

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { StableWSConnection } from './connection';
 import { EVENT_MAP } from './events';
 import { Role } from './permissions';
 
@@ -907,6 +908,7 @@ export type StreamChatOptions = AxiosRequestConfig & {
    */
   recoverStateOnReconnect?: boolean;
   warmUp?: boolean;
+  wsConnection?: StableWSConnection;
 };
 
 export type SyncOptions = {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- Fixed the following issue:

```
QueryChannels failed with error: "Watch or Presence requires an active websocket connection, please make sure to include your websocket connection_id"
```

- Fixed handling of multiple client.openConnection calls