### PR TITLE
fix: change invalid param type of verifyWebhook and patch security issue

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2643,7 +2643,13 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     });
   };
 
-  verifyWebhook(requestBody: string, xSignature: string) {
+  /**
+   * checks signature of a request
+   * @param {string | Buffer} rawBody
+   * @param {string} signature from HTTP header
+   * @returns {boolean}
+   */
+  verifyWebhook(requestBody: string | Buffer, xSignature: string) {
     return !!this.secret && CheckSignature(requestBody, this.secret, xSignature);
   }
 

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -74,13 +74,18 @@ export function DevToken(userId: string) {
 
 /**
  *
- * @param {string} body the signed message
+ * @param {string | Buffer} body the signed message
  * @param {string} secret the shared secret used to generate the signature (Stream API secret)
  * @param {string} signature the signature to validate
  * @return {boolean}
  */
-export function CheckSignature(body: string, secret: string, signature: string) {
-  const key = Buffer.from(secret, 'ascii');
+export function CheckSignature(body: string | Buffer, secret: string, signature: string) {
+  const key = Buffer.from(secret, 'utf8');
   const hash = crypto.createHmac('sha256', key).update(body).digest('hex');
-  return hash === signature;
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(signature));
+  } catch {
+    return false;
+  }
 }

--- a/test/unit/signing.js
+++ b/test/unit/signing.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { CheckSignature } from '../../src';
+
+const MOCK_SECRET = 'porewqKAFDSAKZssecretsercretfads';
+const MOCK_TEXT = 'text';
+const MOCK_JSON_BODY = { a: 1 };
+const MOCK_TEXT_SHA256 = 'd0b770e93a56adc3ee9ac5734533cc0acd71eea8e5e8204a28042ca0f60de1f3';
+const MOCK_JSON_SHA256 = 'e527a6ad4993a4c9a30680c8be4b3eda1c36ab104f1f7d39c744bd27016a9624';
+
+describe('Signing', () => {
+	describe('CheckSignature', () => {
+		it('validates correct text body and signature', () => {
+			const rawBody = Buffer.from(MOCK_TEXT);
+			expect(CheckSignature(rawBody, MOCK_SECRET, MOCK_TEXT_SHA256)).to.be.true;
+		});
+
+		it('validates correct json body and signature', () => {
+			const rawBody = Buffer.from(JSON.stringify(MOCK_JSON_BODY));
+			expect(CheckSignature(rawBody, MOCK_SECRET, MOCK_JSON_SHA256)).to.be.true;
+		});
+
+		it('refutes incorrect json body', () => {
+			const rawBody = Buffer.from(JSON.stringify({ ...MOCK_JSON_BODY, b: 2 }));
+			expect(CheckSignature(rawBody, MOCK_SECRET, MOCK_JSON_SHA256)).to.be.false;
+		});
+	});
+});


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
- Current API accepts strings only in place of `requestBody` while it is should be possible to send instance of a `Buffer`, .e.g while using [firebase functions's requests](https://firebase.google.com/docs/reference/functions/firebase-functions.https.request.md#httpsrequestrawbody). 
This PR fixes it by changing accepting both strings and Buffers. 

- PR adds missing JSDoc for `verifyWebhook`.
- PR patches[ timing attack vulnerability](https://security.stackexchange.com/questions/83660/simple-string-comparisons-not-secure-against-timing-attacks) by using `timingSafeEqual` instead of simple string comparison.
- Adds some unit tests
 

## Changelog
- Fix invalid param type of `verifyWebhook`
