### PR TITLE
fix: prevent channel unread count reset to 0 when sending message and on new own or thread messages

### DIFF
--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -207,7 +207,7 @@ describe('Channel _handleChannelEvent', function () {
 		channel.initialized = true;
 	});
 
-	it('message.new reset the unreadCount for current user messages', function () {
+	it('message.new does not reset the unreadCount for current user messages', function () {
 		channel.state.unreadCount = 100;
 		channel._handleChannelEvent({
 			type: 'message.new',
@@ -215,7 +215,37 @@ describe('Channel _handleChannelEvent', function () {
 			message: generateMsg(),
 		});
 
-		expect(channel.state.unreadCount).to.be.equal(0);
+		expect(channel.state.unreadCount).to.be.equal(100);
+	});
+
+	it('message.new does not reset the unreadCount for own thread replies', function () {
+		channel.state.unreadCount = 100;
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user,
+			message: generateMsg({
+				parent_id: 'parentId',
+				type: 'reply',
+				user,
+			}),
+		});
+
+		expect(channel.state.unreadCount).to.be.equal(100);
+	});
+
+	it('message.new does not reset the unreadCount for others thread replies', function () {
+		channel.state.unreadCount = 100;
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user: { id: 'id' },
+			message: generateMsg({
+				parent_id: 'parentId',
+				type: 'reply',
+				user: { id: 'id' },
+			}),
+		});
+
+		expect(channel.state.unreadCount).to.be.equal(100);
 	});
 
 	it('message.new increment unreadCount properly', function () {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

A user's unread count for a channel is not reset on the back-end when:
1. the user sends a new message
2. a thread reply is received
3. message.new event for own message is received

Therefore neither the client should reset the unread count to 0. Keeping the logic that resets the count to 0 in the above cases would mean that if I channel is marked unread and one of the above actions happen (we receive a thread reply), then the channel unread count would locally be reset to 0, but on the BE it would be kept non-zero.
