### PR TITLE
fix: fix channel.membership type

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -1,7 +1,6 @@
 import { Channel } from './channel';
 import {
   ChannelMemberResponse,
-  ChannelMembership,
   FormatMessageResponse,
   Event,
   ExtendableGenerics,
@@ -42,7 +41,7 @@ export class ChannelState<StreamChatGenerics extends ExtendableGenerics = Defaul
   watchers: Record<string, UserResponse<StreamChatGenerics>>;
   members: Record<string, ChannelMemberResponse<StreamChatGenerics>>;
   unreadCount: number;
-  membership: ChannelMembership<StreamChatGenerics>;
+  membership: ChannelMemberResponse<StreamChatGenerics>;
   last_message_at: Date | null;
   /**
    * Flag which indicates if channel state contain latest/recent messages or no.

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,6 +143,7 @@ export type AppSettingsAPIResponse<StreamChatGenerics extends ExtendableGenerics
     organization?: string;
     permission_version?: string;
     policies?: Record<string, Policy[]>;
+    poll_enabled?: boolean;
     push_notifications?: {
       offline_only: boolean;
       version: string;
@@ -820,6 +821,8 @@ export type UserResponse<StreamChatGenerics extends ExtendableGenerics = Default
   created_at?: string;
   deactivated_at?: string;
   deleted_at?: string;
+  devices?: Device<StreamChatGenerics>[];
+  invisible?: boolean;
   language?: TranslationLanguages | '';
   last_active?: string;
   online?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -821,8 +821,6 @@ export type UserResponse<StreamChatGenerics extends ExtendableGenerics = Default
   created_at?: string;
   deactivated_at?: string;
   deleted_at?: string;
-  devices?: Device<StreamChatGenerics>[];
-  invisible?: boolean;
   language?: TranslationLanguages | '';
   last_active?: string;
   online?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -313,7 +313,7 @@ export type ChannelAPIResponse<StreamChatGenerics extends ExtendableGenerics = D
   messages: MessageResponse<StreamChatGenerics>[];
   pinned_messages: MessageResponse<StreamChatGenerics>[];
   hidden?: boolean;
-  membership?: ChannelMembership<StreamChatGenerics> | null;
+  membership?: ChannelMemberResponse<StreamChatGenerics> | null;
   pending_messages?: PendingMessageResponse<StreamChatGenerics>[];
   read?: ReadResponse<StreamChatGenerics>[];
   threads?: ThreadResponse[];
@@ -331,6 +331,7 @@ export type ChannelMemberAPIResponse<StreamChatGenerics extends ExtendableGeneri
 };
 
 export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
+  ban_expires?: string;
   banned?: boolean;
   channel_role?: Role;
   created_at?: string;
@@ -1667,9 +1668,9 @@ export type UserFilters<StreamChatGenerics extends ExtendableGenerics = DefaultG
       | PrimitiveFilter<UserResponse<StreamChatGenerics>['name']>;
     notifications_muted?:
       | RequireOnlyOne<{
-        $eq?: PrimitiveFilter<UserResponse<StreamChatGenerics>['notifications_muted']>;
-      }>
-    | boolean;
+          $eq?: PrimitiveFilter<UserResponse<StreamChatGenerics>['notifications_muted']>;
+        }>
+      | boolean;
     teams?:
       | RequireOnlyOne<{
           $contains?: PrimitiveFilter<string>;
@@ -2042,18 +2043,12 @@ export type ChannelData<
   name?: string;
 };
 
-export type ChannelMembership<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
-  banned?: boolean;
-  channel_role?: Role;
-  created_at?: string;
-  is_moderator?: boolean;
-  notifications_muted?: boolean;
-  role?: string;
-  shadow_banned?: boolean;
-  status?: string;
-  updated_at?: string;
-  user?: UserResponse<StreamChatGenerics>;
-};
+/**
+ * @deprecated Use ChannelMemberResponse instead
+ */
+export type ChannelMembership<
+  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
+> = ChannelMemberResponse<StreamChatGenerics>;
 
 export type ChannelMute<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   user: UserResponse<StreamChatGenerics>;

--- a/test/typescript/index.js
+++ b/test/typescript/index.js
@@ -11,7 +11,7 @@ const executables = [
 		f: rg.acceptInvite,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; image?: string }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string }; }>['acceptInvite']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; image?: string }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string }; pollType: {}; pollOptionType: {}; }>['acceptInvite']>>",
 	},
 	{
 		f: rg.addDevice,
@@ -22,13 +22,13 @@ const executables = [
 		f: rg.addMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['addMembers']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['addMembers']>>",
 	},
 	{
 		f: rg.addModerators,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['addModerators']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['addModerators']>>",
 	},
 	{
 		f: rg.banUsers,
@@ -60,13 +60,13 @@ const executables = [
 		f: rg.create,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['create']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['create']>>",
 	},
 	{
 		f: rg.createBlockList,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['createBlockList']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['createBlockList']>>",
 	},
 	// createChannelType has a limit. So only run this when needed.
 	// {
@@ -78,7 +78,7 @@ const executables = [
 		f: rg.createCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; image?: string }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string }; }>['createCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; image?: string }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string }; pollType: {}; pollOptionType: {}; }>['createCommand']>>",
 	},
 	{
 		f: rg.createPermission,
@@ -94,13 +94,13 @@ const executables = [
 		f: rg.deleteBlockList,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['deleteBlockList']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['deleteBlockList']>>",
 	},
 	{
 		f: rg.deleteChannel,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['delete']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['delete']>>",
 	},
 	// TODO: Fix the error which results from deleteChannelType api call:
 	// `deleteChannelType failed with error:  { Error: StreamChat error code 16: DeleteChannelType failed with error: "bc0b09df-2cfd-4e80-93e7-1f0091e6a435 is not a defined channel type"`
@@ -114,19 +114,19 @@ const executables = [
 		f: rg.deleteCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['deleteCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['deleteCommand']>>",
 	},
 	{
 		f: rg.deleteFile,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['deleteFile']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['deleteFile']>>",
 	},
 	{
 		f: rg.deleteImage,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['deleteImage']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['deleteImage']>>",
 	},
 	{
 		f: rg.deleteMessage,
@@ -142,7 +142,7 @@ const executables = [
 		f: rg.deleteReaction,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['deleteReaction']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['deleteReaction']>>",
 	},
 	{
 		f: rg.deleteUser,
@@ -153,7 +153,7 @@ const executables = [
 		f: rg.demoteModerators,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['demoteModerators']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['demoteModerators']>>",
 	},
 	// {
 	// 	f: rg.disconnect,
@@ -169,13 +169,13 @@ const executables = [
 		f: rg.flagMessage,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { image: string, status: string }; }>['flagMessage']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { image: string, status: string }; pollType: {}; pollOptionType: {}; }>['flagMessage']>>",
 	},
 	{
 		f: rg.flagUser,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { image: string, status: string }; }>['flagUser']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { image: string, status: string }; pollType: {}; pollOptionType: {}; }>['flagUser']>>",
 	},
 	{
 		f: rg.getAppSettings,
@@ -196,13 +196,13 @@ const executables = [
 		f: rg.getCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['getCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['getCommand']>>",
 	},
 	{
 		f: rg.getConfig,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['getConfig']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['getConfig']>>",
 	},
 	{
 		f: rg.getDevices,
@@ -218,13 +218,13 @@ const executables = [
 		f: rg.getMessagesById,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['getMessagesById']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['getMessagesById']>>",
 	},
 	{
 		f: rg.getMessageWithReply,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; }>['getMessage']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; pollType: {}; pollOptionType: {}; }>['getMessage']>>",
 	},
 	{
 		f: rg.getPermission,
@@ -235,37 +235,37 @@ const executables = [
 		f: rg.getReactions,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['getReactions']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['getReactions']>>",
 	},
 	{
 		f: rg.getReplies,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { instrument?: string; }; }>['getReplies']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { instrument?: string; }; pollType: {}; pollOptionType: {}; }>['getReplies']>>",
 	},
 	{
 		f: rg.hide,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['hide']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['hide']>>",
 	},
 	{
 		f: rg.inviteMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['inviteMembers']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['inviteMembers']>>",
 	},
 	{
 		f: rg.keystroke,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['keystroke']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['keystroke']>>",
 	},
 	{
 		f: rg.lastMessage,
 		imports: ['Channel', 'FormatMessageResponse', 'Unpacked'],
 		type:
-			"Omit<FormatMessageResponse<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>, 'created_at' | 'updated_at'> & { created_at?: string; updated_at?: string } | undefined",
+			"Omit<FormatMessageResponse<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>, 'created_at' | 'updated_at'> & { created_at?: string; updated_at?: string } | undefined",
 	},
 	{
 		f: rg.listBlockLists,
@@ -281,7 +281,7 @@ const executables = [
 		f: rg.listCommands,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['listCommands']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['listCommands']>>",
 	},
 	{
 		f: rg.listPermissions,
@@ -297,19 +297,19 @@ const executables = [
 		f: rg.markRead,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['markRead']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['markRead']>>",
 	},
 	{
 		f: rg.mute,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['mute']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['mute']>>",
 	},
 	{
 		f: rg.muteStatus,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['muteStatus']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['muteStatus']>>",
 	},
 	{
 		f: rg.muteUser,
@@ -332,7 +332,7 @@ const executables = [
 		f: rg.query,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['query']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['query']>>",
 	},
 	// TODO: Add this back in when queryBannedUsers is deployed to all shards for testing
 	// {
@@ -345,7 +345,7 @@ const executables = [
 		f: rg.queryMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['queryMembers']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['queryMembers']>>",
 	},
 	{
 		f: rg.queryUsers,
@@ -368,7 +368,7 @@ const executables = [
 		f: rg.removeMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['removeMembers']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['removeMembers']>>",
 	},
 	{
 		f: rg.removeShadowBan,
@@ -385,13 +385,13 @@ const executables = [
 		f: rg.sendFile,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sendFile']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sendFile']>>",
 	},
 	{
 		f: rg.sendImage,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sendImage']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sendImage']>>",
 	},
 	{
 		f: rg.sendMessage,
@@ -403,13 +403,13 @@ const executables = [
 		f: rg.sendMessageReadEvent,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sendEvent']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sendEvent']>>",
 	},
 	{
 		f: rg.sendReaction,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sendReaction']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sendReaction']>>",
 	},
 	{
 		f: rg.setGuestUser,
@@ -425,31 +425,31 @@ const executables = [
 		f: rg.show,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['show']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['show']>>",
 	},
 	{
 		f: rg.stopTyping,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['stopTyping']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['stopTyping']>>",
 	},
 	{
 		f: rg.stopWatching,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['stopWatching']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['stopWatching']>>",
 	},
 	{
 		f: rg.sync,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sync']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sync']>>",
 	},
 	{
 		f: rg.syncTeam,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['sync']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['sync']>>",
 	},
 	// Need translation on the account to run this test
 	// {
@@ -462,7 +462,7 @@ const executables = [
 		f: rg.truncateChannel,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['truncate']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['truncate']>>",
 	},
 	{
 		f: rg.unbanUsers,
@@ -473,7 +473,7 @@ const executables = [
 		f: rg.unmute,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['unmute']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['unmute']>>",
 	},
 	{
 		f: rg.unmuteUser,
@@ -489,19 +489,19 @@ const executables = [
 		f: rg.updateBlockList,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['updateBlockList']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['updateBlockList']>>",
 	},
 	{
 		f: rg.updateChannel,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['update']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['update']>>",
 	},
 	{
 		f: rg.updateChannelFromOriginal,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; smallTitle: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['update']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; smallTitle: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['update']>>",
 	},
 	{
 		f: rg.updateChannelType,
@@ -512,7 +512,7 @@ const executables = [
 		f: rg.updateCommand,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['updateCommand']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: 'testCreateCommand' | 'testCreateCommand_set' | 'testDeleteCommand' | 'testDeleteCommand_set' | 'testGetCommand' | 'testGetCommand_set' | 'testListCommand' | 'testListCommand_set' | 'testUpdateCommand' | 'testUpdateCommand_set' | 'testUpdateCommand_set_two' | 'ticket' | ''; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['updateCommand']>>",
 	},
 	{
 		f: rg.updateMessage,
@@ -541,7 +541,7 @@ const executables = [
 		f: rg.watch,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; }>['watch']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['watch']>>",
 	},
 
 	// Currently roles do not return

--- a/test/typescript/index.js
+++ b/test/typescript/index.js
@@ -22,13 +22,13 @@ const executables = [
 		f: rg.addMembers,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['addMembers']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['addMembers']>>",
 	},
 	{
 		f: rg.addModerators,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['addModerators']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['addModerators']>>",
 	},
 	{
 		f: rg.banUsers,
@@ -60,13 +60,13 @@ const executables = [
 		f: rg.create,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['create']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['create']>>",
 	},
 	{
 		f: rg.createBlockList,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; pollType: {}; pollOptionType: {}; }>['createBlockList']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: {}; pollType: {}; pollOptionType: {}; }>['createBlockList']>>",
 	},
 	// createChannelType has a limit. So only run this when needed.
 	// {
@@ -320,13 +320,13 @@ const executables = [
 		f: rg.partialUpdateUser,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { gender: string; unique: string; }; }>['partialUpdateUser']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { gender: string; unique: string; }; pollType: {}; pollOptionType: {}; }>['partialUpdateUser']>>",
 	},
 	{
 		f: rg.partialUpdateUsers,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { gender: string; unique: string; work?: string; }; }>['partialUpdateUsers']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { gender: string; unique: string; work?: string; }; pollType: {}; pollOptionType: {}; }>['partialUpdateUsers']>>",
 	},
 	{
 		f: rg.query,
@@ -351,7 +351,7 @@ const executables = [
 		f: rg.queryUsers,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { nickname?: string; }; }>['queryUsers']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { nickname?: string; }; pollType: {}; pollOptionType: {}; }>['queryUsers']>>",
 	},
 	{
 		f: rg.reactivateUser,
@@ -362,7 +362,7 @@ const executables = [
 		f: rg.rejectInvite,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; image?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string; }; }>['rejectInvite']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; image?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { song?: string; }; pollType: {}; pollOptionType: {}; }>['rejectInvite']>>",
 	},
 	{
 		f: rg.removeMembers,
@@ -379,7 +379,7 @@ const executables = [
 		f: rg.sendAction,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; }>['sendAction']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; pollType: {}; pollOptionType: {}; }>['sendAction']>>",
 	},
 	{
 		f: rg.sendFile,
@@ -397,7 +397,7 @@ const executables = [
 		f: rg.sendMessage,
 		imports: ['Channel', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; }>['sendMessage']>>",
+			"Unpacked<ReturnType<Channel<{ attachmentType: {}; channelType: { description?: string; }; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; pollType: {}; pollOptionType: {}; }>['sendMessage']>>",
 	},
 	{
 		f: rg.sendMessageReadEvent,
@@ -518,7 +518,7 @@ const executables = [
 		f: rg.updateMessage,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; }>['updateMessage']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { testString?: string; }; pollType: {}; pollOptionType: {}; }>['updateMessage']>>",
 	},
 	{
 		f: rg.updatePermission,
@@ -529,13 +529,13 @@ const executables = [
 		f: rg.upsertUsers,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { unique: string; }; }>['upsertUsers']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { unique: string; }; pollType: {}; pollOptionType: {}; }>['upsertUsers']>>",
 	},
 	{
 		f: rg.upsertUser,
 		imports: ['StreamChat', 'Unpacked'],
 		type:
-			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { nickname: string; }; }>['upsertUser']>>",
+			"Unpacked<ReturnType<StreamChat<{ attachmentType: {}; channelType: {}; commandType: string & {}; eventType: {}; messageType: {}; reactionType: {}; userType: { nickname: string; }; pollType: {}; pollOptionType: {}; }>['upsertUser']>>",
 	},
 	{
 		f: rg.watch,

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -40,6 +40,8 @@ type EventType = UR;
 type MessageType = UR;
 type ReactionType = UR;
 type CommandType = string & {};
+type PollType = UR;
+type PollOptionType = UR;
 
 type StreamTypes = {
   attachmentType: AttachmentType;
@@ -49,6 +51,8 @@ type StreamTypes = {
   messageType: MessageType;
   reactionType: ReactionType;
   userType: UserType;
+  pollType: PollType;
+  pollOptionType: PollOptionType;
 };
 
 let voidReturn: void | { unsubscribe: () => void };
@@ -67,6 +71,8 @@ const clientWithoutSecret: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }> = new StreamChat<{
   attachmentType: {};
   channelType: ChannelType;
@@ -75,6 +81,8 @@ const clientWithoutSecret: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }>(apiKey, {
   timeout: 3000,
   logger: (logLevel: string, msg: string, extraData?: Record<string, unknown>) => {},
@@ -90,6 +98,8 @@ const singletonClient1: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }> = StreamChat.getInstance<{
   attachmentType: {};
   channelType: ChannelType;
@@ -98,6 +108,8 @@ const singletonClient1: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }>(apiKey);
 
 const singletonClient2: StreamChat<{
@@ -108,6 +120,8 @@ const singletonClient2: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }> = StreamChat.getInstance<{
   attachmentType: {};
   channelType: ChannelType;
@@ -116,6 +130,8 @@ const singletonClient2: StreamChat<{
   messageType: {};
   reactionType: {};
   userType: UserType;
+  pollType: {};
+  pollOptionType: {};
 }>(apiKey, '', {});
 
 const devToken: string = client.devToken('joshua');


### PR DESCRIPTION
We had a separate type for `channel.membership` which seemed to be incomplete and different from the type of `channel.members[i]`.

In this PR:
1. Replace ChannelMembership type with ChannelMemberResponse everywhere, since it's supposed to be the same type (see backend types: [[1]](https://github.com/GetStream/chat/blob/master/controllers/chat/v1/payload/channel.go#L46-L47) and [[2]](https://github.com/GetStream/chat/blob/master/types/channel_member.go#L261)).
2. Keep ChannelMembership for reverse compatibility, but deprecate it and make it an alias for ChannelMemberResponse.