### PR TITLE
fix: evaluate channel.lastRead when channel is not initialized

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -945,11 +945,9 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   /**
    * countUnreadMentions - Count the number of unread messages mentioning the current user
    *
-   * @return {number} Unread mentions count. Value -1 is returned, if channel is not initialized.
+   * @return {number} Unread mentions count
    */
   countUnreadMentions() {
-    if (!this._isInitialized()) return -1;
-
     const lastRead = this.lastRead();
     const userID = this.getClient().userID;
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -898,7 +898,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @return {Date | null | undefined}
    */
   lastRead() {
-    this._checkInitialized();
+    if (this._isInitialized()) return null;
     const { userID } = this.getClient();
     if (userID) {
       return this.state.read[userID] ? this.state.read[userID].last_read : null;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -945,9 +945,11 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   /**
    * countUnreadMentions - Count the number of unread messages mentioning the current user
    *
-   * @return {number} Unread mentions count
+   * @return {number} Unread mentions count. Value -1 is returned, if channel is not initialized.
    */
   countUnreadMentions() {
+    if (!this._isInitialized()) return -1;
+
     const lastRead = this.lastRead();
     const userID = this.getClient().userID;
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -898,7 +898,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    * @return {Date | null | undefined}
    */
   lastRead() {
-    if (this._isInitialized()) return null;
     const { userID } = this.getClient();
     if (userID) {
       return this.state.read[userID] ? this.state.read[userID].last_read : null;

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -592,7 +592,7 @@ describe('Uninitialized Channel', () => {
 	});
 
 	it('returns 0 mentions in unread messages', () => {
-		expect(channel.countUnreadMentions()).to.eq(0);
+		expect(channel.countUnreadMentions()).to.eq(-1);
 	});
 
 	it('reports no lastRead data', () => {

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -592,7 +592,7 @@ describe('Uninitialized Channel', () => {
 	});
 
 	it('returns 0 mentions in unread messages', () => {
-		expect(channel.countUnreadMentions()).to.eq(-1);
+		expect(channel.countUnreadMentions()).to.eq(0);
 	});
 
 	it('reports no lastRead data', () => {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -70,7 +70,7 @@ describe('test if sort is deterministic', () => {
 	});
 });
 
-describe.only('axiosParamsSerializer', () => {
+describe('axiosParamsSerializer', () => {
 	const testCases = [
 		{
 			input: {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Currently `channel.lastRead()` throws an error if a channel is uninitialized.  Call to `channel.countUnreadMentions()` would throw an error in such case too. This complicates the work in an UI with uninitialized `Channel` instance which is a valid use-case. This PR proposes to return valid values like 0 for unread mentions count and `null` for last read data and not to break the UI.
