### PR TITLE
fix: replace String types with string, define options as UR

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2455,38 +2455,38 @@ export type PushProviderListResponse = {
 };
 
 export type CreateCallOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
-  id: String;
-  type: String;
-  options?: Object;
+  id: string;
+  type: string;
+  options?: UR;
   user?: UserResponse<StreamChatGenerics> | null;
   user_id?: string;
 };
 
 export type HMSCall = {
-  room: String;
+  room: string;
 };
 
 export type AgoraCall = {
-  channel: String;
+  channel: string;
 };
 
 export type Call = {
-  id: String;
-  provider: String;
+  id: string;
+  provider: string;
   agora?: AgoraCall;
   hms?: HMSCall;
 };
 
 export type CreateCallResponse = APIResponse & {
   call: Call;
-  token: String;
-  agora_app_id?: String;
+  token: string;
+  agora_app_id?: string;
   agora_uid?: number;
 };
 
 export type GetCallTokenResponse = APIResponse & {
-  token: String;
-  agora_app_id?: String;
+  token: string;
+  agora_app_id?: string;
   agora_uid?: number;
 };
 


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Fixes [improperly specified](https://github.com/GetStream/stream-chat-js/pull/974/files) call related types. Property `options` of type `CreateCallOptions` doesn't specify what the object should look like and I couldn't find anything in the [REST documentation](https://getstream.io/chat/docs/rest/#other-createcall-request) so I typed it as uknown record for now.
