### PR TITLE
feat: add a way to undelete a deleted messages

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1331,6 +1331,17 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           }
         }
         break;
+      case 'message.undeleted':
+        if (event.message) {
+          this._extendEventWithOwnReactions(event);
+          channelState.addMessageSorted(event.message, false, false);
+          if (event.message.pinned) {
+            channelState.addPinnedMessage(event.message);
+          } else {
+            channelState.removePinnedMessage(event.message);
+          }
+        }
+        break;
       case 'channel.truncated':
         if (event.channel?.truncated_at) {
           const truncatedAt = +new Date(event.channel.truncated_at);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1321,16 +1321,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         }
         break;
       case 'message.updated':
-        if (event.message) {
-          this._extendEventWithOwnReactions(event);
-          channelState.addMessageSorted(event.message, false, false);
-          if (event.message.pinned) {
-            channelState.addPinnedMessage(event.message);
-          } else {
-            channelState.removePinnedMessage(event.message);
-          }
-        }
-        break;
       case 'message.undeleted':
         if (event.message) {
           this._extendEventWithOwnReactions(event);

--- a/src/client.ts
+++ b/src/client.ts
@@ -2603,6 +2603,27 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     );
   }
 
+  /**
+   * undeleteMessage - Undelete a message
+   *
+   * undeletes a message that was previous soft deleted. Hard deleted messages
+   * cannot be undeleted. This is only allowed to be called from server-side
+   * clients.
+   *
+   * @param {string} messageID
+   *
+   * @return {{ message: MessageResponse<StreamChatGenerics> }} Response that includes the message
+   */
+  async undeleteMessage(messageID: string) {
+    if (!this._isUsingServerAuth()) {
+      throw Error('Messages can only be deleted with a server-side client');
+    }
+
+    return await this.post<APIResponse & { message: MessageResponse<StreamChatGenerics> }>(
+      this.baseURL + `/messages/${messageID}/undelete`,
+    );
+  }
+
   async getMessage(messageID: string, options?: GetMessageOptions) {
     return await this.get<GetMessageAPIResponse<StreamChatGenerics>>(
       this.baseURL + `/messages/${encodeURIComponent(messageID)}`,

--- a/src/client.ts
+++ b/src/client.ts
@@ -2616,7 +2616,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    */
   async undeleteMessage(messageID: string) {
     if (!this._isUsingServerAuth()) {
-      throw Error('Messages can only be deleted with a server-side client');
+      throw new Error('Messages can only be undeleted with a server-side client');
     }
 
     return await this.post<APIResponse & { message: MessageResponse<StreamChatGenerics> }>(

--- a/src/client.ts
+++ b/src/client.ts
@@ -2616,10 +2616,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @return {{ message: MessageResponse<StreamChatGenerics> }} Response that includes the message
    */
   async undeleteMessage(messageID: string, userID: string) {
-    if (!this._isUsingServerAuth()) {
-      throw new Error('Messages can only be undeleted with a server-side client');
-    }
-
     return await this.post<APIResponse & { message: MessageResponse<StreamChatGenerics> }>(
       this.baseURL + `/messages/${messageID}/undelete`,
       { undeleted_by: userID },

--- a/src/client.ts
+++ b/src/client.ts
@@ -2610,17 +2610,19 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * cannot be undeleted. This is only allowed to be called from server-side
    * clients.
    *
-   * @param {string} messageID
+   * @param {string} messageID The id of the message to undelete
+   * @param {string} userID The id of the user who undeleted the message
    *
    * @return {{ message: MessageResponse<StreamChatGenerics> }} Response that includes the message
    */
-  async undeleteMessage(messageID: string) {
+  async undeleteMessage(messageID: string, userID: string) {
     if (!this._isUsingServerAuth()) {
       throw new Error('Messages can only be undeleted with a server-side client');
     }
 
     return await this.post<APIResponse & { message: MessageResponse<StreamChatGenerics> }>(
       this.baseURL + `/messages/${messageID}/undelete`,
+      { undeleted_by: userID },
     );
   }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -16,6 +16,7 @@ export const EVENT_MAP = {
   'message.new': true,
   'message.read': true,
   'message.updated': true,
+  'message.undeleted': true,
   'notification.added_to_channel': true,
   'notification.channel_deleted': true,
   'notification.channel_mutes_updated': true,


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This adds support for calling a new undelete endpoint, which can be used for undeleting previously soft deleted messages. The API requires this to be called from serverside clients and will return a 403 if called from the browser.

The API will also publish a new `message.undeleted` event when the message has been undelete. I'm not sure if more changes are required here beyond adding it to the event map.

## Changelog

- Add `undeleteMessage` for bringing back soft deleting messages