### PR TITLE
Fix tsc errors related to error type checking

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -11,6 +11,7 @@ import {
 import { buildWsFatalInsight, buildWsSuccessAfterFailureInsight, postInsights } from './insights';
 import { ConnectAPIResponse, ConnectionOpen, ExtendableGenerics, DefaultGenerics, UR, LogLevel } from './types';
 import { StreamChat } from './client';
+import { isAPIError } from 'errors';
 
 // Type guards to check WebSocket error type
 const isCloseEvent = (res: WebSocket.CloseEvent | WebSocket.Data | WebSocket.ErrorEvent): res is WebSocket.CloseEvent =>
@@ -117,6 +118,10 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
       this.isHealthy = false;
       this.consecutiveFailures += 1;
 
+      if (!isAPIError(error)) {
+        throw error;
+      }
+
       if (error.code === chatCodes.TOKEN_EXPIRED && !this.client.tokenManager.isStatic()) {
         this._log('connect() - WS failure due to expired token, so going to try to reload token and reconnect');
         this._reconnect({ refreshToken: true });
@@ -125,7 +130,7 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
         throw new Error(
           JSON.stringify({
             code: error.code,
-            StatusCode: error.StatusCode,
+            StatusCode: error.code,
             message: error.message,
             isWSFailure: error.isWSFailure,
           }),
@@ -149,11 +154,14 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
           try {
             return await this.connectionOpen;
           } catch (error) {
+            if (!isAPIError(error)) {
+              continue;
+            }
             if (i === timeout) {
               throw new Error(
                 JSON.stringify({
                   code: error.code,
-                  StatusCode: error.StatusCode,
+                  StatusCode: error.code,
                   message: error.message,
                   isWSFailure: error.isWSFailure,
                 }),
@@ -300,7 +308,10 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
       }
     } catch (err) {
       this.isConnecting = false;
-      this._log(`_connect() - Error - `, err);
+      if (isAPIError(err)) {
+        this._log(`_connect() - Error - `, { code: err.code });
+      }
+
       if (this.client.options.enableInsights) {
         this.client.insightMetrics.wsConsecutiveFailures++;
         this.client.insightMetrics.wsTotalFailures++;
@@ -369,6 +380,9 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
     } catch (error) {
       this.isHealthy = false;
       this.consecutiveFailures += 1;
+      if (!isAPIError(error)) {
+        throw error;
+      }
       if (error.code === chatCodes.TOKEN_EXPIRED && !this.client.tokenManager.isStatic()) {
         this._log('_reconnect() - WS failure due to expired token, so going to try to reload token and reconnect');
 


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
All catch closures inside `connection.ts` assumed thrown error is instance of `Error` while default type of error is `unknown`. This PR adds proper type checks so compiler won't throw build errors. It should fix this [issue](https://github.com/GetStream/stream-chat-js/issues/1062).

## Changelog

- Fix build errors related to error type checks
