### PR TITLE
feat: reflect user ban events in channel members state

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,21 @@
 # Reporting a Vulnerability
+
 At Stream we are committed to the security of our Software. We appreciate your efforts in disclosing vulnerabilities responsibly and we will make every effort to acknowledge your contributions.
 
 Report security vulnerabilities at the following email address:
+
 ```
 [security@getstream.io](mailto:security@getstream.io)
 ```
+
 Alternatively it is also possible to open a new issue in the affected repository, tagging it with the `security` tag.
 
 A team member will acknowledge the vulnerability and will follow-up with more detailed information. A representative of the security team will be in touch if more information is needed.
 
 # Information to include in a report
+
 While we appreciate any information that you are willing to provide, please make sure to include the following:
-* Which repository is affected
-* Which branch, if relevant
-* Be as descriptive as possible, the team will replicate the vulnerability before working on a fix.
+
+- Which repository is affected
+- Which branch, if relevant
+- Be as descriptive as possible, the team will replicate the vulnerability before working on a fix.

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1389,15 +1389,21 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         break;
       case 'user.banned':
         if (!event.user?.id) break;
-        channelState.members[event.user.id].shadow_banned = !!event.shadow;
-        channelState.members[event.user.id].banned = !event.shadow;
-        channelState.members[event.user.id].user = event.user;
+        channelState.members[event.user.id] = {
+          ...(channelState.members[event.user.id] || {}),
+          shadow_banned: !!event.shadow,
+          banned: !event.shadow,
+          user: { ...(channelState.members[event.user.id]?.user || {}), ...event.user },
+        };
         break;
       case 'user.unbanned':
         if (!event.user?.id) break;
-        channelState.members[event.user.id].shadow_banned = false;
-        channelState.members[event.user.id].banned = false;
-        channelState.members[event.user.id].user = event.user;
+        channelState.members[event.user.id] = {
+          ...(channelState.members[event.user.id] || {}),
+          shadow_banned: false,
+          banned: false,
+          user: { ...(channelState.members[event.user.id]?.user || {}), ...event.user },
+        };
         break;
       default:
     }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1387,6 +1387,18 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           channelState.clearMessages();
         }
         break;
+      case 'user.banned':
+        if (!event.user?.id) break;
+        channelState.members[event.user.id].shadow_banned = !!event.shadow;
+        channelState.members[event.user.id].banned = !event.shadow;
+        channelState.members[event.user.id].user = event.user;
+        break;
+      case 'user.unbanned':
+        if (!event.user?.id) break;
+        channelState.members[event.user.id].shadow_banned = false;
+        channelState.members[event.user.id].banned = false;
+        channelState.members[event.user.id].user = event.user;
+        break;
       default:
     }
 


### PR DESCRIPTION
## CLA

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [X] Code changes are tested

## Description of the changes, What, Why and How?
Start updating the channel members state when `user.banned` and `user.unbanned` events are delivered. This is needed in order the SDKs can react to changes in the client state.
