### PR TITLE
feat: dispatch capabilties.changed event on partial update if own_capabilties are changed

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -398,7 +398,19 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       this._channelURL(),
       update,
     );
+
+    const areCapabilitiesChanged =
+      [...(data.channel.own_capabilities || [])].sort().join() !==
+      [...(Array.isArray(this.data?.own_capabilities) ? (this.data?.own_capabilities as string[]) : [])].sort().join();
     this.data = data.channel;
+    // If the capabiltities are changed, we trigger the `capabilities.changed` event.
+    if (areCapabilitiesChanged) {
+      this.getClient().dispatchEvent({
+        type: 'capabilities.changed',
+        cid: this.cid,
+        own_capabilities: data.channel.own_capabilities,
+      });
+    }
     return data;
   }
 


### PR DESCRIPTION


## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

- On `updatePartial`, the `channel.updated` doesn't send the updated own_capabilties due to some performance reasons. Now, due to this, the send-message capability still remains intact when the channel is frozen. This PR fixes this by dispatching a `capabilities.changed` event when own_capabilties are changed on `updatePartial`. This way, the SDKs can respond to the event and update the UI accordingly.
 
## Changelog

-
