### PR TITLE
chore: add demo of LLC without SCG

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -201,6 +201,7 @@ import {
   QueryMessageHistorySort,
   QueryMessageHistoryOptions,
   QueryMessageHistoryResponse,
+  ReactionResponseEx,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 import { Thread } from './thread';
@@ -1623,7 +1624,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       ...options,
     };
 
-    return await this.post<QueryReactionsAPIResponse<StreamChatGenerics>>(
+    return await this.post<{ reactions: ReactionResponseEx[] }>(
       this.baseURL + '/messages/' + messageID + '/reactions',
       payload,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -742,6 +742,12 @@ export type ReactionResponse<
   updated_at: string;
 };
 
+export type ReactionResponseEx = ReactionEx & {
+  created_at: string;
+  message_id: string;
+  updated_at: string;
+};
+
 export type ReadResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   last_read: string;
   user: UserResponse<StreamChatGenerics>;
@@ -817,6 +823,21 @@ export type UpdateUsersAPIResponse<StreamChatGenerics extends ExtendableGenerics
 };
 
 export type UserResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = User<StreamChatGenerics> & {
+  banned?: boolean;
+  created_at?: string;
+  deactivated_at?: string;
+  deleted_at?: string;
+  language?: TranslationLanguages | '';
+  last_active?: string;
+  online?: boolean;
+  privacy_settings?: PrivacySettings;
+  push_notifications?: PushNotificationSettings;
+  revoke_tokens_issued_before?: string;
+  shadow_banned?: boolean;
+  updated_at?: string;
+};
+
+export type UserResponseEx = UserEx & {
   banned?: boolean;
   created_at?: string;
   deactivated_at?: string;
@@ -2511,6 +2532,14 @@ export type Reaction<
   user_id?: string;
 };
 
+export interface ReactionEx {
+  type: string;
+  message_id?: string;
+  score?: number;
+  user?: UserResponseEx | null;
+  user_id?: string;
+}
+
 export type Resource =
   | 'AddLinks'
   | 'BanUser'
@@ -2660,6 +2689,15 @@ export type User<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
   teams?: string[];
   username?: string;
 };
+
+export interface UserEx {
+  id: string;
+  anon?: boolean;
+  name?: string;
+  role?: string;
+  teams?: string[];
+  username?: string;
+}
 
 export type TaskResponse = {
   task_id: string;


### PR DESCRIPTION
Adds two new types:

1. `UserEx` - analog of our `User` type, but non-generic
2. `ReactionEx` - analog of our `Reaction` type, but non-generic

And, just as an example, builds two types on top of them:

1. `UserResponseEx` uses `UserEx`
2. `ReactionResponseEx` uses both `ReactionEx` and `UserEx`

Also, `queryReactions` return type updated.