### PR TITLE
fix: fix most TODOs and tests for Threads class

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,5 +132,6 @@
   },
   "engines": {
     "node": ">=16"
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha1.1959a18351b811cdeedbd484a8f86c3cc3bbaf72"
 }

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -153,7 +153,7 @@ export class ThreadManager<SCG extends ExtendableGenerics = DefaultGenerics> {
           // thread with registered handlers has been removed or its signature changed (new instance)
           // deregister and let gc do its thing
           if (typeof newThreadIdIndexMap[t.id] === 'undefined' || newThreads[newThreadIdIndexMap[t.id]] !== t) {
-            t.deregisterSubscriptions();
+            t.unregisterSubscriptions();
           }
         });
       }

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -5,342 +5,298 @@ import { generateChannel } from './test-utils/generateChannel';
 import { generateMsg } from './test-utils/generateMessage';
 import { generateThread } from './test-utils/generateThread';
 
+import sinon from 'sinon';
 import {
   Channel,
   ChannelResponse,
-  DEFAULT_MARK_AS_READ_THROTTLE_DURATION,
   MessageResponse,
   StreamChat,
   Thread,
   ThreadManager,
   ThreadResponse,
-  formatMessage,
 } from '../../src';
-import sinon from 'sinon';
 
 const TEST_USER_ID = 'observer';
 
 describe('Threads 2.0', () => {
   let client: StreamChat;
-  let channelResponse: ReturnType<typeof generateChannel>['channel'];
+  let channelResponse: ChannelResponse;
   let channel: Channel;
-  let parentMessageResponse: ReturnType<typeof generateMsg>;
-  let thread: Thread;
+  let parentMessageResponse: MessageResponse;
   let threadManager: ThreadManager;
+
+  function createTestThread({
+    channelOverrides = {},
+    parentMessageOverrides = {},
+    ...overrides
+  }: Partial<ThreadResponse> & {
+    channelOverrides?: Partial<ChannelResponse>;
+    parentMessageOverrides?: Partial<MessageResponse>;
+  } = {}) {
+    return new Thread({
+      client,
+      threadData: generateThread(
+        { ...channelResponse, ...channelOverrides },
+        { ...parentMessageResponse, ...parentMessageOverrides },
+        overrides,
+      ),
+    });
+  }
 
   beforeEach(() => {
     client = new StreamChat('apiKey');
     client._setUser({ id: TEST_USER_ID });
-    channelResponse = generateChannel({ channel: { id: uuidv4() } }).channel;
+    channelResponse = generateChannel({ channel: { id: uuidv4() } }).channel as ChannelResponse;
     channel = client.channel(channelResponse.type, channelResponse.id);
-    parentMessageResponse = generateMsg();
-    thread = new Thread({ client, threadData: generateThread(channelResponse, parentMessageResponse) });
+    parentMessageResponse = generateMsg() as MessageResponse;
     threadManager = new ThreadManager({ client });
   });
 
-  describe('Thread', () => {
-    it('has constructed proper initial state', () => {
-      // TODO: id equal to parent message id
-      // TODO: read state as dictionary
-      // TODO: channel as instance
-      // TODO: latest replies formatted
-      // TODO: parent message formatted
-      // TODO: created_at formatted
-      // TODO: deleted_at formatted (or null if not applicable)
-      //
+  describe.only('Thread', () => {
+    it('initializes properly', () => {
+      const thread = new Thread({ client, threadData: generateThread(channelResponse, parentMessageResponse) });
+      expect(thread.id).to.equal(parentMessageResponse.id);
     });
 
     describe('Methods', () => {
-      describe('Thread.upsertReplyLocally', () => {
-        // does not test whether the message has been inserted at the correct position
-        // that should be unit-tested separately (addToMessageList utility function)
-
+      describe('upsertReplyLocally', () => {
         it('prevents inserting a new message that does not belong to the associated thread', () => {
-          const newMessage = generateMsg();
-
-          const fn = () => {
-            thread.upsertReplyLocally({ message: newMessage as MessageResponse });
-          };
-
-          expect(fn).to.throw(Error);
+          const thread = createTestThread();
+          const message = generateMsg() as MessageResponse;
+          expect(() => thread.upsertReplyLocally({ message })).to.throw();
         });
 
         it('inserts a new message that belongs to the associated thread', () => {
-          const newMessage = generateMsg({ parent_id: thread.id });
+          const thread = createTestThread();
+          const message = generateMsg({ parent_id: thread.id }) as MessageResponse;
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.replies).to.have.lengthOf(0);
 
-          const { latestReplies } = thread.state.getLatestValue();
+          thread.upsertReplyLocally({ message });
 
-          expect(latestReplies).to.have.lengthOf(0);
-
-          thread.upsertReplyLocally({ message: newMessage as MessageResponse });
-
-          expect(thread.state.getLatestValue().latestReplies).to.have.lengthOf(1);
-          expect(thread.state.getLatestValue().latestReplies[0].id).to.equal(newMessage.id);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.lengthOf(1);
+          expect(stateAfter.replies[0].id).to.equal(message.id);
         });
 
         it('updates existing message', () => {
-          const newMessage = formatMessage(generateMsg({ parent_id: thread.id, text: 'aaa' }) as MessageResponse);
-          const newMessageCopy = ({ ...newMessage, text: 'bbb' } as unknown) as MessageResponse;
+          const message = generateMsg({ parent_id: parentMessageResponse.id, text: 'aaa' }) as MessageResponse;
+          const thread = createTestThread({ latest_replies: [message] });
+          const udpatedMessage = { ...message, text: 'bbb' };
 
-          thread.state.partialNext({ latestReplies: [newMessage] });
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.replies).to.have.lengthOf(1);
+          expect(stateBefore.replies[0].id).to.equal(message.id);
+          expect(stateBefore.replies[0].text).to.not.equal(udpatedMessage.text);
 
-          const { latestReplies } = thread.state.getLatestValue();
+          thread.upsertReplyLocally({ message: udpatedMessage });
 
-          expect(latestReplies).to.have.lengthOf(1);
-          expect(latestReplies.at(0)!.id).to.equal(newMessageCopy.id);
-          expect(latestReplies.at(0)!.text).to.not.equal(newMessageCopy.text);
-
-          thread.upsertReplyLocally({ message: newMessageCopy });
-
-          expect(thread.state.getLatestValue().latestReplies).to.have.lengthOf(1);
-          expect(thread.state.getLatestValue().latestReplies.at(0)!.text).to.equal(newMessageCopy.text);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.lengthOf(1);
+          expect(stateAfter.replies[0].text).to.equal(udpatedMessage.text);
         });
 
-        // TODO: timestampChanged (check that duplicates get removed)
+        it('updates optimistically added message', () => {
+          const optimisticMessage = generateMsg({
+            parent_id: parentMessageResponse.id,
+            text: 'aaa',
+            date: '2020-01-01T00:00:00Z',
+          }) as MessageResponse;
+
+          const message = generateMsg({
+            parent_id: parentMessageResponse.id,
+            text: 'bbb',
+            date: '2020-01-01T00:00:10Z',
+          }) as MessageResponse;
+
+          const thread = createTestThread({ latest_replies: [optimisticMessage, message] });
+          const udpatedMessage = { ...optimisticMessage, text: 'ccc', date: '2020-01-01T00:00:20Z' };
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.replies).to.have.lengthOf(2);
+          expect(stateBefore.replies[0].id).to.equal(optimisticMessage.id);
+          expect(stateBefore.replies[0].text).to.equal('aaa');
+          expect(stateBefore.replies[1].id).to.equal(message.id);
+
+          thread.upsertReplyLocally({ message: udpatedMessage, timestampChanged: true });
+
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.lengthOf(2);
+          expect(stateAfter.replies[0].id).to.equal(message.id);
+          expect(stateAfter.replies[1].id).to.equal(optimisticMessage.id);
+          expect(stateAfter.replies[1].text).to.equal('ccc');
+        });
       });
 
-      describe('Thread.updateParentMessageLocally', () => {
+      describe('updateParentMessageLocally', () => {
         it('prevents updating a parent message if the ids do not match', () => {
-          const newMessage = generateMsg();
-
-          const fn = () => {
-            thread.updateParentMessageLocally(newMessage as MessageResponse);
-          };
-
-          expect(fn).to.throw(Error);
+          const thread = createTestThread();
+          const message = generateMsg() as MessageResponse;
+          expect(() => thread.updateParentMessageLocally(message)).to.throw();
         });
 
-        it('updates parent message and related top-level properties (deletedAt & replyCount)', () => {
-          const newMessage = generateMsg({
+        it('updates parent message and related top-level properties', () => {
+          const thread = createTestThread();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.deletedAt).to.be.null;
+          expect(stateBefore.replyCount).to.equal(0);
+          expect(stateBefore.parentMessage.text).to.equal(parentMessageResponse.text);
+
+          const updatedMessage = generateMsg({
             id: parentMessageResponse.id,
             text: 'aaa',
             reply_count: 10,
             deleted_at: new Date().toISOString(),
-          });
+          }) as MessageResponse;
 
-          const { deletedAt, replyCount, parentMessage } = thread.state.getLatestValue();
+          thread.updateParentMessageLocally(updatedMessage);
 
-          // baseline
-          expect(parentMessage!.id).to.equal(thread.id);
-          expect(deletedAt).to.be.null;
-          expect(replyCount).to.equal(0);
-          expect(parentMessage!.text).to.equal(parentMessageResponse.text);
-
-          thread.updateParentMessageLocally(newMessage as MessageResponse);
-
-          expect(thread.state.getLatestValue().deletedAt).to.be.a('date');
-          expect(thread.state.getLatestValue().deletedAt!.toISOString()).to.equal(
-            (newMessage as MessageResponse).deleted_at,
-          );
-          expect(thread.state.getLatestValue().replyCount).to.equal(newMessage.reply_count);
-          expect(thread.state.getLatestValue().parentMessage!.text).to.equal(newMessage.text);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.deletedAt).to.be.not.null;
+          expect(stateAfter.deletedAt!.toISOString()).to.equal(updatedMessage.deleted_at);
+          expect(stateAfter.replyCount).to.equal(updatedMessage.reply_count);
+          expect(stateAfter.parentMessage.text).to.equal(updatedMessage.text);
         });
       });
 
-      describe('Thread.updateParentMessageOrReplyLocally', () => {
-        it('calls upsertReplyLocally if the message has parent_id and it equals to the thread.id', () => {
-          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally').returns();
-          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally').returns();
+      describe('updateParentMessageOrReplyLocally', () => {
+        it('updates reply if the message has a matching parent id', () => {
+          const thread = createTestThread();
+          const message = generateMsg({ parent_id: thread.id }) as MessageResponse;
+          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally');
+          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally');
 
-          thread.updateParentMessageOrReplyLocally(generateMsg({ parent_id: thread.id }) as MessageResponse);
+          thread.updateParentMessageOrReplyLocally(message);
 
           expect(upsertReplyLocallyStub.called).to.be.true;
           expect(updateParentMessageLocallyStub.called).to.be.false;
         });
 
-        it('calls updateParentMessageLocally if message does not have parent_id and its id equals to the id of the thread', () => {
-          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally').returns();
-          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally').returns();
+        it('updates parent message if the message has a matching id and is not a reply', () => {
+          const thread = createTestThread();
+          const message = generateMsg({ id: thread.id }) as MessageResponse;
+          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally');
+          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally');
 
-          thread.updateParentMessageOrReplyLocally(generateMsg({ id: thread.id }) as MessageResponse);
+          thread.updateParentMessageOrReplyLocally(message);
 
           expect(upsertReplyLocallyStub.called).to.be.false;
           expect(updateParentMessageLocallyStub.called).to.be.true;
         });
 
-        it('does not call either updateParentMessageLocally or upsertReplyLocally', () => {
-          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally').returns();
-          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally').returns();
+        it('does nothing if the message is unrelated to the thread', () => {
+          const thread = createTestThread();
+          const message = generateMsg() as MessageResponse;
+          const upsertReplyLocallyStub = sinon.stub(thread, 'upsertReplyLocally');
+          const updateParentMessageLocallyStub = sinon.stub(thread, 'updateParentMessageLocally');
 
-          thread.updateParentMessageOrReplyLocally(generateMsg() as MessageResponse);
+          thread.updateParentMessageOrReplyLocally(message);
 
           expect(upsertReplyLocallyStub.called).to.be.false;
           expect(updateParentMessageLocallyStub.called).to.be.false;
         });
       });
 
-      describe('Thread.partiallyReplaceState', () => {
-        it('prevents copying state of the instance with different id', () => {
-          const newThread = new Thread({
-            client,
-            threadData: generateThread(generateChannel({ channel: { id: channelResponse.id } }).channel, generateMsg()),
-          });
+      describe('hydrateState', () => {
+        it('prevents hydrating state from the instance with a different id', () => {
+          const thread = createTestThread();
+          const otherThread = createTestThread({ parentMessageOverrides: { id: uuidv4() } });
 
-          expect(thread.id).to.not.equal(newThread.id);
-
-          thread.partiallyReplaceState({ thread: newThread });
-
-          const { read, latestReplies, parentMessage, participants } = thread.state.getLatestValue();
-
-          // compare non-primitive values only
-          expect(read).to.not.equal(newThread.state.getLatestValue().read);
-          expect(latestReplies).to.not.equal(newThread.state.getLatestValue().latestReplies);
-          expect(parentMessage).to.not.equal(newThread.state.getLatestValue().parentMessage);
-          expect(participants).to.not.equal(newThread.state.getLatestValue().participants);
+          expect(thread.id).to.not.equal(otherThread.id);
+          expect(() => thread.hydrateState(otherThread)).to.throw();
         });
 
         it('copies state of the instance with the same id', () => {
-          const newThread = new Thread({
-            client,
-            threadData: generateThread(
-              generateChannel({ channel: { id: channelResponse.id } }).channel,
-              generateMsg({ id: parentMessageResponse.id }),
-            ),
-          });
+          const thread = createTestThread();
+          const hydrationThread = createTestThread();
+          thread.hydrateState(hydrationThread);
 
-          expect(thread.id).to.equal(newThread.id);
-          expect(thread).to.not.equal(newThread);
-
-          thread.partiallyReplaceState({ thread: newThread });
-
-          const { read, latestReplies, parentMessage, participants } = thread.state.getLatestValue();
+          const stateAfter = thread.state.getLatestValue();
+          const hydrationState = hydrationThread.state.getLatestValue();
 
           // compare non-primitive values only
-          expect(read).to.equal(newThread.state.getLatestValue().read);
-          expect(latestReplies).to.equal(newThread.state.getLatestValue().latestReplies);
-          expect(parentMessage).to.equal(newThread.state.getLatestValue().parentMessage);
-          expect(participants).to.equal(newThread.state.getLatestValue().participants);
+          expect(stateAfter.read).to.equal(hydrationState.read);
+          expect(stateAfter.replies).to.equal(hydrationState.replies);
+          expect(stateAfter.parentMessage).to.equal(hydrationState.parentMessage);
+          expect(stateAfter.participants).to.equal(hydrationState.participants);
         });
 
-        it('appends own failed replies from failedRepliesMap during merging', () => {
-          const newThread = new Thread({
-            client,
-            threadData: generateThread(
-              generateChannel({ channel: { id: channelResponse.id } }).channel,
-              generateMsg({ id: parentMessageResponse.id }),
-              { latest_replies: [generateMsg({ parent_id: parentMessageResponse.id })] },
-            ),
+        it('retains failed replies after hydration', () => {
+          const thread = createTestThread();
+          const hydrationThread = createTestThread({
+            latest_replies: [generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse],
           });
 
-          const failedMessage = formatMessage(
-            generateMsg({ status: 'failed', parent_id: thread.id }) as MessageResponse,
-          );
+          const failedMessage = generateMsg({
+            status: 'failed',
+            parent_id: parentMessageResponse.id,
+          }) as MessageResponse;
           thread.upsertReplyLocally({ message: failedMessage });
 
-          expect(thread.id).to.equal(newThread.id);
-          expect(thread).to.not.equal(newThread);
+          thread.hydrateState(hydrationThread);
 
-          thread.partiallyReplaceState({ thread: newThread });
-
-          const { latestReplies } = thread.state.getLatestValue();
-
-          // compare non-primitive values only
-          expect(latestReplies).to.have.lengthOf(2);
-          expect(latestReplies.at(-1)!.id).to.equal(failedMessage.id);
-          expect(latestReplies).to.not.equal(newThread.state.getLatestValue().latestReplies);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.lengthOf(2);
+          expect(stateAfter.replies[1].id).to.equal(failedMessage.id);
         });
       });
 
-      describe('Thread.incrementOwnUnreadCount', () => {
-        it('increments own unread count even if read object is empty', () => {
-          const { read } = thread.state.getLatestValue();
-          // TODO: write a helper for immediate own unread count
-          const ownUnreadCount = read[TEST_USER_ID]?.unread_messages ?? 0;
-
-          expect(ownUnreadCount).to.equal(0);
-
-          thread.incrementOwnUnreadCount();
-
-          expect(thread.state.getLatestValue().read[TEST_USER_ID]?.unread_messages).to.equal(1);
-        });
-
-        it("increments own unread count if read object contains current user's record", () => {
-          // prepare
-          thread.state.partialNext({
-            read: {
-              [TEST_USER_ID]: {
-                lastReadAt: new Date(),
-                last_read: '',
-                last_read_message_id: '',
-                unread_messages: 2,
-                user: { id: TEST_USER_ID },
-              },
-            },
-          });
-
-          const { read } = thread.state.getLatestValue();
-          const ownUnreadCount = read[TEST_USER_ID]?.unread_messages ?? 0;
-
-          expect(ownUnreadCount).to.equal(2);
-
-          thread.incrementOwnUnreadCount();
-
-          expect(thread.state.getLatestValue().read[TEST_USER_ID]?.unread_messages).to.equal(3);
-        });
-      });
-
-      describe('Thread.deleteReplyLocally', () => {
-        it('deletes appropriate message from the latestReplies array', () => {
-          const TARGET_MESSAGE_INDEX = 2;
-
+      describe('deleteReplyLocally', () => {
+        it('deletes appropriate message', () => {
           const createdAt = new Date().getTime();
           // five messages "created" second apart
-          thread.state.partialNext({
-            latestReplies: Array.from({ length: 5 }, (_, i) =>
-              formatMessage(
-                generateMsg({ created_at: new Date(createdAt + 1000 * i).toISOString() }) as MessageResponse,
-              ),
-            ),
-          });
+          const messages = Array.from(
+            { length: 5 },
+            (_, i) => generateMsg({ created_at: new Date(createdAt + 1000 * i).toISOString() }) as MessageResponse,
+          );
+          const thread = createTestThread({ latest_replies: messages });
 
-          const { latestReplies } = thread.state.getLatestValue();
-
-          expect(latestReplies).to.have.lengthOf(5);
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.replies).to.have.lengthOf(5);
 
           const messageToDelete = generateMsg({
-            created_at: latestReplies[TARGET_MESSAGE_INDEX].created_at.toISOString(),
-            id: latestReplies[TARGET_MESSAGE_INDEX].id,
-          });
+            created_at: messages[2].created_at,
+            id: messages[2].id,
+          }) as MessageResponse;
 
-          expect(latestReplies[TARGET_MESSAGE_INDEX].id).to.equal(messageToDelete.id);
-          expect(latestReplies[TARGET_MESSAGE_INDEX].created_at.toISOString()).to.equal(messageToDelete.created_at);
+          thread.deleteReplyLocally({ message: messageToDelete });
 
-          thread.deleteReplyLocally({ message: messageToDelete as MessageResponse });
-
-          // check whether array signatures changed
-          expect(thread.state.getLatestValue().latestReplies).to.not.equal(latestReplies);
-          expect(thread.state.getLatestValue().latestReplies).to.have.lengthOf(4);
-          expect(thread.state.getLatestValue().latestReplies[TARGET_MESSAGE_INDEX].id).to.not.equal(messageToDelete.id);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.not.equal(stateBefore.replies);
+          expect(stateAfter.replies).to.have.lengthOf(4);
+          expect(stateAfter.replies.find((reply) => reply.id === messageToDelete.id)).to.be.undefined;
         });
       });
 
-      describe('Thread.markAsRead', () => {
+      describe('markAsRead', () => {
         let stubbedChannelMarkRead: sinon.SinonStub<Parameters<Channel['markRead']>, ReturnType<Channel['markRead']>>;
 
         beforeEach(() => {
           stubbedChannelMarkRead = sinon.stub(channel, 'markRead').resolves();
         });
 
-        it('prevents calling channel.markRead if the unread count of the current user is 0', async () => {
-          const { read } = thread.state.getLatestValue();
-          const ownUnreadCount = read[TEST_USER_ID]?.unread_messages ?? 0;
-
-          expect(ownUnreadCount).to.equal(0);
+        it('does nothing if unread count of the current user is zero', async () => {
+          const thread = createTestThread();
+          expect(thread.ownUnreadCount).to.equal(0);
 
           await thread.markAsRead();
 
           expect(stubbedChannelMarkRead.notCalled).to.be.true;
         });
 
-        it('calls channel.markRead if the unread count is greater than zero', async () => {
-          // prepare
-          thread.incrementOwnUnreadCount();
+        it('calls channel.markRead if unread count of the current user is greater than zero', async () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: TEST_USER_ID },
+                unread_messages: 42,
+              },
+            ],
+          });
 
-          const { read } = thread.state.getLatestValue();
-
-          const ownUnreadCount = read[TEST_USER_ID]?.unread_messages ?? 0;
-
-          expect(ownUnreadCount).to.equal(1);
+          expect(thread.ownUnreadCount).to.equal(42);
 
           await thread.markAsRead();
 
@@ -348,76 +304,195 @@ describe('Threads 2.0', () => {
         });
       });
 
-      describe('Thread.loadNextPage', () => {});
+      describe('loadPage', () => {
+        it('sets up pagination on initialization (all replies included in response)', () => {
+          const thread = createTestThread({ latest_replies: [generateMsg() as MessageResponse], reply_count: 1 });
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.prevCursor).to.be.null;
+          expect(state.pagination.nextCursor).to.be.null;
+        });
 
-      describe('Thread.loadPreviousPage', () => {});
+        it('sets up pagination on initialization (not all replies included in response)', () => {
+          const firstMessage = generateMsg() as MessageResponse;
+          const lastMessage = generateMsg() as MessageResponse;
+          const thread = createTestThread({ latest_replies: [firstMessage, lastMessage], reply_count: 3 });
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.prevCursor).not.to.be.null;
+          expect(state.pagination.nextCursor).not.to.be.null;
+        });
+
+        it('updates pagination after loading next page (end reached)', async () => {
+          const thread = createTestThread({
+            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
+            reply_count: 3,
+          });
+          sinon.stub(thread, 'queryReplies').resolves({
+            messages: [generateMsg()] as MessageResponse[],
+            duration: '',
+          });
+
+          await thread.loadPage(2);
+
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.nextCursor).to.be.null;
+        });
+
+        it('updates pagination after loading next page (end not reached)', async () => {
+          const thread = createTestThread({
+            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
+            reply_count: 4,
+          });
+          const lastMessage = generateMsg() as MessageResponse;
+          sinon.stub(thread, 'queryReplies').resolves({
+            messages: [generateMsg(), lastMessage] as MessageResponse[],
+            duration: '',
+          });
+
+          await thread.loadPage(2);
+
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.nextCursor).to.equal(lastMessage.id);
+        });
+
+        it('forms correct request when loading next page', async () => {
+          const firstMessage = generateMsg() as MessageResponse;
+          const lastMessage = generateMsg() as MessageResponse;
+          const thread = createTestThread({ latest_replies: [firstMessage, lastMessage], reply_count: 3 });
+          const queryRepliesStub = sinon.stub(thread, 'queryReplies').resolves({ messages: [], duration: '' });
+
+          await thread.loadPage(42);
+
+          expect(
+            queryRepliesStub.calledOnceWith({
+              id_gt: lastMessage.id,
+              limit: 42,
+            }),
+          ).to.be.true;
+        });
+
+        it('updates pagination after loading previous page (end reached)', async () => {
+          const thread = createTestThread({
+            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
+            reply_count: 3,
+          });
+          sinon.stub(thread, 'queryReplies').resolves({
+            messages: [generateMsg()] as MessageResponse[],
+            duration: '',
+          });
+
+          await thread.loadPage(-2);
+
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.prevCursor).to.be.null;
+        });
+
+        it('updates pagination after loading previous page (end not reached)', async () => {
+          const thread = createTestThread({
+            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
+            reply_count: 4,
+          });
+          const firstMessage = generateMsg() as MessageResponse;
+          sinon.stub(thread, 'queryReplies').resolves({
+            messages: [firstMessage, generateMsg()] as MessageResponse[],
+            duration: '',
+          });
+
+          await thread.loadPage(-2);
+
+          const state = thread.state.getLatestValue();
+          expect(state.pagination.prevCursor).to.equal(firstMessage.id);
+        });
+
+        it('forms correct request when loading previous page', async () => {
+          const firstMessage = generateMsg() as MessageResponse;
+          const lastMessage = generateMsg() as MessageResponse;
+          const thread = createTestThread({ latest_replies: [firstMessage, lastMessage], reply_count: 3 });
+          const queryRepliesStub = sinon.stub(thread, 'queryReplies').resolves({ messages: [], duration: '' });
+
+          await thread.loadPage(-42);
+
+          expect(
+            queryRepliesStub.calledOnceWith({
+              id_lt: firstMessage.id,
+              limit: 42,
+            }),
+          ).to.be.true;
+        });
+      });
     });
 
-    describe('Subscription Handlers', () => {
-      // let timers: sinon.SinonFakeTimers;
-
-      beforeEach(() => {
+    describe('Subscription and Event Handlers', () => {
+      it('marks active channel as read', () => {
+        const thread = createTestThread({
+          read: [
+            {
+              last_read: new Date().toISOString(),
+              user: { id: TEST_USER_ID },
+              unread_messages: 42,
+            },
+          ],
+        });
         thread.registerSubscriptions();
-      });
 
-      it('calls markAsRead whenever thread becomes active or own reply count increases', () => {
-        const timers = sinon.useFakeTimers({ toFake: ['setTimeout'] });
-
+        const stateBefore = thread.state.getLatestValue();
         const stubbedMarkAsRead = sinon.stub(thread, 'markAsRead').resolves();
-
-        thread.incrementOwnUnreadCount();
-
-        expect(thread.state.getLatestValue().active).to.be.false;
-        expect(thread.state.getLatestValue().read[TEST_USER_ID].unread_messages).to.equal(1);
+        expect(stateBefore.active).to.be.false;
+        expect(thread.ownUnreadCount).to.equal(42);
         expect(stubbedMarkAsRead.called).to.be.false;
 
         thread.activate();
 
-        expect(thread.state.getLatestValue().active).to.be.true;
-        expect(stubbedMarkAsRead.calledOnce, 'Called once').to.be.true;
+        const stateAfter = thread.state.getLatestValue();
+        expect(stateAfter.active).to.be.true;
+        expect(stubbedMarkAsRead.calledOnce).to.be.true;
 
-        thread.incrementOwnUnreadCount();
+        client.dispatchEvent({
+          type: 'message.new',
+          message: generateMsg({ parent_id: thread.id, user: { id: 'bob' } }) as MessageResponse,
+          user: { id: 'bob' },
+        });
 
-        timers.tick(DEFAULT_MARK_AS_READ_THROTTLE_DURATION + 1);
+        expect(stubbedMarkAsRead.calledTwice).to.be.true;
 
-        expect(stubbedMarkAsRead.calledTwice, 'Called twice').to.be.true;
-
-        timers.restore();
+        thread.unregisterSubscriptions();
       });
 
-      it('recovers from stale state whenever the thread becomes active (or is active and its state becomes stale)', async () => {
-        // prepare
-        const newThread = new Thread({
-          client,
-          threadData: generateThread(channelResponse, generateMsg({ id: parentMessageResponse.id })),
-        });
-        const stubbedGetThread = sinon.stub(client, 'getThread').resolves(newThread);
-        const partiallyReplaceStateSpy = sinon.spy(thread, 'partiallyReplaceState');
+      it('reloads stale state when thread is active', async () => {
+        const thread = createTestThread();
+        thread.registerSubscriptions();
+
+        const stateBefore = thread.state.getLatestValue();
+        const stubbedGetThread = sinon
+          .stub(client, 'getThread')
+          .resolves(createTestThread({ latest_replies: [generateMsg() as MessageResponse] }));
 
         thread.state.partialNext({ isStateStale: true });
 
-        expect(thread.state.getLatestValue().isStateStale).to.be.true;
+        expect(thread.hasStaleState).to.be.true;
         expect(stubbedGetThread.called).to.be.false;
-        expect(partiallyReplaceStateSpy.called).to.be.false;
 
         thread.activate();
 
         expect(stubbedGetThread.calledOnce).to.be.true;
-
         await stubbedGetThread.firstCall.returnValue;
+        const stateAfter = thread.state.getLatestValue();
+        expect(stateAfter.replies).not.to.equal(stateBefore.replies);
 
-        expect(partiallyReplaceStateSpy.calledWith({ thread: newThread })).to.be.true;
+        thread.unregisterSubscriptions();
       });
 
-      describe('Event user.watching.stop', () => {
+      describe('Event: user.watching.stop', () => {
         it('ignores incoming event if the data do not match (channel or user.id)', () => {
+          const thread = createTestThread();
+          thread.registerSubscriptions();
+
           client.dispatchEvent({
             type: 'user.watching.stop',
-            channel: channelResponse as ChannelResponse,
+            channel: channelResponse,
             user: { id: 'bob' },
           });
 
-          expect(thread.state.getLatestValue().isStateStale).to.be.false;
+          expect(thread.hasStaleState).to.be.false;
 
           client.dispatchEvent({
             type: 'user.watching.stop',
@@ -425,148 +500,274 @@ describe('Threads 2.0', () => {
             user: { id: TEST_USER_ID },
           });
 
-          expect(thread.state.getLatestValue().isStateStale).to.be.false;
+          expect(thread.hasStaleState).to.be.false;
+
+          thread.unregisterSubscriptions();
         });
 
         it('marks own state as stale whenever current user stops watching associated channel', () => {
+          const thread = createTestThread();
+          thread.registerSubscriptions();
+
           client.dispatchEvent({
             type: 'user.watching.stop',
-            channel: channelResponse as ChannelResponse,
+            channel: channelResponse,
             user: { id: TEST_USER_ID },
           });
 
-          expect(thread.state.getLatestValue().isStateStale).to.be.true;
+          expect(thread.hasStaleState).to.be.true;
+
+          thread.unregisterSubscriptions();
         });
       });
 
-      describe('Event message.read', () => {
-        it('prevents adjusting unread_messages & last_read if thread.id does not match', () => {
-          // prepare
-          thread.incrementOwnUnreadCount();
-          expect(thread.state.getLatestValue().read[TEST_USER_ID].unread_messages).to.equal(1);
+      describe('Event: message.read', () => {
+        it('does not update read state with events from other threads', () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: 'bob' },
+                unread_messages: 42,
+              },
+            ],
+          });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.read['bob']?.unreadMessageCount).to.equal(42);
 
           client.dispatchEvent({
             type: 'message.read',
-            user: { id: TEST_USER_ID },
-            thread: (generateThread(channelResponse, generateMsg()) as unknown) as ThreadResponse,
+            user: { id: 'bob' },
+            thread: generateThread(channelResponse, generateMsg()) as ThreadResponse,
           });
 
-          expect(thread.state.getLatestValue().read[TEST_USER_ID].unread_messages).to.equal(1);
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.read['bob']?.unreadMessageCount).to.equal(42);
         });
 
-        [TEST_USER_ID, 'bob'].forEach((userId) => {
-          it(`correctly sets read information for user with id: ${userId}`, () => {
-            // prepare
-            const lastReadAt = new Date();
-            thread.state.partialNext({
-              read: {
-                [userId]: {
-                  lastReadAt: lastReadAt,
-                  last_read: lastReadAt.toISOString(),
-                  last_read_message_id: '',
-                  unread_messages: 1,
-                  user: { id: userId },
-                },
+        it('correctly updates read information for user', () => {
+          const lastReadAt = new Date();
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: lastReadAt.toISOString(),
+                last_read_message_id: '',
+                unread_messages: 42,
+                user: { id: 'bob' },
               },
-            });
-
-            expect(thread.state.getLatestValue().read[userId].unread_messages).to.equal(1);
-
-            const createdAt = new Date().toISOString();
-
-            client.dispatchEvent({
-              type: 'message.read',
-              user: { id: userId },
-              thread: (generateThread(
-                channelResponse,
-                generateMsg({ id: parentMessageResponse.id }),
-              ) as unknown) as ThreadResponse,
-              created_at: createdAt,
-            });
-
-            expect(thread.state.getLatestValue().read[userId].unread_messages).to.equal(0);
-            expect(thread.state.getLatestValue().read[userId].last_read).to.equal(createdAt);
+            ],
           });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.read['bob']?.unreadMessageCount).to.equal(42);
+          const createdAt = new Date();
+
+          client.dispatchEvent({
+            type: 'message.read',
+            user: { id: 'bob' },
+            thread: generateThread(channelResponse, generateMsg({ id: parentMessageResponse.id })) as ThreadResponse,
+            created_at: createdAt.toISOString(),
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.read['bob']?.unreadMessageCount).to.equal(0);
+          expect(stateAfter.read['bob']?.lastReadAt.toISOString()).to.equal(createdAt.toISOString());
+
+          thread.unregisterSubscriptions();
         });
       });
 
-      describe('Event message.new', () => {
-        it('prevents handling a reply if it does not belong to the associated thread', () => {
-          // prepare
-          const upsertReplyLocallySpy = sinon.spy(thread, 'upsertReplyLocally');
+      describe('Event: message.new', () => {
+        it('ignores a reply if it does not belong to the associated thread', () => {
+          const thread = createTestThread();
+          thread.registerSubscriptions();
+          const stateBefore = thread.state.getLatestValue();
 
           client.dispatchEvent({
             type: 'message.new',
             message: generateMsg({ parent_id: uuidv4() }) as MessageResponse,
+            user: { id: TEST_USER_ID },
           });
 
-          expect(upsertReplyLocallySpy.called).to.be.false;
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateBefore).to.equal(stateAfter);
+
+          thread.unregisterSubscriptions();
         });
 
         it('prevents handling a reply if the state of the thread is stale', () => {
-          // prepare
-          const upsertReplyLocallySpy = sinon.spy(thread, 'upsertReplyLocally');
-
+          const thread = createTestThread();
+          thread.registerSubscriptions();
           thread.state.partialNext({ isStateStale: true });
+          const stateBefore = thread.state.getLatestValue();
 
-          client.dispatchEvent({ type: 'message.new', message: generateMsg({ id: thread.id }) as MessageResponse });
+          client.dispatchEvent({
+            type: 'message.new',
+            message: generateMsg({ parent_id: uuidv4() }) as MessageResponse,
+            user: { id: TEST_USER_ID },
+          });
 
-          expect(upsertReplyLocallySpy.called).to.be.false;
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateBefore).to.equal(stateAfter);
+
+          thread.unregisterSubscriptions();
         });
 
-        it('calls upsertLocalReply with proper values and calls incrementOwnUnreadCount if the reply does not belong to current user', () => {
-          // prepare
-          const upsertReplyLocallySpy = sinon.spy(thread, 'upsertReplyLocally');
-          const incrementOwnUnreadCountSpy = sinon.spy(thread, 'incrementOwnUnreadCount');
+        it('increments unread count if the reply does not belong to current user', () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: TEST_USER_ID },
+                unread_messages: 0,
+              },
+            ],
+          });
+          thread.registerSubscriptions();
 
           const newMessage = generateMsg({ parent_id: thread.id, user: { id: 'bob' } }) as MessageResponse;
-
           client.dispatchEvent({
             type: 'message.new',
             message: newMessage,
+            user: { id: 'bob' },
           });
 
-          expect(upsertReplyLocallySpy.calledWith({ message: newMessage, timestampChanged: false })).to.be.true;
-          expect(incrementOwnUnreadCountSpy.called).to.be.true;
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.length(1);
+          expect(stateAfter.replies.find((reply) => reply.id === newMessage.id)).not.to.be.undefined;
+          expect(thread.ownUnreadCount).to.equal(1);
+
+          thread.unregisterSubscriptions();
         });
 
-        it('calls upsertLocalReply with timestampChanged true if the reply belongs to the current user', () => {
-          // prepare
-          const upsertReplyLocallySpy = sinon.spy(thread, 'upsertReplyLocally');
-          const incrementOwnUnreadCountSpy = sinon.spy(thread, 'incrementOwnUnreadCount');
+        it('handles receiving a reply that was previously optimistically added', () => {
+          const thread = createTestThread({
+            latest_replies: [generateMsg() as MessageResponse],
+            read: [
+              {
+                user: { id: TEST_USER_ID },
+                last_read: new Date().toISOString(),
+                unread_messages: 0,
+              },
+            ],
+          });
+          const message = generateMsg({
+            parent_id: thread.id,
+            user: { id: TEST_USER_ID },
+          }) as MessageResponse;
+          thread.upsertReplyLocally({ message });
 
-          const newMessage = generateMsg({ parent_id: thread.id, user: { id: TEST_USER_ID } }) as MessageResponse;
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.replies).to.have.length(2);
+          expect(thread.ownUnreadCount).to.equal(0);
 
           client.dispatchEvent({
             type: 'message.new',
-            message: newMessage,
+            message,
+            user: { id: TEST_USER_ID },
           });
 
-          expect(upsertReplyLocallySpy.calledWith({ message: newMessage, timestampChanged: true })).to.be.true;
-          expect(incrementOwnUnreadCountSpy.called).to.be.false;
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.length(2);
+          expect(thread.ownUnreadCount).to.equal(0);
         });
-
-        // TODO: cover failed replies at some point
       });
 
-      describe('Events message.updated, message.deleted, reaction.new, reaction.deleted', () => {
-        it('calls deleteReplyLocally if the reply has been hard-deleted', () => {
-          const deleteReplyLocallySpy = sinon.spy(thread, 'deleteReplyLocally');
-          const updateParentMessageOrReplyLocallySpy = sinon.spy(thread, 'updateParentMessageOrReplyLocally');
+      it('resets unread count when new message is by the current user', () => {
+        const thread = createTestThread({
+          read: [
+            {
+              last_read: new Date().toISOString(),
+              user: { id: TEST_USER_ID },
+              unread_messages: 42,
+            },
+          ],
+        });
+        thread.registerSubscriptions();
+
+        expect(thread.ownUnreadCount).to.equal(42);
+
+        client.dispatchEvent({
+          type: 'message.new',
+          message: generateMsg({
+            parent_id: thread.id,
+            user: { id: TEST_USER_ID },
+          }) as MessageResponse,
+          user: { id: TEST_USER_ID },
+        });
+
+        expect(thread.ownUnreadCount).to.equal(0);
+
+        thread.unregisterSubscriptions();
+      });
+
+      it('does not increment unread count in an active thread', () => {
+        const thread = createTestThread({
+          read: [
+            {
+              last_read: new Date().toISOString(),
+              user: { id: TEST_USER_ID },
+              unread_messages: 0,
+            },
+          ],
+        });
+        thread.registerSubscriptions();
+        thread.activate();
+
+        client.dispatchEvent({
+          type: 'message.new',
+          message: generateMsg({
+            parent_id: thread.id,
+            user: { id: 'bob' },
+          }) as MessageResponse,
+          user: { id: 'bob' },
+        });
+
+        expect(thread.ownUnreadCount).to.equal(0);
+
+        thread.unregisterSubscriptions();
+      });
+
+      describe('Event: message.deleted', () => {
+        it('deletes reply if the message was hard-deleted', () => {
+          const createdAt = new Date().getTime();
+          // five messages "created" second apart
+          const messages = Array.from(
+            { length: 5 },
+            (_, i) =>
+              generateMsg({
+                parent_id: parentMessageResponse.id,
+                created_at: new Date(createdAt + 1000 * i).toISOString(),
+              }) as MessageResponse,
+          );
+          const thread = createTestThread({ latest_replies: messages });
+          thread.registerSubscriptions();
+
+          const messageToDelete = messages[2];
 
           client.dispatchEvent({
             type: 'message.deleted',
             hard_delete: true,
-            message: generateMsg({ parent_id: thread.id }) as MessageResponse,
+            message: messageToDelete,
           });
 
-          expect(deleteReplyLocallySpy.calledOnce).to.be.true;
-          expect(updateParentMessageOrReplyLocallySpy.called).to.be.false;
-        });
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.replies).to.have.lengthOf(4);
+          expect(stateAfter.replies.find((reply) => reply.id === messageToDelete.id)).to.be.undefined;
 
-        (['message.updated', 'message.deleted', 'reaction.new', 'reaction.deleted'] as const).forEach((eventType) => {
-          it(`calls updateParentMessageOrReplyLocally on ${eventType}`, () => {
+          thread.unregisterSubscriptions();
+        });
+      });
+
+      describe('Events: message.updated, reaction.new, reaction.deleted', () => {
+        (['message.updated', 'reaction.new', 'reaction.deleted'] as const).forEach((eventType) => {
+          it(`updates reply or parent message on "${eventType}"`, () => {
+            const thread = createTestThread();
             const updateParentMessageOrReplyLocallySpy = sinon.spy(thread, 'updateParentMessageOrReplyLocally');
+            thread.registerSubscriptions();
 
             client.dispatchEvent({
               type: eventType,
@@ -574,6 +775,8 @@ describe('Threads 2.0', () => {
             });
 
             expect(updateParentMessageOrReplyLocallySpy.calledOnce).to.be.true;
+
+            thread.unregisterSubscriptions();
           });
         });
       });
@@ -821,7 +1024,7 @@ describe('Threads 2.0', () => {
 
           const newThread = new Thread({
             client,
-            threadData: generateThread(channelResponse, parentMessageResponse, { thread_participants: [{ id: 'u1' }] }),
+            threadData: generateThread(channelResponse, parentMessage, { thread_participants: [{ id: 'u1' }] }),
           });
 
           expect(thread.state.getLatestValue().participants).to.have.lengthOf(0);
@@ -856,7 +1059,7 @@ describe('Threads 2.0', () => {
             // same thread.id as prepared thread (just changed position in the response and different instance)
             new Thread({
               client,
-              threadData: generateThread(channelResponse, parentMessageResponse, {
+              threadData: generateThread(channelResponse, parentMessage, {
                 thread_participants: [{ id: 'u1' }],
               }),
             }),

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -451,6 +451,8 @@ describe('Threads 2.0', () => {
 
     describe('Subscription and Event Handlers', () => {
       it('marks active channel as read', () => {
+        const clock = sinon.useFakeTimers();
+
         const thread = createTestThread({
           read: [
             {
@@ -469,6 +471,7 @@ describe('Threads 2.0', () => {
         expect(stubbedMarkAsRead.called).to.be.false;
 
         thread.activate();
+        clock.runAll();
 
         const stateAfter = thread.state.getLatestValue();
         expect(stateAfter.active).to.be.true;
@@ -479,10 +482,12 @@ describe('Threads 2.0', () => {
           message: generateMsg({ parent_id: thread.id, user: { id: 'bob' } }) as MessageResponse,
           user: { id: 'bob' },
         });
+        clock.runAll();
 
         expect(stubbedMarkAsRead.calledTwice).to.be.true;
 
         thread.unregisterSubscriptions();
+        clock.restore();
       });
 
       it('reloads stale state when thread is active', async () => {


### PR DESCRIPTION
Notable changes:

- Removed throttling from all subscriptions, should work properly without any throttling.
- Fixed handling read states (see `subscribeNewReplies` and `markAsRead`). Got rid of the `incrementOwnUnreadCount` - it's now part of a more generic update performed on `message.new`.
- Fixed a bug caused by typo in pagination logic.
- Updated most tests. Replaced spying on methods (which tests implementation details) with checking resulting state.
- Added tests for pagination logic.
- All tests for Thread are now green.
- Either fixed TODOs that were fixable, or removed TODOs that we are not going to get to any time soon.

Don't expect green CI in this PR. These changes are in a separate PR so that reviewing is at least feasible :)