### PR TITLE
fix: handle getting channel by members with channel id explicitly undefined

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1737,16 +1737,21 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       throw Error(`Invalid channel group ${channelType}, can't contain the : character`);
     }
 
+    // support channel("messaging", {options})
+    if (channelIDOrCustom && typeof channelIDOrCustom === 'object') {
+      return this.getChannelByMembers(channelType, channelIDOrCustom);
+    }
+
+    // // support channel("messaging", undefined, {options})
+    if (!channelIDOrCustom && typeof custom === 'object' && custom.members?.length) {
+      return this.getChannelByMembers(channelType, custom);
+    }
+
     // support channel("messaging", null, {options})
     // support channel("messaging", undefined, {options})
     // support channel("messaging", "", {options})
-    if (channelIDOrCustom == null || channelIDOrCustom === '') {
+    if (!channelIDOrCustom) {
       return new Channel<StreamChatGenerics>(this, channelType, undefined, custom);
-    }
-
-    // support channel("messaging", {options})
-    if (typeof channelIDOrCustom === 'object') {
-      return this.getChannelByMembers(channelType, channelIDOrCustom);
     }
 
     return this.getChannelById(channelType, channelIDOrCustom, custom);


### PR DESCRIPTION
## CLA

- [ X ] Code changes are tested

## Description of the changes, What, Why and How?
The `client.channel()` method did not handle correctly `client.channel(type, undefined, channelData)` calls. Instead of trying to find channel by members it directly returned a brand new `Channel` instance. Also it tried to get channel by id, if id was explicitly set to `undefined`.


