### PR TITLE
feat: handle notification.mark_unread

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1360,6 +1360,19 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           delete channelState.members[event.user.id];
         }
         break;
+      case 'notification.mark_unread': {
+        const ownMessage = event.user?.id === this.getClient().user?.id;
+        if (!(ownMessage && event.user)) break;
+        channelState.read[event.user.id] = {
+          last_read: new Date(event.last_read_at as string),
+          last_read_message_id: event.last_read_message_id,
+          user: event.user,
+          unread_messages: event.unread_messages ?? 0,
+        };
+
+        channelState.unreadCount = event.unread_messages ?? 0;
+        break;
+      }
       case 'channel.updated':
         if (event.channel) {
           const isFrozenChanged = event.channel?.frozen !== undefined && event.channel.frozen !== channel.data?.frozen;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1241,7 +1241,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       case 'message.read':
         if (event.user?.id && event.created_at) {
           channelState.read[event.user.id] = {
-            // because in client.ts the handleEvent call that flows to this sets this `event.received_at = new Date();`
             last_read: new Date(event.created_at),
             last_read_message_id: event.last_read_message_id,
             user: event.user,
@@ -1363,7 +1362,9 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       case 'notification.mark_unread': {
         const ownMessage = event.user?.id === this.getClient().user?.id;
         if (!(ownMessage && event.user)) break;
+
         channelState.read[event.user.id] = {
+          first_unread_message_id: event.first_unread_message_id,
           last_read: new Date(event.last_read_at as string),
           last_read_message_id: event.last_read_message_id,
           user: event.user,

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -15,7 +15,13 @@ import {
 
 type ChannelReadStatus<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Record<
   string,
-  { last_read: Date; unread_messages: number; user: UserResponse<StreamChatGenerics>; last_read_message_id?: string }
+  {
+    last_read: Date;
+    unread_messages: number;
+    user: UserResponse<StreamChatGenerics>;
+    first_unread_message_id?: string;
+    last_read_message_id?: string;
+  }
 >;
 
 /**

--- a/src/events.ts
+++ b/src/events.ts
@@ -24,6 +24,7 @@ export const EVENT_MAP = {
   'notification.invite_rejected': true,
   'notification.invited': true,
   'notification.mark_read': true,
+  'notification.mark_unread': true,
   'notification.message_new': true,
   'notification.mutes_updated': true,
   'notification.removed_from_channel': true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1055,8 +1055,13 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   cid?: string;
   clear_history?: boolean;
   connection_id?: string;
+  // event creation timestamp, format Date ISO string
   created_at?: string;
+  // id of the message that was marked as unread - all the following messages are considered unread. (notification.mark_unread)
+  first_unread_message_id?: string;
   hard_delete?: boolean;
+  // creation date of a message with last_read_message_id, formatted as Date ISO string
+  last_read_at?: string;
   last_read_message_id?: string;
   mark_messages_deleted?: boolean;
   me?: OwnUserResponse<StreamChatGenerics>;
@@ -1072,9 +1077,14 @@ export type Event<StreamChatGenerics extends ExtendableGenerics = DefaultGeneric
   reaction?: ReactionResponse<StreamChatGenerics>;
   received_at?: string | Date;
   team?: string;
+  // @deprecated number of all unread messages across all current user's unread channels, equals unread_count
   total_unread_count?: number;
+  // number of all current user's channels with at least one unread message including the channel in this event
   unread_channels?: number;
+  // number of all unread messages across all current user's unread channels
   unread_count?: number;
+  // number of unread messages in the channel from this event (notification.mark_unread)
+  unread_messages?: number;
   user?: UserResponse<StreamChatGenerics>;
   user_id?: string;
   watcher_count?: number;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Upon receiving the new `notification.mark_unread` event update:
- channel read state for "author" of the event
- update channel's `unreadCount` property

A new property added to the `ChannelReadStatus` is `first_unread_message_id` which basically is an indicator whether the channel has been marked unread. The property is undefined for `message.new` events.

With the above state updates, the SDK can implement the feature of marking messages in a channel as unread.
