### PR TITLE
fix: read event handling and markRead api params

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1212,10 +1212,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         }
         break;
       case 'message.read':
-        if (event.user?.id) {
+        if (event.user?.id && event.created_at) {
           channelState.read[event.user.id] = {
             // because in client.ts the handleEvent call that flows to this sets this `event.received_at = new Date();`
-            last_read: event.received_at as Date,
+            last_read: new Date(event.created_at),
             user: event.user,
             unread_messages: 0,
           };

--- a/src/types.ts
+++ b/src/types.ts
@@ -826,7 +826,6 @@ export type MarkChannelsReadOptions<StreamChatGenerics extends ExtendableGeneric
 export type MarkReadOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   client_id?: string;
   connection_id?: string;
-  message_id?: string;
   user?: UserResponse<StreamChatGenerics>;
   user_id?: string;
 };


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Following PR fixes two issues:

#### message_id param in markRead api

https://github.com/GetStream/stream-chat-react-native/issues/1570 `message_id` param in `markRead` api should ideally mark the channel as read until that message. But this feature was never implemented on backend, so its better to drop it from typescript.

#### message.read event handling

_This is not from customer, but we noticed while investigating previous issue. But could possibly fix long standing https://github.com/GetStream/stream-chat-react-native/issues/148_

When we receive `message.read` event, we use the `received_at` as a timestamp as `last_read` (time at which user corresponding to event last read the channel). But `received_at` is [generated on client side](https://github.com/GetStream/stream-chat-js/blob/master/src/client.ts#L1044) using `new Date()` constructor. So if user's device is off by even few milliseconds (which happens to be case with me) it will not mark necessary message as read on UI or it will mark message as read when it shouldn't be.

This issue is producible on my device. After investigating with @bokan and @thesyncim , what I noticed with my device (macbook) is that if I [set NTP server](https://kb.iu.edu/d/auxr) as `time.google.com` or `time.apple.com`, I can see my device time is off by 1-2 seconds. Works well with `pool.ntp.org`. Obviously there is something wrong with my device that needs fixing. But this may happen easily with other device as well. Few milliseconds can break the read receipt feature.

<img width="573" alt="Screenshot 2022-11-18 at 10 12 58" src="https://user-images.githubusercontent.com/11586388/202665352-c706426b-010d-4694-b473-bdeaef7e38b1.png">

Thus instead of using `received_at`, we should be using `created_at`, which is server side generated timestamp.

P.S Special thanks for @bokan and @thesyncim for your time in debugging and helping with investigation of these issues.
