### PR TITLE
feat: user privacy settings

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -55,7 +55,6 @@ import {
   QueryChannelAPIResponse,
   PollVoteData,
   SendMessageOptions,
-  UserPrivacySettings,
 } from './types';
 import { Role } from './permissions';
 
@@ -1632,15 +1631,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   async _shouldReportTyping() {
-    if (!this.getConfig()?.typing_events) {
-      return false;
-    }
-
-    const userPrivacySettings: Partial<UserPrivacySettings> = this.getClient().user?.privacy_settings || {};
-    const defaultPrivacySettings: Partial<UserPrivacySettings> =
-      (await this.getClient().getAppSettings()).app?.chat_default_user_privacy_settings || {};
-
-    return userPrivacySettings.typing_indicators?.enabled ?? defaultPrivacySettings.typing_indicators?.enabled ?? true;
+    return !Array.isArray(this.data?.own_capabilities) || this.data?.own_capabilities.includes('typing-events');
   }
 
   _disconnect() {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1631,7 +1631,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   async _shouldReportTyping() {
-    return !Array.isArray(this.data?.own_capabilities) || this.data?.own_capabilities.includes('typing-events');
+    return this.getClient().user?.privacy_settings?.typing_indicators ?? true;
   }
 
   _disconnect() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,7 +249,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   defaultWSTimeoutWithFallback: number;
   defaultWSTimeout: number;
   private nextRequestAbortController: AbortController | null = null;
-  private _appSettings: AppSettingsAPIResponse | null = null;
 
   /**
    * Initialize a client
@@ -701,15 +700,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
   /**
    * getAppSettings - retrieves application settings
-   *
-   * @param [options={}] App settings are cached by default. Pass { force: true } to force cache refresh.
    */
-  async getAppSettings(options: { force?: boolean } = {}) {
-    if (options.force || !this._appSettings) {
-      this._appSettings = await this.get<AppSettingsAPIResponse<StreamChatGenerics>>(this.baseURL + '/app');
-    }
-
-    return this._appSettings;
+  async getAppSettings() {
+    return await this.get<AppSettingsAPIResponse<StreamChatGenerics>>(this.baseURL + '/app');
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -249,6 +249,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   defaultWSTimeoutWithFallback: number;
   defaultWSTimeout: number;
   private nextRequestAbortController: AbortController | null = null;
+  private _appSettings: AppSettingsAPIResponse | null = null;
 
   /**
    * Initialize a client
@@ -700,9 +701,15 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
   /**
    * getAppSettings - retrieves application settings
+   *
+   * @param [options={}] App settings are cached by default. Pass { force: true } to force cache refresh.
    */
-  async getAppSettings() {
-    return await this.get<AppSettingsAPIResponse<StreamChatGenerics>>(this.baseURL + '/app');
+  async getAppSettings(options: { force?: boolean } = {}) {
+    if (options.force || !this._appSettings) {
+      this._appSettings = await this.get<AppSettingsAPIResponse<StreamChatGenerics>>(this.baseURL + '/app');
+    }
+
+    return this._appSettings;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
         url_enrichment?: boolean;
       }
     >;
+    chat_default_user_privacy_settings: UserPrivacySettings;
     reminders_interval: number;
     agora_options?: AgoraOptions | null;
     async_moderation_config?: AsyncModerationOptions;
@@ -804,10 +805,24 @@ export type UserResponse<StreamChatGenerics extends ExtendableGenerics = Default
   language?: TranslationLanguages | '';
   last_active?: string;
   online?: boolean;
+  privacy_settings?: Partial<UserPrivacySettings>;
   push_notifications?: PushNotificationSettings;
   revoke_tokens_issued_before?: string;
   shadow_banned?: boolean;
   updated_at?: string;
+};
+
+export type UserPrivacySettings = {
+  read_receipts: ReadReceiptsPrivacySettings;
+  typing_indicators: TypingIndicatorsPrivacySettings;
+};
+
+export type TypingIndicatorsPrivacySettings = {
+  enabled: boolean;
+};
+
+export type ReadReceiptsPrivacySettings = {
+  enabled: boolean;
 };
 
 export type PushNotificationSettings = {


### PR DESCRIPTION
Adds support for user-level privacy settings. A new field `privacy_settings` can be passed in a user object in `connectUser()` and `upsertUser()`.

Generally, just passing this data to backend should be enough (backend will discard read/typing events accordingly). However, we go one step further and also prevent the client from sending `typing.start` and `typing.stop` events at all.