### PR TITLE
fix: update user reference in channel read data

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1094,7 +1094,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   };
 
   /**
-   * Updates the members and watchers of the currently active channels that contain this user
+   * Updates the members, watchers and read references of the currently active channels that contain this user
    *
    * @param {UserResponse<StreamChatGenerics>} user
    */
@@ -1102,13 +1102,15 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     const refMap = this.state.userChannelReferences[user.id] || {};
     for (const channelID in refMap) {
       const channel = this.activeChannels[channelID];
-      /** search the members and watchers and update as needed... */
       if (channel?.state) {
         if (channel.state.members[user.id]) {
           channel.state.members[user.id].user = user;
         }
         if (channel.state.watchers[user.id]) {
           channel.state.watchers[user.id] = user;
+        }
+        if (channel.state.read[user.id]) {
+          channel.state.read[user.id].user = user;
         }
       }
     }


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

When a user was updated the client didn't update the user reference in `channel.state.read` object.

## Changelog

-
