### PR TITLE
fix: add missing in$ operator for teams filter in queryUsers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1507,6 +1507,7 @@ export type UserFilters<StreamChatGenerics extends ExtendableGenerics = DefaultG
       | RequireOnlyOne<{
           $contains?: PrimitiveFilter<string>;
           $eq?: PrimitiveFilter<UserResponse<StreamChatGenerics>['teams']>;
+          $in?: PrimitiveFilter<UserResponse<StreamChatGenerics>['teams']>;
         }>
       | PrimitiveFilter<UserResponse<StreamChatGenerics>['teams']>;
     username?:


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- fix: add missing `in$` operator for `teams` filter in `queryUsers`
