### PR TITLE
fix: use postForm instead of post for sending files

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -968,6 +968,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
         case 'post':
           response = await this.axiosInstance.post(url, data, requestConfig);
           break;
+        case 'postForm':
+          response = await this.axiosInstance.postForm(url, data, requestConfig);
+          break;
         case 'put':
           response = await this.axiosInstance.put(url, data, requestConfig);
           break;
@@ -1034,7 +1037,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     const data = addFileToFormData(uri, name, contentType);
     if (user != null) data.append('user', JSON.stringify(user));
 
-    return this.doAxiosRequest<SendFileAPIResponse>('post', url, data, {
+    return this.doAxiosRequest<SendFileAPIResponse>('postForm', url, data, {
       headers: data.getHeaders ? data.getHeaders() : {}, // node vs browser
       config: {
         timeout: 0,


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Post the V1 axios upgrade, if an integrator uses [axios interceptors ](https://axios-http.com/docs/interceptors)

whatever content type we pass to sendFile method is not used. Instead it uses ` "Content-Type": "application/x-www-form-urlencoded",`

This caused broken image/video uploads for a customer using RN SDK. 

In this change, we move to using postForm method instead of post to default to `Content-Type: multipart/form-data`

## Tested on

- RN TS sample
- React Vite sample

