### PR TITLE
feat: extend SendMessage to server-side moderation API

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -163,12 +163,14 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @param {boolean} [options.skip_push] Skip sending push notifications
    * @param {boolean} [options.is_pending_message] Make this message pending
    * @param {Record<string,string>} [options.pending_message_metadata] Metadata for the pending message
+   * @param {boolean} [options.force_moderation] Apply force moderation for server-side requests
    *
    * @return {Promise<SendMessageAPIResponse<StreamChatGenerics>>} The Server Response
    */
   async sendMessage(
     message: Message<StreamChatGenerics>,
     options?: {
+      force_moderation?: boolean;
       is_pending_message?: boolean;
       pending_message_metadata?: Record<string, string>;
       skip_enrich_url?: boolean;


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
We extended the Send Message endpoint to receive an optional `force_moderation` _bool_ parameter, in order to provide option for enforcing moderation on server side sent messages. 
https://github.com/GetStream/stream-services/issues/1181
## Changelog

-  Add `force_moderation` option field in the sendMessage() request
