### PR TITLE
fix: markRead and markUnread can be called from server-side

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -708,7 +708,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   async markRead(data: MarkReadOptions<StreamChatGenerics> = {}) {
     this._checkInitialized();
 
-    if (!this.getConfig()?.read_events) {
+    if (!this.getConfig()?.read_events && !this.getClient()._isUsingServerAuth()) {
       return Promise.resolve(null);
     }
 
@@ -726,7 +726,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   async markUnread(data: MarkUnreadOptions<StreamChatGenerics>) {
     this._checkInitialized();
 
-    if (!this.getConfig()?.read_events) {
+    if (!this.getConfig()?.read_events && !this.getClient()._isUsingServerAuth()) {
       return Promise.resolve(null);
     }
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

The `markRead` and `markUnread` calls should be available on server-side, but a client-side permission check made it impossible to call them before. This PR fixes that.

After the merge these calls will work on server-side:
```
const channel = streamClient.channel(
  "<channel type>",
  "<channel id>"
);

channel
  .markRead({
    user_id: "<user id>",
  })
  .then(console.log)
  .catch(console.error);

channel
  .markUnread({
    message_id: "<message id>",
    user_id: "<user id>",
  })
  .then(console.log)
  .catch(console.error);
```

## Changelog

- fix: markRead and markUnread can be called from server-side
