### PR TITLE
chore: allow string arrays on sort parameters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1790,7 +1790,7 @@ export type PinnedMessagesSort = PinnedMessagesSortBase | Array<PinnedMessagesSo
 export type PinnedMessagesSortBase = { pinned_at?: AscDesc };
 
 export type Sort<T> = {
-  [P in keyof T]?: AscDesc;
+  [P in keyof T]?: AscDesc | string[];
 };
 
 export type UserSort<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1790,6 +1790,10 @@ export type PinnedMessagesSort = PinnedMessagesSortBase | Array<PinnedMessagesSo
 export type PinnedMessagesSortBase = { pinned_at?: AscDesc };
 
 export type Sort<T> = {
+  [P in keyof T]?: AscDesc;
+};
+
+export type SortMember<T> = {
   [P in keyof T]?: AscDesc | string[];
 };
 
@@ -1798,8 +1802,8 @@ export type UserSort<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   | Array<Sort<UserResponse<StreamChatGenerics>>>;
 
 export type MemberSort<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
-  | Sort<Pick<UserResponse<StreamChatGenerics>, 'id' | 'created_at' | 'name'>>
-  | Array<Sort<Pick<UserResponse<StreamChatGenerics>, 'id' | 'created_at' | 'name'>>>;
+  | SortMember<Pick<UserResponse<StreamChatGenerics>, 'id' | 'created_at' | 'name' | 'channel_role'>>
+  | Array<SortMember<Pick<UserResponse<StreamChatGenerics>, 'id' | 'created_at' | 'name' | 'channel_role'>>>;
 
 export type SearchMessageSortBase<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Sort<
   StreamChatGenerics['messageType']

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,7 +115,7 @@ export function addFileToFormData(
 
   return data;
 }
-export function normalizeQuerySort<T extends Record<string, AscDesc | undefined>>(sort: T | T[]) {
+export function normalizeQuerySort<T extends Record<string, AscDesc | undefined | string[]>>(sort: T | T[]) {
   const sortFields: Array<{ direction: AscDesc; field: keyof T }> = [];
   const sortArr = Array.isArray(sort) ? sort : [sort];
   for (const item of sortArr) {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Added support to Sort by arrays of strings:

```
const { members } = await channel.queryMembers(
    {},
    { channel_role: ['channel_moderator', 'channel_member'], name: 1 },
);
```

Now users should be able to query members sorted by role.

## Changelog

-
