### PR TITLE
Revert "fix: queue channel WS events until the channel is initialized"

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -47,28 +47,3 @@ export const EVENT_MAP = {
   'connection.recovered': true,
   'transport.changed': true,
 };
-
-// events handled by channel._handleChannelEvent
-export const CHANNEL_HANDLED_EVENTS = {
-  'typing.start': true,
-  'typing.stop': true,
-  'message.read': true,
-  'user.watching.start': true,
-  'user.updated': true,
-  'user.watching.stop': true,
-  'message.deleted': true,
-  'message.new': true,
-  'message.updated': true,
-  'channel.truncated': true,
-  'member.added': true,
-  'member.updated': true,
-  'member.removed': true,
-  'channel.updated': true,
-  'reaction.new': true,
-  'reaction.deleted': true,
-  'reaction.updated': true,
-  'channel.hidden': true,
-  'channel.visible': true,
-  'user.banned': true,
-  'user.unbanned': true,
-};

--- a/test/unit/channel_state.js
+++ b/test/unit/channel_state.js
@@ -645,7 +645,6 @@ describe('ChannelState clean', () => {
 		client.userID = 'observer';
 		channel = new Channel(client, 'live', 'stream', {});
 		client.activeChannels[channel.cid] = channel;
-		channel.initialized = true;
 	});
 
 	it('should remove any stale typing events with either string or Date received_at', async () => {


### PR DESCRIPTION
## CLA

- [ X ] Code changes are tested

## Description of the changes, What, Why and How?

The `channel.deleted` event marks a channel as disconnected, but then other arriving channel events on the server-side cannot be executed, because `Channel.getClient()` throws an error for disconnected channel. The client is being accessed within `Channel._isInitialized()` method that was invoked for each incoming channel event.  As we do not have immediate solution for this, we are reverting the queuing of channel WS events. The next step is to decide, whether channel events listeners should be executed for disconnected channel. 

This reverts commit 2073579e


