### PR TITLE
feat: declare and export types SendMessageOptions and UpdateMessageOptions

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -53,6 +53,7 @@ import {
   UserFilters,
   UserResponse,
   QueryChannelAPIResponse,
+  SendMessageOptions,
 } from './types';
 import { Role } from './permissions';
 
@@ -168,18 +169,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    *
    * @return {Promise<SendMessageAPIResponse<StreamChatGenerics>>} The Server Response
    */
-  async sendMessage(
-    message: Message<StreamChatGenerics>,
-    options?: {
-      force_moderation?: boolean;
-      is_pending_message?: boolean;
-      keep_channel_hidden?: boolean;
-      pending?: boolean;
-      pending_message_metadata?: Record<string, string>;
-      skip_enrich_url?: boolean;
-      skip_push?: boolean;
-    },
-  ) {
+  async sendMessage(message: Message<StreamChatGenerics>, options?: SendMessageOptions) {
     const sendMessageResponse = await this.getClient().post<SendMessageAPIResponse<StreamChatGenerics>>(
       this._channelURL() + '/message',
       {

--- a/src/client.ts
+++ b/src/client.ts
@@ -154,6 +154,7 @@ import {
   UpdateCommandResponse,
   UpdatedMessage,
   UpdateMessageAPIResponse,
+  UpdateMessageOptions,
   UserCustomEvent,
   UserFilters,
   UserOptions,
@@ -2439,7 +2440,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   async updateMessage(
     message: UpdatedMessage<StreamChatGenerics>,
     userId?: string | { id: string },
-    options?: { skip_enrich_url?: boolean },
+    options?: UpdateMessageOptions,
   ) {
     if (!message.id) {
       throw Error('Please specify the message id when calling updateMessage');
@@ -2510,7 +2511,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     id: string,
     partialMessageObject: PartialMessageUpdate<StreamChatGenerics>,
     userId?: string | { id: string },
-    options?: { skip_enrich_url?: boolean },
+    options?: UpdateMessageOptions,
   ) {
     if (!id) {
       throw Error('Please specify the message id when calling partialUpdateMessage');

--- a/src/types.ts
+++ b/src/types.ts
@@ -2076,6 +2076,20 @@ export type MessageBase<
 
 export type MessageLabel = 'deleted' | 'ephemeral' | 'error' | 'regular' | 'reply' | 'system';
 
+export type SendMessageOptions = {
+  force_moderation?: boolean;
+  is_pending_message?: boolean;
+  keep_channel_hidden?: boolean;
+  pending?: boolean;
+  pending_message_metadata?: Record<string, string>;
+  skip_enrich_url?: boolean;
+  skip_push?: boolean;
+};
+
+export type UpdateMessageOptions = {
+  skip_enrich_url?: boolean;
+};
+
 export type Mute<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   created_at: string;
   target: UserResponse<StreamChatGenerics>;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Types are used by stream-chat-react.
