### PR TITLE
feat: add reactiongroups in `MessageResponse`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -627,6 +627,7 @@ export type MessageResponse<
 export type MessageResponseBase<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = MessageBase<StreamChatGenerics> & {
+  reaction_groups: Record<string, ReactionGroupResponse>;
   type: MessageLabel;
   args?: string;
   before_message_send_failed?: boolean;
@@ -656,6 +657,13 @@ export type MessageResponseBase<
   status?: string;
   thread_participants?: UserResponse<StreamChatGenerics>[];
   updated_at?: string;
+};
+
+export type ReactionGroupResponse = {
+  count: number;
+  sum_scores: number;
+  first_reaction_at?: string;
+  last_reaction_at?: string;
 };
 
 export type ModerationDetailsResponse = {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This adds new field in `MessageResponse` that represents a map of reactions for that msg.
As a key you have the type ('like', 'love') and as value some useful information for building a better UI.
