### PR TITLE
fix: don't keep removed users when reinitializing channel

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1412,11 +1412,12 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     }
 
     if (state.members) {
-      for (const member of state.members) {
+      this.state.members = state.members.reduce((acc, member) => {
         if (member.user) {
-          this.state.members[member.user.id] = member;
+          acc[member.user.id] = member;
         }
-      }
+        return acc;
+      }, {} as ChannelState<StreamChatGenerics>['members']);
     }
   }
 

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -615,3 +615,43 @@ describe('Channel lastMessage', async () => {
 		expect(channel.lastMessage().created_at.getTime()).to.be.equal(new Date(latestMessageDate).getTime());
 	});
 });
+
+describe('Channel _initializeState', () => {
+	it('should not keep members that have unwatched since last watch', async () => {
+		const client = await getClientWithUser();
+		const channel = client.channel('messaging', uuidv4());
+
+		const firstState = {
+			members: [
+				{
+					user: {
+						id: 'alice',
+					},
+				},
+				{
+					user: {
+						id: 'bob',
+					},
+				},
+			],
+		};
+
+		channel._initializeState(firstState);
+
+		expect(Object.keys(channel.state.members)).deep.to.be.equal(['alice', 'bob']);
+
+		const secondState = {
+			members: [
+				{
+					user: {
+						id: 'alice',
+					},
+				},
+			],
+		};
+
+		channel._initializeState(secondState);
+
+		expect(Object.keys(channel.state.members)).deep.to.be.equal(['alice']);
+	});
+});


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Currently, if you unwatch a channel and then watch it again, only members that were already present in channel state and new members added to the channel will be updated in the channel state. Users that have been removed between unwatching and rewatching will stay in the channel state.

This PR aims to solve that, and with that fix #988 
