### PR TITLE
fix: update unread_messages when new message is received

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1262,13 +1262,22 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
             channelState.addPinnedMessage(event.message);
           }
 
-          if (ownMessage && event.user?.id) {
+          if (event.user?.id) {
+            for (const userId in channelState.read) {
+              if (userId === event.user.id) {
+                channelState.read[event.user.id] = {
+                  last_read: new Date(event.created_at as string),
+                  user: event.user,
+                  unread_messages: 0,
+                };
+              } else {
+                channelState.read[userId].unread_messages += 1;
+              }
+            }
+          }
+
+          if (ownMessage) {
             channelState.unreadCount = 0;
-            channelState.read[event.user.id] = {
-              last_read: new Date(event.created_at as string),
-              user: event.user,
-              unread_messages: 0,
-            };
           } else if (this._countMessageAsUnread(event.message)) {
             channelState.unreadCount = channelState.unreadCount + 1;
           }


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

When we received a new message, we only update `unread_messages` for the current user. But not for other members of channel. This PR updates unread_messages for all the members of channel by incrementing it by 1.

Source of issue discussion - https://getstream.slack.com/archives/CML3HAEJW/p1669389073043739