### PR TITLE
fix: include system messages in unread count

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -925,7 +925,6 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     if (message.parent_id && !message.show_in_channel) return false;
     if (message.user?.id === this.getClient().userID) return false;
     if (message.user?.id && this.getClient().userMuteStatus(message.user.id)) return false;
-    if (message.type === 'system') return false;
 
     // Return false if channel doesn't allow read events.
     if (Array.isArray(this.data?.own_capabilities) && !this.data?.own_capabilities.includes('read-events'))

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -66,8 +66,8 @@ describe('Channel count unread', function () {
 		expect(channel._countMessageAsUnread({ user })).not.to.be.ok;
 	});
 
-	it('_countMessageAsUnread should return false for system messages', function () {
-		expect(channel._countMessageAsUnread({ type: 'system' })).not.to.be.ok;
+	it('_countMessageAsUnread should return true for system messages', function () {
+		expect(channel._countMessageAsUnread({ type: 'system' })).to.be.true;
 	});
 
 	it('_countMessageAsUnread should return false for muted user', function () {


### PR DESCRIPTION
The client should include system messages in the unread count, like all other SDKs do.

Before:

https://github.com/user-attachments/assets/11a59968-1b3b-4528-9cbf-1040abedb49b

After:

https://github.com/user-attachments/assets/2c85ff18-8c8d-44a0-83ae-e8e8d863ab40