### PR TITLE
fix: update client to use channel.cid as config keys

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1006,7 +1006,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       }
     }
 
-    this.getClient()._addChannelConfig(state);
+    this.getClient()._addChannelConfig(state.channel);
 
     // add any messages to our channel state
     const { messageSet } = this._initializeState(state, messageSetToAddToIfDoesNotExist);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -145,13 +145,13 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   /**
-   * getConfig - Get the configs for this channel type
+   * getConfig - Get the config for this channel id (cid)
    *
    * @return {Record<string, unknown>}
    */
   getConfig() {
     const client = this.getClient();
-    return client.configs[this.type];
+    return client.configs[this.cid];
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -179,9 +179,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   clientID?: string;
   configs: Configs<StreamChatGenerics>;
   key: string;
-  listeners: {
-    [key: string]: Array<(event: Event<StreamChatGenerics>) => void>;
-  };
+  listeners: Record<string, Array<(event: Event<StreamChatGenerics>) => void>>;
   logger: Logger;
   /**
    * When network is recovered, we re-query the active channels on client. But in single query, you can recover
@@ -1197,7 +1195,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     }
 
     if (event.channel && event.type === 'notification.message_new') {
-      this.configs[event.channel.type] = event.channel.config;
+      this._addChannelConfig({ channel: event.channel });
     }
 
     if (event.type === 'notification.channel_mutes_updated' && event.me?.channel_mutes) {
@@ -1671,8 +1669,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     });
   }
 
-  _addChannelConfig(channelState: ChannelAPIResponse<StreamChatGenerics>) {
-    this.configs[channelState.channel.type] = channelState.channel.config;
+  _addChannelConfig(channelState: { channel: ChannelResponse<StreamChatGenerics> }) {
+    this.configs[channelState.channel.cid] = channelState.channel.config;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1195,7 +1195,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     }
 
     if (event.channel && event.type === 'notification.message_new') {
-      this._addChannelConfig({ channel: event.channel });
+      this._addChannelConfig(event.channel);
     }
 
     if (event.type === 'notification.channel_mutes_updated' && event.me?.channel_mutes) {
@@ -1512,7 +1512,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     const { skipInitialization, offlineMode = false } = stateOptions;
 
     for (const channelState of channelsFromApi) {
-      this._addChannelConfig(channelState);
+      this._addChannelConfig(channelState.channel);
     }
 
     const channels: Channel<StreamChatGenerics>[] = [];
@@ -1669,8 +1669,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     });
   }
 
-  _addChannelConfig(channelState: { channel: ChannelResponse<StreamChatGenerics> }) {
-    this.configs[channelState.channel.cid] = channelState.channel.config;
+  _addChannelConfig({ cid, config }: ChannelResponse<StreamChatGenerics>) {
+    this.configs[cid] = config;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1773,9 +1773,10 @@ export type CommandVariants<StreamChatGenerics extends ExtendableGenerics = Defa
   | 'unmute'
   | StreamChatGenerics['commandType'];
 
-export type Configs<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
-  [channel_type: string]: ChannelConfigWithInfo<StreamChatGenerics> | undefined;
-};
+export type Configs<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Record<
+  string,
+  ChannelConfigWithInfo<StreamChatGenerics> | undefined
+>;
 
 export type ConnectionOpen<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   connection_id: string;


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Channel configurations can differ from channel to channel so storing configurations under `channel.type` causes overrides for other loaded channels.

Channel `A` of type `messaging` for user `john` with channel role `channel_moderator` has different set of commands in the channel configuration than the channel `B` of type `messaging` where `john` isn't a `channel_moderator`. As channel `B` is after channel `A` in the list and is of the same type, the configuration gets overriden and `john` isn't able to see available commands for channel `A`.

I find using `channel.cid` as the most appropriate store key as the configuration should be bound to user/channel. I might be missing something so I'd like you guys to share your opinions (especially RN team).
