### PR TITLE
fix: skip updateUserMessageReferences if channel is undefined

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1147,6 +1147,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
     for (const channelID in refMap) {
       const channel = this.activeChannels[channelID];
+
+      if (!channel) continue;
+
       const state = channel.state;
 
       /** update the messages from this user. */


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Fixes an issue where apps would crash due missing state on undefined channel when trying to update `userChannelReferences`.

Error in question:
```
TypeError: Cannot read properties of undefined (reading 'state')
node_modules/stream-chat/dist/browser.es.js at line 6861:31

    _defineProperty(this, "_updateUserMessageReferences", function (user) {
      var refMap = _this.state.userChannelReferences[user.id] || {};

      for (var _channelID2 in refMap) {
        var _channel3 = _this.activeChannels[_channelID2];
        var state = _channel3.state;
        /** update the messages from this user. */

        state === null || state === void 0 ? void 0 : state.updateUserMessages(user);
      }
    });
```