### PR TITLE
Khushal87/new message channel hidden

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1385,14 +1385,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           channelState.clearMessages();
         }
         break;
-      case 'channel.visible':
-        if (event.channel) {
-          channel.data = {
-            ...event.channel,
-            hidden: false,
-          };
-        }
-        break;
       default:
     }
 
@@ -1436,7 +1428,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   _checkInitialized() {
     if (!this.initialized && !this.offlineMode && !this.getClient()._isUsingServerAuth()) {
       throw Error(
-        `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve ${this.initialized}, ${this.offlineMode}`,
+        `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve`,
       );
     }
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1276,6 +1276,8 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           const ownMessage = event.user?.id === this.getClient().user?.id;
           const isThreadMessage = event.message.parent_id && !event.message.show_in_channel;
 
+          channel.data = { ...channel.data, hidden: false };
+
           if (this.state.isUpToDate || isThreadMessage) {
             channelState.addMessageSorted(event.message, ownMessage);
           }
@@ -1383,6 +1385,14 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           channelState.clearMessages();
         }
         break;
+      case 'channel.visible':
+        if (event.channel) {
+          channel.data = {
+            ...event.channel,
+            hidden: false,
+          };
+        }
+        break;
       default:
     }
 
@@ -1426,7 +1436,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   _checkInitialized() {
     if (!this.initialized && !this.offlineMode && !this.getClient()._isUsingServerAuth()) {
       throw Error(
-        `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve`,
+        `Channel ${this.cid} hasn't been initialized yet. Make sure to call .watch() and wait for it to resolve ${this.initialized}, ${this.offlineMode}`,
       );
     }
   }


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

According to this documentation, the channel should not stay hidden if a new message is received or `message.new` event is triggered. Without this, the channel is still shown in the channel list even if the filter matches the `channel.data.hidden` always remains as true. This needs to be updated when a new message is received. Hence this change is introduced.

In React Native, even if `channelRenderFilterFn` is used, the hidden remains true, and in an environment of a two-channel (one with filter as hidden true and the other with false) list, both channels receive the update, which seems buggy.

## Changelog

-
