### PR TITLE
feat: add field deleted_reply_count to MessageResponseBase

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -527,6 +527,7 @@ export type MessageResponseBase<
   command_info?: { name?: string };
   created_at?: string;
   deleted_at?: string;
+  deleted_reply_count?: number;
   i18n?: RequireAtLeastOne<Record<`${TranslationLanguages}_text`, string>> & {
     language: TranslationLanguages;
   };


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ X ] Code changes are tested

## Description of the changes, What, Why and How?

The message object return in API response now contains a new field `deleted_reply_count`
