### PR TITLE
fix: Revert "fix: remove unused unread count api endpoint #1143"

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -93,6 +93,7 @@ import {
   GetImportResponse,
   GetMessageAPIResponse,
   GetRateLimitsResponse,
+  GetUnreadCountAPIResponse,
   ListChannelResponse,
   ListCommandsResponse,
   ListImportsPaginationOptions,
@@ -1661,6 +1662,10 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       this.baseURL + '/devices',
       userID ? { user_id: userID } : {},
     );
+  }
+
+  async getUnreadCount(userID?: string) {
+    return await this.get<GetUnreadCountAPIResponse>(this.baseURL + '/unread', userID ? { user_id: userID } : {});
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -483,6 +483,20 @@ export type GetRepliesAPIResponse<StreamChatGenerics extends ExtendableGenerics 
   messages: MessageResponse<StreamChatGenerics>[];
 };
 
+export type GetUnreadCountAPIResponse = APIResponse & {
+  channel_type: {
+    channel_count: number;
+    channel_type: string;
+    unread_count: number;
+  }[];
+  channels: {
+    channel_id: string;
+    last_read: string;
+    unread_count: number;
+  }[];
+  total_unread_count: number;
+};
+
 export type ListChannelResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
   channel_types: Record<
     string,


### PR DESCRIPTION
This reverts commit 5700abdb072e41c23e4439b8fb01eafd1993d5e8.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
`getUnreadCount` is required in backend QA tests.

## Changelog

-
