### PR TITLE
feat: support limit for load message into state

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -664,7 +664,7 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
    * @param {string} messageId The id of the message, or 'latest' to indicate switching to the latest messages
    * @param {string} parentMessageId The id of the parent message, if we want load a thread reply
    */
-  async loadMessageIntoState(messageId: string | 'latest', parentMessageId?: string) {
+  async loadMessageIntoState(messageId: string | 'latest', parentMessageId?: string, limit = 25) {
     let messageSetIndex: number;
     let switchedToMessageSet = false;
     let loadedMessageThread = false;
@@ -686,10 +686,10 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
       return;
     }
     if (!switchedToMessageSet) {
-      await this._channel.query({ messages: { id_around: messageIdToFind, limit: 25 } }, 'new');
+      await this._channel.query({ messages: { id_around: messageIdToFind, limit } }, 'new');
     }
     if (!loadedMessageThread && parentMessageId) {
-      await this._channel.getReplies(parentMessageId, { id_around: messageId, limit: 25 });
+      await this._channel.getReplies(parentMessageId, { id_around: messageId, limit });
     }
     messageSetIndex = this.findMessageSetIndex({ id: messageIdToFind });
     if (messageSetIndex !== -1) {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
This change allows the SDKs to increase the size of the messages loaded when jumping, thus avoiding multiple requests to the db.

## Changelog
`loadMessageIntoState` accepts an optional `limit` parameter, (default value is 25)
-
