### PR TITLE
fix: fix filter type for query reactions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -297,6 +297,7 @@ export type QueryReactionsOptions = Pager;
 
 export type QueryReactionsAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
   reactions: ReactionResponse<StreamChatGenerics>[];
+  next?: string;
 };
 
 export type QueryChannelsAPIResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = APIResponse & {
@@ -627,7 +628,6 @@ export type MessageResponse<
 export type MessageResponseBase<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = MessageBase<StreamChatGenerics> & {
-  reaction_groups: Record<string, ReactionGroupResponse>;
   type: MessageLabel;
   args?: string;
   before_message_send_failed?: boolean;
@@ -651,6 +651,7 @@ export type MessageResponseBase<
   pinned_by?: UserResponse<StreamChatGenerics> | null;
   poll?: PollResponse<StreamChatGenerics>;
   reaction_counts?: { [key: string]: number } | null;
+  reaction_groups?: { [key: string]: ReactionGroupResponse } | null;
   reaction_scores?: { [key: string]: number } | null;
   reply_count?: number;
   shadowed?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1381,11 +1381,7 @@ export type ReactionFilters<StreamChatGenerics extends ExtendableGenerics = Defa
     created_at?:
       | RequireOnlyOne<Pick<QueryFilter<PollResponse['created_at']>, '$eq' | '$gt' | '$lt' | '$gte' | '$lte'>>
       | PrimitiveFilter<PollResponse['created_at']>;
-  } & {
-      [Key in keyof Omit<ReactionResponse<StreamChatGenerics>, 'user_id' | 'type' | 'created_at'>]: RequireOnlyOne<
-        QueryFilter<ReactionResponse<StreamChatGenerics>[Key]>
-      >;
-    }
+  }
 >;
 
 export type ChannelFilters<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = QueryFilters<


### PR DESCRIPTION
According to the [implementation](https://github.com/GetStream/chat/blob/master/utils/mq/reaction/reaction.go#L38-L53), reactions filter only supports the following fields:

- user_id
- type
- created_at

So no need to include any other keys in the filter type. Adding all other keys from the `Reaction` type breaks the filter type, because `Reaction` type is overridable via generic params.

Also, adds pagination `next` field to response.