### PR TITLE
feat: do not store channelData in thread state

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -429,8 +429,7 @@ export class Thread<Scg extends ExtendableGenerics = DefaultGenerics> {
 
       // update channel on channelData change (unlikely but handled anyway)
       if (message.channel) {
-        newData['channelData'] = message.channel;
-        newData['channel'] = this.client.channel(message.channel.type, message.channel.id);
+        newData['channel'] = this.client.channel(message.channel.type, message.channel.id, message.channel);
       }
 
       return newData;


### PR DESCRIPTION
Cleaning up types a bit:
1. State when `Thread` is initialized without an underlying `Channel` is not very useful. Now threads always have a channel.
2. Storing `channelData` separately is excessive, we have it in `channel`.
3. `staggeredRead` removed for now, it's supposed to make a triumphant return at some point.

This will break ThreadProvider in React SDK, fixed in a follow-up PR.