### PR TITLE
feat: receive last_read_message_id from server

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1495,6 +1495,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       for (const read of state.read) {
         this.state.read[read.user.id] = {
           last_read: new Date(read.last_read),
+          last_read_message_id: read.last_read_msg_id,
           unread_messages: read.unread_messages ?? 0,
           user: read.user,
         };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1495,7 +1495,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       for (const read of state.read) {
         this.state.read[read.user.id] = {
           last_read: new Date(read.last_read),
-          last_read_message_id: read.last_read_msg_id,
+          last_read_message_id: read.last_read_message_id,
           unread_messages: read.unread_messages ?? 0,
           user: read.user,
         };

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -15,7 +15,7 @@ import {
 
 type ChannelReadStatus<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Record<
   string,
-  { last_read: Date; unread_messages: number; user: UserResponse<StreamChatGenerics> }
+  { last_read: Date; unread_messages: number; user: UserResponse<StreamChatGenerics>; last_read_message_id?: string }
 >;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -599,7 +599,7 @@ export type ReactionResponse<
 export type ReadResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   last_read: string;
   user: UserResponse<StreamChatGenerics>;
-  last_read_msg_id?: string;
+  last_read_message_id?: string;
   unread_messages?: number;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -598,8 +598,8 @@ export type ReactionResponse<
 
 export type ReadResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   last_read: string;
-  last_read_msg_id: string;
   user: UserResponse<StreamChatGenerics>;
+  last_read_msg_id?: string;
   unread_messages?: number;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -598,6 +598,7 @@ export type ReactionResponse<
 
 export type ReadResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   last_read: string;
+  last_read_msg_id: string;
   user: UserResponse<StreamChatGenerics>;
   unread_messages?: number;
 };


### PR DESCRIPTION
receive last_read_msg_id from server

also populate last_read_message_id

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
To create a QA test on the chat project, I needed this library to return a new property. 
Corresponding pull request in chat: https://github.com/GetStream/chat/pull/4930

## Changelog

- `ReadResponse` now includes `last_read_msg_id` received from server.
- `last_read_message_id` is added to type `ChannelReadStatus`.
