### PR TITLE
fix: do not mutate settings param

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -579,8 +579,12 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     }
    */
   async updateAppSettings(options: AppSettings) {
-    if (options.apn_config?.p12_cert) {
-      options.apn_config.p12_cert = Buffer.from(options.apn_config.p12_cert).toString('base64');
+    const apn_config = options.apn_config;
+    if (apn_config?.p12_cert) {
+      options = {
+        ...options,
+        apn_config: { ...apn_config, p12_cert: Buffer.from(apn_config.p12_cert).toString('base64') },
+      };
     }
     return await this.patch<APIResponse>(this.baseURL + '/app', options);
   }

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -68,6 +68,15 @@ describe('StreamChat getInstance', () => {
 
 		expect(client.baseURL).to.equal(baseURL);
 	});
+
+	it('app settings do not mutate', async () => {
+		const client = new StreamChat('key', 'secret');
+		const cert = Buffer.from('test');
+		const options = { apn_config: { p12_cert: cert } };
+		await expect(client.updateAppSettings(options)).to.be.rejectedWith(/.*/);
+
+		expect(options.apn_config.p12_cert).to.be.eql(cert);
+	});
 });
 
 describe('Client userMuteStatus', function () {


### PR DESCRIPTION
if apn certificate exists, update app settings mutates given parameters