### PR TITLE
feat: allow optimistically added messages in local state

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1423,7 +1423,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     if (!this.state.messages) {
       this.state.initMessages();
     }
-    const { messageSet } = this.state.addMessagesSorted(messages, false, true, true, messageSetToAddToIfDoesNotExist);
+    const { messageSet } = this.state.addMessagesSorted(messages, true, true, true, messageSetToAddToIfDoesNotExist);
 
     if (!this.state.pinnedMessages) {
       this.state.pinnedMessages = [];


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Changes to support optimistic DB update - https://github.com/GetStream/stream-chat-react-native/pull/1758

2nd param to function `addMessagesSorted` determines weather messages being added may already exist in state or not. If they already exist, that means they were optimistically added, but timestamp of the message needs to be updated with the one stored on backend. 