### PR TITLE
fix: add missing property "joined" to ChannelResponse type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -255,6 +255,7 @@ export type ChannelResponse<
   deleted_at?: string;
   hidden?: boolean;
   invites?: string[];
+  joined?: boolean;
   last_message_at?: string;
   member_count?: number;
   members?: ChannelMemberResponse<StreamChatGenerics>[];


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Add missing optional property `joined` to `ChannelResponse` type.

Fixes: #850
