### PR TITLE
fix: align unread counting on muted channel

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -914,6 +914,9 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read-events'))
       return false;
 
+    // FIXME: see #1265, adjust and count new messages even when the channel is muted
+    if (this.muteStatus().muted) return false;
+
     return true;
   }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -914,8 +914,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read-events'))
       return false;
 
-    if (this.muteStatus().muted) return false;
-
     return true;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1261,19 +1261,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     }
 
     if (event.type === 'notification.channel_mutes_updated' && event.me?.channel_mutes) {
-      const currentMutedChannelIds: string[] = [];
-      const nextMutedChannelIds: string[] = [];
-
-      this.mutedChannels.forEach((mute) => mute.channel && currentMutedChannelIds.push(mute.channel.cid));
-      event.me.channel_mutes.forEach((mute) => mute.channel && nextMutedChannelIds.push(mute.channel.cid));
-
-      /** Set the unread count of un-muted channels to 0, which is the behaviour of backend */
-      currentMutedChannelIds.forEach((cid) => {
-        if (!nextMutedChannelIds.includes(cid) && this.activeChannels[cid]) {
-          this.activeChannels[cid].state.unreadCount = 0;
-        }
-      });
-
       this.mutedChannels = event.me.channel_mutes;
     }
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Few weeks ago we received a [GH issue](https://github.com/GetStream/stream-chat-react/issues/2306) where integrator mentions, that muting a channel with unread count `> 0` will reset unread count to zero - while that is not the case, the issue they described further still stands and that is when the state gets actually reset (upon unmuting said channel) and the page is reloaded (re-query the channels), the unread count is back where it was prior to muting/unmuting.

This PR removes condition from unread counting function and removes state resetting in the `notification.channel_mutes_updated` handler. That way when the channel is unmuted the unread count represents actual value which would match the one received from the channel when re-queried.

__Circle back once applicable__:
Adjust unread count behavior for muted channels - whenever muted channel receives a new message, the unread count state should increment. Currently this is not the case and re-querying after unmuting will result in new messages not being counted as unread.

To test:

1. user A sends message to channel C
2. user B does not display the channel C and mutes it (`/read` is not called)
3. user A sends another message to channel C
4. user B unmutes channel C and reloads the page (requeries the channels)

Expected count of unread messages for user B on channel C: 2
Actual unread count: 1

Handlers should account for this behaviour during runtime as well and should increase unread count; meaning `_countMessageAsUnread` should be adjusted as well.

Closes: GetStream/stream-chat-react#2306

## TODO

- [x] add tests