### PR TITLE
feat: register first unread message id on message.new & when initializing Channel state

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1299,6 +1299,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
               } else {
                 channelState.read[userId].unread_messages += 1;
               }
+              // register the first unread msg id for the current user if this new message is the only one unread
               if (userId === ownUserId && channelState.read[ownUserId].unread_messages === 1) {
                 channelState.read[ownUserId].first_unread_message_id = event.message.id;
               }

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1259,4 +1259,38 @@ describe('Channel _initializeState', () => {
 		channel._initializeState(state);
 		expect(channel.state.read[client.user.id].first_unread_message_id).to.be.undefined;
 	});
+
+	it('should update first unread message id if last_read has not changed', async () => {
+		const createdAtMsg3 = new Date();
+		const createdAtMsg2 = new Date(new Date(createdAtMsg3).getTime() - 500);
+		const createdAtMsg1 = new Date(new Date(createdAtMsg3).getTime() - 1000);
+		const messages = [
+			generateMsg({ date: createdAtMsg1.toISOString() }),
+			generateMsg({ date: createdAtMsg2.toISOString() }),
+			generateMsg({ date: createdAtMsg3.toISOString() }),
+		];
+		let newState = { messages, read: [{ last_read: createdAtMsg1.toISOString(), user: client.user }] };
+		channel._initializeState(newState);
+		expect(channel.state.read[client.user.id].first_unread_message_id).to.be.equal(messages[1].id);
+		newState = { messages, read: [{ last_read: createdAtMsg2.toISOString(), user: client.user }] };
+		channel._initializeState(newState);
+		expect(channel.state.read[client.user.id].first_unread_message_id).to.be.equal(messages[2].id);
+	});
+
+	it('should not update first unread message id if last_read has not changed', async () => {
+		const createdAtMsg3 = new Date();
+		const createdAtMsg2 = new Date(new Date(createdAtMsg3).getTime() - 500);
+		const createdAtMsg1 = new Date(new Date(createdAtMsg3).getTime() - 1000);
+		const messages = [
+			generateMsg({ date: createdAtMsg1.toISOString() }),
+			generateMsg({ date: createdAtMsg2.toISOString() }),
+			generateMsg({ date: createdAtMsg3.toISOString() }),
+		];
+		let newState = { messages, read: [{ last_read: createdAtMsg1.toISOString(), user: client.user }] };
+		channel._initializeState(newState);
+		expect(channel.state.read[client.user.id].first_unread_message_id).to.be.equal(messages[1].id);
+		newState = { messages, read: [{ last_read: createdAtMsg1.toISOString(), user: client.user }] };
+		channel._initializeState(newState);
+		expect(channel.state.read[client.user.id].first_unread_message_id).to.be.equal(messages[1].id);
+	});
 });

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -207,7 +207,7 @@ describe('Channel _handleChannelEvent', function () {
 		channel.initialized = true;
 	});
 
-	it('message.new reset the unreadCount for current user messages', function () {
+	it('message.new does not reset the unreadCount for current user messages', function () {
 		channel.state.unreadCount = 100;
 		channel._handleChannelEvent({
 			type: 'message.new',
@@ -215,7 +215,37 @@ describe('Channel _handleChannelEvent', function () {
 			message: generateMsg(),
 		});
 
-		expect(channel.state.unreadCount).to.be.equal(0);
+		expect(channel.state.unreadCount).to.be.equal(100);
+	});
+
+	it('message.new does not reset the unreadCount for own thread replies', function () {
+		channel.state.unreadCount = 100;
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user,
+			message: generateMsg({
+				parent_id: 'parentId',
+				type: 'reply',
+				user,
+			}),
+		});
+
+		expect(channel.state.unreadCount).to.be.equal(100);
+	});
+
+	it('message.new does not reset the unreadCount for others thread replies', function () {
+		channel.state.unreadCount = 100;
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user: { id: 'id' },
+			message: generateMsg({
+				parent_id: 'parentId',
+				type: 'reply',
+				user: { id: 'id' },
+			}),
+		});
+
+		expect(channel.state.unreadCount).to.be.equal(100);
 	});
 
 	it('message.new increment unreadCount properly', function () {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

To achieve consistency in the UI concerning the display of unread messages indicators, we need to provide the `first_unread_message_id` value consistently. The value is not provided when querying channels, neither when a new message arrives. Therefore, we have to calculate it client-side.
In this PR we register the `first_unread_message_id` in `message.new` handler and in `Channel._initializeState()`. The latter is invoked every time a `Channel` instance is created or channel data is queried from the BE. In `Channel._initializeState()` we inspect the whole message set and not only the recently queried messages.

This PR also removes dead code, that was anyways overwritten on the following lines.
