### PR TITLE
chore: thread and thread manager into separate file

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -205,8 +205,9 @@ import {
   QueryMessageHistoryResponse,
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
-import { Thread, ThreadManager } from './thread';
+import { Thread } from './thread';
 import { Moderation } from './moderation';
+import { ThreadManager } from './thread_manager';
 
 function isString(x: unknown): x is string {
   return typeof x === 'string' || x instanceof String;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export * from './client_state';
 export * from './channel';
 export * from './channel_state';
 export * from './thread';
+export * from './thread_manager';
 export * from './connection';
 export * from './events';
 export * from './moderation';

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -1,27 +1,24 @@
-import { StreamChat } from './client';
-import { Channel } from './channel';
+import type { Channel } from './channel';
+import type { StreamChat } from './client';
+import { SimpleStateStore } from './store/SimpleStateStore';
 import type {
+  AscDesc,
   DefaultGenerics,
+  Event,
   ExtendableGenerics,
+  FormatMessageResponse,
+  MessagePaginationOptions,
   MessageResponse,
   ThreadResponse,
-  FormatMessageResponse,
   UserResponse,
-  Event,
-  QueryThreadsOptions,
-  MessagePaginationOptions,
-  AscDesc,
 } from './types';
 import {
   addToMessageList,
   findIndexInSortedArray,
   formatMessage,
-  transformReadArrayToDictionary,
   throttle,
+  transformReadArrayToDictionary,
 } from './utils';
-import { Handler, SimpleStateStore } from './store/SimpleStateStore';
-
-type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 type ThreadReadStatus<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   [key: string]: {
@@ -62,8 +59,6 @@ export type ThreadState<T extends ExtendableGenerics = DefaultGenerics> = {
 };
 
 const DEFAULT_PAGE_LIMIT = 50;
-const DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION = 1000;
-const MAX_QUERY_THREADS_LIMIT = 25;
 const DEFAULT_SORT: { created_at: AscDesc }[] = [{ created_at: -1 }];
 export const DEFAULT_MARK_AS_READ_THROTTLE_DURATION = 1000;
 
@@ -232,27 +227,19 @@ export class Thread<Scg extends ExtendableGenerics = DefaultGenerics> {
         ),
       );
 
-    // TODO: use debounce instead
-    const throttledHandleStateRecovery = throttle(
-      async () => {
-        // TODO: add online status to prevent recovery attempts during the time the connection is down
-        try {
-          const thread = await this.client.getThread(this.id, { watch: true });
+    const handleStateRecovery = async () => {
+      // TODO: add online status to prevent recovery attempts during the time the connection is down
+      try {
+        const thread = await this.client.getThread(this.id, { watch: true });
 
-          this.partiallyReplaceState({ thread });
-        } catch (error) {
-          // TODO: handle recovery fail
-          console.warn(error);
-        } finally {
-          // this.updateLocalState('recovering', false);
-        }
-      },
-      DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION,
-      {
-        leading: true,
-        trailing: true,
-      },
-    );
+        this.partiallyReplaceState({ thread });
+      } catch (error) {
+        // TODO: handle recovery fail
+        console.warn(error);
+      } finally {
+        // this.updateLocalState('recovering', false);
+      }
+    };
 
     // when the thread becomes active or it becomes stale while active (channel stops being watched or connection drops)
     // the recovery handler pulls its latest state to replace with the current one
@@ -262,7 +249,7 @@ export class Thread<Scg extends ExtendableGenerics = DefaultGenerics> {
         (nextValue) => [nextValue.active, nextValue.isStateStale],
         async ([active, isStateStale]) => {
           // TODO: cancel in-progress recovery?
-          if (active && isStateStale) throttledHandleStateRecovery();
+          if (active && isStateStale) handleStateRecovery();
         },
       ),
     );
@@ -561,313 +548,6 @@ export class Thread<Scg extends ExtendableGenerics = DefaultGenerics> {
       this.client.logger('error', (error as Error).message);
     } finally {
       this.state.patchedNext('loadingPreviousPage', false);
-    }
-  };
-}
-
-export type ThreadManagerState<Scg extends ExtendableGenerics = DefaultGenerics> = {
-  active: boolean;
-  lastConnectionDownAt: Date | null;
-  loadingNextPage: boolean;
-  threadIdIndexMap: { [key: string]: number };
-  threads: Thread<Scg>[];
-  unreadThreadsCount: number;
-  unseenThreadIds: string[];
-  nextCursor?: string | null; // null means no next page available
-  // TODO?: implement once supported by BE
-  // previousCursor?: string | null;
-  // loadingPreviousPage: boolean;
-};
-
-export class ThreadManager<Scg extends ExtendableGenerics = DefaultGenerics> {
-  public readonly state: SimpleStateStore<ThreadManagerState<Scg>>;
-  private client: StreamChat<Scg>;
-  private unsubscribeFunctions: Set<() => void> = new Set();
-
-  constructor({ client }: { client: StreamChat<Scg> }) {
-    this.client = client;
-    this.state = new SimpleStateStore<ThreadManagerState<Scg>>({
-      active: false,
-      threads: [],
-      threadIdIndexMap: {},
-      unreadThreadsCount: 0,
-      // new threads or threads which have not been loaded and is not possible to paginate to anymore
-      // as these threads received new replies which moved them up in the list - used for the badge
-      unseenThreadIds: [],
-      lastConnectionDownAt: null,
-      loadingNextPage: false,
-      nextCursor: undefined,
-    });
-  }
-
-  public activate = () => {
-    this.state.patchedNext('active', true);
-  };
-
-  public deactivate = () => {
-    this.state.patchedNext('active', false);
-  };
-
-  // eslint-disable-next-line sonarjs/cognitive-complexity
-  public registerSubscriptions = () => {
-    if (this.unsubscribeFunctions.size) return;
-
-    const handleUnreadThreadsCountChange = (event: Event) => {
-      const { unread_threads: unreadThreadsCount } = event.me ?? event;
-
-      if (typeof unreadThreadsCount === 'undefined') return;
-
-      this.state.next((current) => ({
-        ...current,
-        unreadThreadsCount,
-      }));
-    };
-
-    [
-      'health.check',
-      'notification.mark_read',
-      'notification.thread_message_new',
-      'notification.channel_deleted',
-    ].forEach((eventType) =>
-      this.unsubscribeFunctions.add(this.client.on(eventType, handleUnreadThreadsCountChange).unsubscribe),
-    );
-
-    // TODO: return to previous recovery option as state merging is now in place
-    const throttledHandleConnectionRecovery = throttle(
-      async () => {
-        const { lastConnectionDownAt, threads } = this.state.getLatestValue();
-
-        if (!lastConnectionDownAt) return;
-
-        const channelCids = new Set<string>();
-        for (const thread of threads) {
-          if (!thread.channel) continue;
-
-          channelCids.add(thread.channel.cid);
-        }
-
-        if (!channelCids.size) return;
-
-        try {
-          // FIXME: syncing does not work for me
-          await this.client.sync(Array.from(channelCids), lastConnectionDownAt.toISOString(), { watch: true });
-          this.state.patchedNext('lastConnectionDownAt', null);
-        } catch (error) {
-          // TODO: if error mentions that the amount of events is more than 2k
-          // do a reload-type recovery (re-query threads and merge states)
-
-          console.warn(error);
-        }
-      },
-      DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION,
-      {
-        leading: true,
-        trailing: true,
-      },
-    );
-
-    this.unsubscribeFunctions.add(
-      this.client.on('connection.recovered', throttledHandleConnectionRecovery).unsubscribe,
-    );
-
-    this.unsubscribeFunctions.add(
-      this.client.on('connection.changed', (event) => {
-        if (typeof event.online === 'undefined') return;
-
-        const { lastConnectionDownAt } = this.state.getLatestValue();
-
-        if (!event.online && !lastConnectionDownAt) {
-          this.state.patchedNext('lastConnectionDownAt', new Date());
-        }
-      }).unsubscribe,
-    );
-
-    this.unsubscribeFunctions.add(
-      this.state.subscribeWithSelector(
-        (nextValue) => [nextValue.active],
-        ([active]) => {
-          if (!active) return;
-
-          // automatically clear all the changes that happened "behind the scenes"
-          this.reload();
-        },
-      ),
-    );
-
-    const handleThreadsChange: Handler<readonly [Thread<Scg>[]]> = ([newThreads], previouslySelectedValue) => {
-      // create new threadIdIndexMap
-      const newThreadIdIndexMap = newThreads.reduce<ThreadManagerState['threadIdIndexMap']>((map, thread, index) => {
-        map[thread.id] ??= index;
-        return map;
-      }, {});
-
-      //  handle individual thread subscriptions
-      if (previouslySelectedValue) {
-        const [previousThreads] = previouslySelectedValue;
-        previousThreads.forEach((t) => {
-          // thread with registered handlers has been removed or its signature changed (new instance)
-          // deregister and let gc do its thing
-          if (typeof newThreadIdIndexMap[t.id] === 'undefined' || newThreads[newThreadIdIndexMap[t.id]] !== t) {
-            t.deregisterSubscriptions();
-          }
-        });
-      }
-      newThreads.forEach((t) => t.registerSubscriptions());
-
-      // publish new threadIdIndexMap
-      this.state.next((current) => ({ ...current, threadIdIndexMap: newThreadIdIndexMap }));
-    };
-
-    this.unsubscribeFunctions.add(
-      // re-generate map each time the threads array changes
-      this.state.subscribeWithSelector((nextValue) => [nextValue.threads] as const, handleThreadsChange),
-    );
-
-    // TODO: handle parent message hard-deleted (extend state with \w hardDeletedThreadIds?)
-
-    const handleNewReply = (event: Event) => {
-      if (!event.message || !event.message.parent_id) return;
-      const parentId = event.message.parent_id;
-
-      const { threadIdIndexMap, nextCursor, threads, unseenThreadIds } = this.state.getLatestValue();
-
-      // prevents from handling replies until the threads have been loaded
-      // (does not fill information for "unread threads" banner to appear)
-      if (!threads.length && nextCursor !== null) return;
-
-      const existsLocally = typeof threadIdIndexMap[parentId] !== 'undefined';
-
-      if (existsLocally || unseenThreadIds.includes(parentId)) return;
-
-      return this.state.next((current) => ({
-        ...current,
-        unseenThreadIds: current.unseenThreadIds.concat(parentId),
-      }));
-    };
-
-    this.unsubscribeFunctions.add(this.client.on('notification.thread_message_new', handleNewReply).unsubscribe);
-  };
-
-  public deregisterSubscriptions = () => {
-    // TODO: think about state reset or at least invalidation
-    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
-  };
-
-  public reload = async () => {
-    const { threads, unseenThreadIds } = this.state.getLatestValue();
-
-    if (!unseenThreadIds.length) return;
-
-    const combinedLimit = threads.length + unseenThreadIds.length;
-
-    try {
-      const data = await this.queryThreads({
-        limit: combinedLimit <= MAX_QUERY_THREADS_LIMIT ? combinedLimit : MAX_QUERY_THREADS_LIMIT,
-      });
-
-      const { threads, threadIdIndexMap } = this.state.getLatestValue();
-
-      const newThreads: Thread<Scg>[] = [];
-      // const existingThreadIdsToFilterOut: string[] = [];
-
-      for (const thread of data.threads) {
-        const existingThread: Thread<Scg> | undefined = threads[threadIdIndexMap[thread.id]];
-
-        newThreads.push(existingThread ?? thread);
-
-        // replace state of threads which report stale state
-        // *(state can be considered as stale when channel associated with the thread stops being watched)
-        if (existingThread && existingThread.hasStaleState) {
-          existingThread.partiallyReplaceState({ thread });
-        }
-
-        // if (existingThread) existingThreadIdsToFilterOut.push(existingThread.id);
-      }
-
-      // TODO: use some form of a "cache" for unused threads
-      // to reach for upon next pagination or re-query
-      // keep them subscribed and "running" behind the scenes but
-      // not in the list for multitude of reasons (clean cache on last pagination which returns empty array - nothing to pair cached threads to)
-      // (this.loadedThreadIdMap)
-      // const existingFilteredThreads = threads.filter(({ id }) => !existingThreadIdsToFilterOut.includes(id));
-
-      this.state.next((current) => ({
-        ...current,
-        unseenThreadIds: [], // reset
-        // TODO: extract merging logic and allow loadNextPage to merge as well (in combination with the cache thing)
-        threads: newThreads, //.concat(existingFilteredThreads),
-        nextCursor: data.next ?? null, // re-adjust next cursor
-      }));
-    } catch (error) {
-      // TODO: loading states
-      console.error(error);
-    } finally {
-      // ...
-    }
-  };
-
-  public queryThreads = async ({
-    limit = 25,
-    participant_limit = 10,
-    reply_limit = 10,
-    watch = true,
-    ...restOfTheOptions
-  }: QueryThreadsOptions = {}) => {
-    const optionsWithDefaults: WithRequired<
-      QueryThreadsOptions,
-      'reply_limit' | 'limit' | 'participant_limit' | 'watch'
-    > = {
-      limit,
-      participant_limit,
-      reply_limit,
-      watch,
-      ...restOfTheOptions,
-    };
-
-    const { threads, next } = await this.client.queryThreads(optionsWithDefaults);
-
-    // FIXME: currently this is done within threads based on reply_count property
-    // but that does not take into consideration sorting (only oldest -> newest)
-    // re-enable functionality bellow, and take into consideration sorting
-
-    // re-adjust next/previous cursors based on query options
-    // data.threads.forEach((thread) => {
-    //   thread.state.next((current) => ({
-    //     ...current,
-    //     nextCursor: current.latestReplies.length < optionsWithDefaults.reply_limit ? null : current.nextCursor,
-    //     previousCursor:
-    //       current.latestReplies.length < optionsWithDefaults.reply_limit ? null : current.previousCursor,
-    //   }));
-    // });
-
-    return { threads, next };
-  };
-
-  // remove `next` from options as that is handled internally
-  public loadNextPage = async (options: Omit<QueryThreadsOptions, 'next'> = {}) => {
-    const { nextCursor, loadingNextPage } = this.state.getLatestValue();
-
-    if (nextCursor === null || loadingNextPage) return;
-
-    const optionsWithNextCursor: QueryThreadsOptions = {
-      ...options,
-      next: nextCursor,
-    };
-
-    this.state.next((current) => ({ ...current, loadingNextPage: true }));
-
-    try {
-      const data = await this.queryThreads(optionsWithNextCursor);
-
-      this.state.next((current) => ({
-        ...current,
-        threads: data.threads.length ? current.threads.concat(data.threads) : current.threads,
-        nextCursor: data.next ?? null,
-      }));
-    } catch (error) {
-      this.client.logger('error', (error as Error).message);
-    } finally {
-      this.state.next((current) => ({ ...current, loadingNextPage: false }));
     }
   };
 }

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -1,0 +1,318 @@
+import type { StreamChat } from './client';
+import type { Handler } from './store/SimpleStateStore';
+import { SimpleStateStore } from './store/SimpleStateStore';
+import type { Thread } from './thread';
+import type { DefaultGenerics, Event, ExtendableGenerics, QueryThreadsOptions } from './types';
+import { throttle } from './utils';
+
+const DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION = 1000;
+const MAX_QUERY_THREADS_LIMIT = 25;
+
+export type ThreadManagerState<Scg extends ExtendableGenerics = DefaultGenerics> = {
+  active: boolean;
+  lastConnectionDownAt: Date | null;
+  loadingNextPage: boolean;
+  threadIdIndexMap: { [key: string]: number };
+  threads: Thread<Scg>[];
+  unreadThreadsCount: number;
+  unseenThreadIds: string[];
+  nextCursor?: string | null; // null means no next page available
+  // TODO?: implement once supported by BE
+  // previousCursor?: string | null;
+  // loadingPreviousPage: boolean;
+};
+
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+export class ThreadManager<Scg extends ExtendableGenerics = DefaultGenerics> {
+  public readonly state: SimpleStateStore<ThreadManagerState<Scg>>;
+  private client: StreamChat<Scg>;
+  private unsubscribeFunctions: Set<() => void> = new Set();
+
+  constructor({ client }: { client: StreamChat<Scg> }) {
+    this.client = client;
+    this.state = new SimpleStateStore<ThreadManagerState<Scg>>({
+      active: false,
+      threads: [],
+      threadIdIndexMap: {},
+      unreadThreadsCount: 0,
+      // new threads or threads which have not been loaded and is not possible to paginate to anymore
+      // as these threads received new replies which moved them up in the list - used for the badge
+      unseenThreadIds: [],
+      lastConnectionDownAt: null,
+      loadingNextPage: false,
+      nextCursor: undefined,
+    });
+  }
+
+  public activate = () => {
+    this.state.patchedNext('active', true);
+  };
+
+  public deactivate = () => {
+    this.state.patchedNext('active', false);
+  };
+
+  // eslint-disable-next-line sonarjs/cognitive-complexity
+  public registerSubscriptions = () => {
+    if (this.unsubscribeFunctions.size) return;
+
+    const handleUnreadThreadsCountChange = (event: Event<Scg>) => {
+      const { unread_threads: unreadThreadsCount } = event.me ?? event;
+
+      if (typeof unreadThreadsCount === 'undefined') return;
+
+      this.state.next((current) => ({
+        ...current,
+        unreadThreadsCount,
+      }));
+    };
+
+    [
+      'health.check',
+      'notification.mark_read',
+      'notification.thread_message_new',
+      'notification.channel_deleted',
+    ].forEach((eventType) =>
+      this.unsubscribeFunctions.add(this.client.on(eventType, handleUnreadThreadsCountChange).unsubscribe),
+    );
+
+    // TODO: return to previous recovery option as state merging is now in place
+    const throttledHandleConnectionRecovery = throttle(
+      async () => {
+        const { lastConnectionDownAt, threads } = this.state.getLatestValue();
+
+        if (!lastConnectionDownAt) return;
+
+        const channelCids = new Set<string>();
+        for (const thread of threads) {
+          if (!thread.channel) continue;
+
+          channelCids.add(thread.channel.cid);
+        }
+
+        if (!channelCids.size) return;
+
+        try {
+          // FIXME: syncing does not work for me
+          await this.client.sync(Array.from(channelCids), lastConnectionDownAt.toISOString(), { watch: true });
+          this.state.patchedNext('lastConnectionDownAt', null);
+        } catch (error) {
+          // TODO: if error mentions that the amount of events is more than 2k
+          // do a reload-type recovery (re-query threads and merge states)
+
+          console.warn(error);
+        }
+      },
+      DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION,
+      {
+        leading: true,
+        trailing: true,
+      },
+    );
+
+    this.unsubscribeFunctions.add(
+      this.client.on('connection.recovered', throttledHandleConnectionRecovery).unsubscribe,
+    );
+
+    this.unsubscribeFunctions.add(
+      this.client.on('connection.changed', (event) => {
+        if (typeof event.online === 'undefined') return;
+
+        const { lastConnectionDownAt } = this.state.getLatestValue();
+
+        if (!event.online && !lastConnectionDownAt) {
+          this.state.patchedNext('lastConnectionDownAt', new Date());
+        }
+      }).unsubscribe,
+    );
+
+    this.unsubscribeFunctions.add(
+      this.state.subscribeWithSelector(
+        (nextValue) => [nextValue.active],
+        ([active]) => {
+          if (!active) return;
+
+          // automatically clear all the changes that happened "behind the scenes"
+          this.reload();
+        },
+      ),
+    );
+
+    const handleThreadsChange: Handler<readonly [Thread<Scg>[]]> = ([newThreads], previouslySelectedValue) => {
+      // create new threadIdIndexMap
+      const newThreadIdIndexMap = newThreads.reduce<ThreadManagerState['threadIdIndexMap']>((map, thread, index) => {
+        map[thread.id] ??= index;
+        return map;
+      }, {});
+
+      //  handle individual thread subscriptions
+      if (previouslySelectedValue) {
+        const [previousThreads] = previouslySelectedValue;
+        previousThreads.forEach((t) => {
+          // thread with registered handlers has been removed or its signature changed (new instance)
+          // deregister and let gc do its thing
+          if (typeof newThreadIdIndexMap[t.id] === 'undefined' || newThreads[newThreadIdIndexMap[t.id]] !== t) {
+            t.deregisterSubscriptions();
+          }
+        });
+      }
+      newThreads.forEach((t) => t.registerSubscriptions());
+
+      // publish new threadIdIndexMap
+      this.state.next((current) => ({ ...current, threadIdIndexMap: newThreadIdIndexMap }));
+    };
+
+    this.unsubscribeFunctions.add(
+      // re-generate map each time the threads array changes
+      this.state.subscribeWithSelector((nextValue) => [nextValue.threads] as const, handleThreadsChange),
+    );
+
+    // TODO: handle parent message hard-deleted (extend state with \w hardDeletedThreadIds?)
+
+    const handleNewReply = (event: Event<Scg>) => {
+      if (!event.message || !event.message.parent_id) return;
+      const parentId = event.message.parent_id;
+
+      const { threadIdIndexMap, nextCursor, threads, unseenThreadIds } = this.state.getLatestValue();
+
+      // prevents from handling replies until the threads have been loaded
+      // (does not fill information for "unread threads" banner to appear)
+      if (!threads.length && nextCursor !== null) return;
+
+      const existsLocally = typeof threadIdIndexMap[parentId] !== 'undefined';
+
+      if (existsLocally || unseenThreadIds.includes(parentId)) return;
+
+      return this.state.next((current) => ({
+        ...current,
+        unseenThreadIds: current.unseenThreadIds.concat(parentId),
+      }));
+    };
+
+    this.unsubscribeFunctions.add(this.client.on('notification.thread_message_new', handleNewReply).unsubscribe);
+  };
+
+  public deregisterSubscriptions = () => {
+    // TODO: think about state reset or at least invalidation
+    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
+  };
+
+  public reload = async () => {
+    const { threads, unseenThreadIds } = this.state.getLatestValue();
+
+    if (!unseenThreadIds.length) return;
+
+    const combinedLimit = threads.length + unseenThreadIds.length;
+
+    try {
+      const data = await this.queryThreads({
+        limit: combinedLimit <= MAX_QUERY_THREADS_LIMIT ? combinedLimit : MAX_QUERY_THREADS_LIMIT,
+      });
+
+      const { threads, threadIdIndexMap } = this.state.getLatestValue();
+
+      const newThreads: Thread<Scg>[] = [];
+      // const existingThreadIdsToFilterOut: string[] = [];
+
+      for (const thread of data.threads) {
+        const existingThread: Thread<Scg> | undefined = threads[threadIdIndexMap[thread.id]];
+
+        newThreads.push(existingThread ?? thread);
+
+        // replace state of threads which report stale state
+        // *(state can be considered as stale when channel associated with the thread stops being watched)
+        if (existingThread && existingThread.hasStaleState) {
+          existingThread.partiallyReplaceState({ thread });
+        }
+
+        // if (existingThread) existingThreadIdsToFilterOut.push(existingThread.id);
+      }
+
+      // TODO: use some form of a "cache" for unused threads
+      // to reach for upon next pagination or re-query
+      // keep them subscribed and "running" behind the scenes but
+      // not in the list for multitude of reasons (clean cache on last pagination which returns empty array - nothing to pair cached threads to)
+      // (this.loadedThreadIdMap)
+      // const existingFilteredThreads = threads.filter(({ id }) => !existingThreadIdsToFilterOut.includes(id));
+
+      this.state.next((current) => ({
+        ...current,
+        unseenThreadIds: [], // reset
+        // TODO: extract merging logic and allow loadNextPage to merge as well (in combination with the cache thing)
+        threads: newThreads, //.concat(existingFilteredThreads),
+        nextCursor: data.next ?? null, // re-adjust next cursor
+      }));
+    } catch (error) {
+      // TODO: loading states
+      console.error(error);
+    } finally {
+      // ...
+    }
+  };
+
+  public queryThreads = async ({
+    limit = 25,
+    participant_limit = 10,
+    reply_limit = 10,
+    watch = true,
+    ...restOfTheOptions
+  }: QueryThreadsOptions = {}) => {
+    const optionsWithDefaults: WithRequired<
+      QueryThreadsOptions,
+      'reply_limit' | 'limit' | 'participant_limit' | 'watch'
+    > = {
+      limit,
+      participant_limit,
+      reply_limit,
+      watch,
+      ...restOfTheOptions,
+    };
+
+    const { threads, next } = await this.client.queryThreads(optionsWithDefaults);
+
+    // FIXME: currently this is done within threads based on reply_count property
+    // but that does not take into consideration sorting (only oldest -> newest)
+    // re-enable functionality bellow, and take into consideration sorting
+
+    // re-adjust next/previous cursors based on query options
+    // data.threads.forEach((thread) => {
+    //   thread.state.next((current) => ({
+    //     ...current,
+    //     nextCursor: current.latestReplies.length < optionsWithDefaults.reply_limit ? null : current.nextCursor,
+    //     previousCursor:
+    //       current.latestReplies.length < optionsWithDefaults.reply_limit ? null : current.previousCursor,
+    //   }));
+    // });
+
+    return { threads, next };
+  };
+
+  // remove `next` from options as that is handled internally
+  public loadNextPage = async (options: Omit<QueryThreadsOptions, 'next'> = {}) => {
+    const { nextCursor, loadingNextPage } = this.state.getLatestValue();
+
+    if (nextCursor === null || loadingNextPage) return;
+
+    const optionsWithNextCursor: QueryThreadsOptions = {
+      ...options,
+      next: nextCursor,
+    };
+
+    this.state.next((current) => ({ ...current, loadingNextPage: true }));
+
+    try {
+      const data = await this.queryThreads(optionsWithNextCursor);
+
+      this.state.next((current) => ({
+        ...current,
+        threads: data.threads.length ? current.threads.concat(data.threads) : current.threads,
+        nextCursor: data.next ?? null,
+      }));
+    } catch (error) {
+      this.client.logger('error', (error as Error).message);
+    } finally {
+      this.state.next((current) => ({ ...current, loadingNextPage: false }));
+    }
+  };
+}


### PR DESCRIPTION
Just splitting a large file in two for easier navigation.

Also, removed throttling from `throttledHandleConnectionRecovery` here, mostly to avoid imports, but also because it's not a correct way to deal with this async method. More fixes to this method are coming in further PRs.
