### PR TITLE
fix: declare channel.lastMessage return value type as possibly being undefined

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -707,7 +707,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    *
    * @return {ReturnType<ChannelState<StreamChatGenerics>['formatMessage']> | undefined} Description
    */
-  lastMessage() {
+  lastMessage(): FormatMessageResponse<StreamChatGenerics> | undefined {
     // get last 5 messages, sort, return the latest
     // get a slice of the last 5
     let min = this.state.latestMessages.length - 5;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Fix #1151

