### PR TITLE
fix: undefined values in query params

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -250,6 +250,10 @@ export function removeConnectionEventListeners(cb: (e: Event) => void) {
 export const axiosParamsSerializer: AxiosRequestConfig['paramsSerializer'] = (params) => {
   const newParams = [];
   for (const k in params) {
+    // Stream backend doesn't treat "undefined" value same as value not being present.
+    // So, we need to skip the undefined values.
+    if (params[k] === undefined) continue;
+
     if (Array.isArray(params[k]) || typeof params[k] === 'object') {
       newParams.push(`${k}=${encodeURIComponent(JSON.stringify(params[k]))}`);
     } else {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -77,6 +77,7 @@ describe('axiosParamsSerializer', () => {
 				a: 1,
 				b: 2,
 				c: null,
+				d: undefined,
 			},
 			output: 'a=1&b=2&c=null',
 		},


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
fixes: https://github.com/GetStream/stream-chat-react-native/issues/2257

params with undefined values need to be excluded from param serialization logic, since stream backend doesn't treat `undefined` same as param not being present.


