### PR TITLE
feat: add reaction groups fallback

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
   "{**/*.{js,ts,md,css,scss,json}, .eslintrc.json, .prettierrc, .babelrc}": "prettier --list-different",
-  "**/*.{js,md,ts}": "eslint --max-warnings 0"
+  "**/*.{js,md,ts}, !test": "eslint --max-warnings 0"
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -627,7 +627,6 @@ export type MessageResponse<
 export type MessageResponseBase<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = MessageBase<StreamChatGenerics> & {
-  reaction_groups: Record<string, ReactionGroupResponse>;
   type: MessageLabel;
   args?: string;
   before_message_send_failed?: boolean;
@@ -651,6 +650,7 @@ export type MessageResponseBase<
   pinned_by?: UserResponse<StreamChatGenerics> | null;
   poll?: PollResponse<StreamChatGenerics>;
   reaction_counts?: { [key: string]: number } | null;
+  reaction_groups?: { [key: string]: ReactionGroupResponse } | null;
   reaction_scores?: { [key: string]: number } | null;
   reply_count?: number;
   shadowed?: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
   UserResponse,
   MessageResponse,
   FormatMessageResponse,
+  ReactionGroupResponse,
 } from './types';
 import { AxiosRequestConfig } from 'axios';
 
@@ -295,6 +296,11 @@ export function formatMessage<StreamChatGenerics extends ExtendableGenerics = De
     created_at: message.created_at ? new Date(message.created_at) : new Date(),
     updated_at: message.updated_at ? new Date(message.updated_at) : new Date(),
     status: message.status || 'received',
+    reaction_groups: maybeGetReactionGroupsFallback(
+      message.reaction_groups,
+      message.reaction_counts,
+      message.reaction_scores,
+    ),
   };
 }
 
@@ -363,4 +369,29 @@ export function addToMessageList<StreamChatGenerics extends ExtendableGenerics =
     messageArr.splice(left, 0, message);
   }
   return [...messageArr];
+}
+
+function maybeGetReactionGroupsFallback(
+  groups: { [key: string]: ReactionGroupResponse } | null | undefined,
+  counts: { [key: string]: number } | null | undefined,
+  scores: { [key: string]: number } | null | undefined,
+): { [key: string]: ReactionGroupResponse } | null {
+  if (groups) {
+    return groups;
+  }
+
+  if (counts && scores) {
+    const fallback: { [key: string]: ReactionGroupResponse } = {};
+
+    for (const type of Object.keys(counts)) {
+      fallback[type] = {
+        count: counts[type],
+        sum_scores: scores[type],
+      };
+    }
+
+    return fallback;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Adds fallback for the new `reaction_groups` property on messages.

Since `reaction_groups` will not be available for older messages, we use the data from `reaction_counts` and `reaction_scores` to provide reactions data in a similar shape as a fallack.

The `reaction_groups` property is marked as optional.