### PR TITLE
feat: add message edited timestamp

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -626,6 +626,7 @@ export type MessageResponseBase<
   };
   latest_reactions?: ReactionResponse<StreamChatGenerics>[];
   mentioned_users?: UserResponse<StreamChatGenerics>[];
+  message_text_updated_at?: string;
   moderation_details?: ModerationDetailsResponse;
   own_reactions?: ReactionResponse<StreamChatGenerics>[] | null;
   pin_expires?: string | null;


### PR DESCRIPTION
Adds support for a new optional message field `message_text_updated_at` that contains the timestamp of the last time the message text was edited.