### PR TITLE
fix: handle issue with process and DOM conflict

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -324,11 +324,11 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
 
     this.setBaseURL(this.options.baseURL || 'https://chat.stream-io-api.com');
 
-    if (typeof process !== 'undefined' && process.env.STREAM_LOCAL_TEST_RUN) {
+    if (typeof process !== 'undefined' && 'env' in process && process.env.STREAM_LOCAL_TEST_RUN) {
       this.setBaseURL('http://localhost:3030');
     }
 
-    if (typeof process !== 'undefined' && process.env.STREAM_LOCAL_TEST_HOST) {
+    if (typeof process !== 'undefined' && 'env' in process && process.env.STREAM_LOCAL_TEST_HOST) {
       this.setBaseURL('http://' + process.env.STREAM_LOCAL_TEST_HOST);
     }
 


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?
Any DOM element with an id can be accessed from the window object by `window.{EL_ID}`.
Also, global variables are available without chaining window object. e.g. 
`variableName // global variable` is the same as `window.variableName`

Therefore if a page contains a DOM element with id "process" the client constructor check `typeof process !== "undefined"` is not sufficient. `process.env.ANY_ENV_VARIABLE` will throw the TypeError `TypeError: process.env is undefined` that crashes the messenger.

![image](https://github.com/user-attachments/assets/2355b960-961a-4872-aa91-0067ddea725f)


## Changelog

- Implemented additional check for process.env object.
