### PR TITLE
fix: add an extra step after yarn link for the RN setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,26 @@ yarn start
 Open `metro.config.js` file and set value for watchFolders as
 
 ```javascript
+const streamChatRoot = '{{CHANGE_TO_THE_PATH_TO_YOUR_PROJECT}}/stream-chat-js'
+
 module.exports = {
+  // the rest of the metro config goes here
   ...
-  watchFolders: [projectRoot].concat(alternateRoots).concat(['{{CHANGE_TO_THE_PATH_TO_YOUR_PROJECT}}/stream-chat-js'])
+  watchFolders: [projectRoot].concat(alternateRoots).concat([streamChatRoot]),
+  resolver: {
+    // the other resolver configurations go here
+    ...
+    extraNodeModules: {
+      // the other extra node modules go here
+      ...
+      'stream-chat': streamChatRoot
+    }
+  }
 };
 ```
 
-Make sure to replace `{{CHANGE_TO_THE_PATH_TO_YOUR_PROJECT}}` with the correct path for stream-chat-js folder as per your directory structure
+Make sure to replace `{{CHANGE_TO_THE_PATH_TO_YOUR_PROJECT}}` with the correct path for the `stream-chat-js` folder as per your directory structure.
+
 Run in the root of this repo
 
 ```shell


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Running `yarn link` and then following the steps mentioned in the `README.md` did not particularly do the trick for the React Native CHAT SDK specifically. There is also the required step of adding the path towards the `stream-chat-js` directory to the `resolver.extraNodeModules` object under the `stream-chat` key.

## Changelog

- Added the extra step to our `README.md` file
