### PR TITLE
fix: add missing property 'silent' to MessageBase type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2068,6 +2068,7 @@ export type MessageBase<
   pinned_at?: string | null;
   quoted_message_id?: string;
   show_in_channel?: boolean;
+  silent?: boolean;
   text?: string;
   user?: UserResponse<StreamChatGenerics> | null;
   user_id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -540,7 +540,6 @@ export type MessageResponseBase<
   reaction_scores?: { [key: string]: number } | null;
   reply_count?: number;
   shadowed?: boolean;
-  silent?: boolean;
   status?: string;
   thread_participants?: UserResponse<StreamChatGenerics>[];
   updated_at?: string;


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

[According to the JS SDK documentation](https://getstream.io/chat/docs/javascript/silent_messages/?language=javascript), the `Message` object passed as the first argument to `Channel.sendMessage()` method should optionally carry `silent` property. This property was however not declared in the type definition. This PR adds the property  to the underlying `MessageBase` type definition.


