### PR TITLE
feat: add moderation types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -558,6 +558,7 @@ export type MessageResponseBase<
   };
   latest_reactions?: ReactionResponse<StreamChatGenerics>[];
   mentioned_users?: UserResponse<StreamChatGenerics>[];
+  moderation_details?: ModerationDetailsResponse;
   own_reactions?: ReactionResponse<StreamChatGenerics>[] | null;
   pin_expires?: string | null;
   pinned_at?: string | null;
@@ -569,6 +570,18 @@ export type MessageResponseBase<
   status?: string;
   thread_participants?: UserResponse<StreamChatGenerics>[];
   updated_at?: string;
+};
+
+export type ModerationDetailsResponse = {
+  action: 'MESSAGE_RESPONSE_ACTION_BOUNCE' | string;
+  error_msg: string;
+  harms: ModerationHarmResponse[];
+  original_text: string;
+};
+
+export type ModerationHarmResponse = {
+  name: string;
+  phrase_list_ids: number[];
 };
 
 export type MuteResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -573,7 +573,7 @@ export type MessageResponseBase<
 };
 
 export type ModerationDetailsResponse = {
-  action: 'MESSAGE_RESPONSE_ACTION_BOUNCE' | string;
+  action: 'MESSAGE_RESPONSE_ACTION_BOUNCE' | (string & {});
   error_msg: string;
   harms: ModerationHarmResponse[];
   original_text: string;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Added new types for moderation responses, and a new optional property `moderation_details` on `MessageResponse`.

When the message doesn't pass moderation and is bounced, the response from POST `/channels/:type/:id/message` endpoint contains `moderation_details`. The clients may use this field to properly notify users.

The types are based on 
https://github.com/GetStream/chat/blob/master/automod/moderation/nnbb.go#L61-L66, since they are not exposed in OpenAPI.

## Changelog

- new optional property `moderation_details` in `MessageResponseBase` type
