### PR TITLE
feat: add support for show_deleted_message in `getMessage`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -172,6 +172,7 @@ import {
   SegmentTargetsResponse,
   QuerySegmentTargetsFilter,
   SortParam,
+  GetMessageOptions,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 import { Thread } from './thread';
@@ -2602,10 +2603,14 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     );
   }
 
-  async getMessage(messageID: string) {
-    return await this.get<GetMessageAPIResponse<StreamChatGenerics>>(
-      this.baseURL + `/messages/${encodeURIComponent(messageID)}`,
-    );
+  async getMessage(messageID: string, options?: GetMessageOptions) {
+    const url = this.baseURL + `/messages/${messageID}`;
+    let params = {};
+    if (options?.show_deleted_message) {
+      params = { show_deleted_message: true };
+    }
+
+    return await this.get<GetMessageAPIResponse<StreamChatGenerics>>(url, params);
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2218,6 +2218,10 @@ export type UpdateMessageOptions = {
   skip_enrich_url?: boolean;
 };
 
+export type GetMessageOptions = {
+  show_deleted_message?: boolean;
+};
+
 export type Mute<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   created_at: string;
   target: UserResponse<StreamChatGenerics>;


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

This allow the optional query parameter `show_deleted_message` in API `getMessage` in order to show text of deleted msg.
