### PR TITLE
feat: option to set axios config

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2606,6 +2606,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       },
       ...(signal ? { signal } : {}),
       ...options.config,
+      ...this.options.axiosRequestConfig,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -920,6 +920,7 @@ export type StreamChatOptions = AxiosRequestConfig & {
    * Used to disable warnings that are triggered by using connectUser or connectAnonymousUser server-side.
    */
   allowServerSideConnect?: boolean;
+  axiosRequestConfig?: AxiosRequestConfig;
   /**
    * Base url to use for API
    * such as https://chat-proxy-dublin.stream-io-api.com

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -69,6 +69,30 @@ describe('StreamChat getInstance', () => {
 		expect(client.baseURL).to.equal(baseURL);
 	});
 
+	it('should set axios request config correctly', async () => {
+		const client = StreamChat.getInstance('key', 'secret', {
+			axiosRequestConfig: {
+				headers: {
+					'Cache-Control': 'no-cache',
+					Pragma: 'no-cache',
+				},
+			},
+		});
+
+		let requestConfig = {};
+		client.axiosInstance.get = (url, config) => {
+			requestConfig = config;
+			return {
+				status: 200,
+			};
+		};
+
+		await client.getChannelType('messaging');
+
+		expect(requestConfig.headers).to.haveOwnProperty('Cache-Control', 'no-cache');
+		expect(requestConfig.headers).to.haveOwnProperty('Pragma', 'no-cache');
+	});
+
 	it('app settings do not mutate', async () => {
 		const client = new StreamChat('key', 'secret');
 		const cert = Buffer.from('test');


### PR DESCRIPTION
### Example

```ts
const client = StreamChat.getInstance('key', 'secret', {
	axiosRequestConfig: {
		headers: {
			'Cache-Control': 'no-cache',
			Pragma: 'no-cache',
		},
	},
});

```