### PR TITLE
fix: queue channel WS events until the channel is initialized

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1576,7 +1576,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
 
   _flushWsEventQueue() {
     while (this.wsEventQueue.length) {
-      const event = this.wsEventQueue.pop();
+      const event = this.wsEventQueue.shift();
       if (event) this.getClient().dispatchEvent(event);
     }
   }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -89,6 +89,12 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   lastTypingEvent: Date | null;
   isTyping: boolean;
   disconnected: boolean;
+  /**
+   * Collects the incoming WS events before the channel is marked as initialized.
+   * This prevents executing procedures that depend on channel being initialized.
+   * Once the channel is marked as initialized the queue is flushed.
+   */
+  wsEventQueue: Event<StreamChatGenerics>[];
 
   /**
    * constructor - Create a channel
@@ -132,6 +138,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     this.lastTypingEvent = null;
     this.isTyping = false;
     this.disconnected = false;
+    this.wsEventQueue = [];
   }
 
   /**
@@ -780,6 +787,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     const combined = { ...defaultOptions, ...options };
     const state = await this.query(combined, 'latest');
     this.initialized = true;
+    this._flushWsEventQueue();
     this.data = state.channel;
 
     this._client.logger('info', `channel:watch() - started watching channel ${this.cid}`, {
@@ -1207,6 +1215,12 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   // eslint-disable-next-line sonarjs/cognitive-complexity
   _handleChannelEvent(event: Event<StreamChatGenerics>) {
     const channel = this;
+
+    if (!this._isInitialized()) {
+      this.wsEventQueue.push(event);
+      return;
+    }
+
     this._client.logger(
       'info',
       `channel:_handleChannelEvent - Received event of type { ${event.type} } on ${this.cid}`,
@@ -1442,6 +1456,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     return `${this.getClient().baseURL}/channels/${this.type}/${this.id}`;
   };
 
+  _isInitialized() {
+    return this.initialized || this.offlineMode || this.getClient()._isUsingServerAuth();
+  }
+
   _checkInitialized() {
     if (!this.initialized && !this.offlineMode && !this.getClient()._isUsingServerAuth()) {
       throw Error(
@@ -1554,5 +1572,12 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
 
     this.disconnected = true;
     this.state.setIsUpToDate(false);
+  }
+
+  _flushWsEventQueue() {
+    while (this.wsEventQueue.length) {
+      const event = this.wsEventQueue.pop();
+      if (event) this.getClient().dispatchEvent(event);
+    }
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -47,3 +47,28 @@ export const EVENT_MAP = {
   'connection.recovered': true,
   'transport.changed': true,
 };
+
+// events handled by channel._handleChannelEvent
+export const CHANNEL_HANDLED_EVENTS = {
+  'typing.start': true,
+  'typing.stop': true,
+  'message.read': true,
+  'user.watching.start': true,
+  'user.updated': true,
+  'user.watching.stop': true,
+  'message.deleted': true,
+  'message.new': true,
+  'message.updated': true,
+  'channel.truncated': true,
+  'member.added': true,
+  'member.updated': true,
+  'member.removed': true,
+  'channel.updated': true,
+  'reaction.new': true,
+  'reaction.deleted': true,
+  'reaction.updated': true,
+  'channel.hidden': true,
+  'channel.visible': true,
+  'user.banned': true,
+  'user.unbanned': true,
+};

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -645,6 +645,7 @@ describe('ChannelState clean', () => {
 		client.userID = 'observer';
 		channel = new Channel(client, 'live', 'stream', {});
 		client.activeChannels[channel.cid] = channel;
+		channel.initialized = true;
 	});
 
 	it('should remove any stale typing events with either string or Date received_at', async () => {


### PR DESCRIPTION
## CLA

- [ X ] Code changes are tested

## Description of the changes, What, Why and How?

A channel is flagged as `initialized` only after `channel.query` call successfully returns inside `channel.watch()` method. The WS events for a given channel can however arrive sooner to the client than `channel.query` call returns. Processing WS events before the `channel.query` call returns leads to checking whether the channel has been initialized. If the channel was not flagged as initialized, then the code throws error.

To prevent processing WS events before the initialization has finished, this PR introduces a WS event queue for a channel. There will all the event objects be gathered until the channel is flagged as initialized. Once flagged as initialized, the queue is flushed.
