### PR TITLE
fix: prevent truncating message timestamps when updating references to deleted quoted message

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -345,9 +345,9 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
     const parseMessage = (m: ReturnType<ChannelState<StreamChatGenerics>['formatMessage']>) =>
       (({
         ...m,
-        created_at: m.created_at.toString(),
-        pinned_at: m.pinned_at?.toString(),
-        updated_at: m.updated_at?.toString(),
+        created_at: m.created_at.toISOString(),
+        pinned_at: m.pinned_at?.toISOString(),
+        updated_at: m.updated_at?.toISOString(),
       } as unknown) as MessageResponse<StreamChatGenerics>);
 
     this.messageSets.forEach((set) => {


### PR DESCRIPTION
## CLA

- [ X ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ X ] Code changes are tested

## Description of the changes, What, Why and How?
When `message.deleted` event was delivered, the client code invoked `channelState.removeQuotedMessageReferences(event.message);`. This function was converting  `created_at, pinned_at, updated_at` values of each quoting message to string using `toString()` method. That lead to truncation of milliseconds from each timestamp. Later the truncated timestamps distorted the decision logic in `ChannelState._addToMessageList()` in the following way,

1. the last message B in the list was also quoting another message A
2. the quoted message was deleted (timestamps of message B now truncated)
3. the message B was then updated and the WS event `message.updated` carried `created_at` timestamp with milliseconds
4. the message B in the state carried `created_at` timestamp without milliseconds
5. the updated B message was considered a new message but `addIfDoesNotExist` param for `ChannelState._addToMessageList()` is set to false when handling `message.updated` events
6. that leads to pure copying of the previous message list state without adding the updates

Solution is not to truncate the message timestamps, when updating references to deleted quoted message.

