### PR TITLE
fix: hydrate channel instance from thread response

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1653,12 +1653,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     }
 
     if (state.members) {
-      this.state.members = state.members.reduce((acc, member) => {
-        if (member.user) {
-          acc[member.user.id] = member;
-        }
-        return acc;
-      }, {} as ChannelState<StreamChatGenerics>['members']);
+      this._hydrateMembers(state.members);
     }
 
     return {
@@ -1674,6 +1669,15 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     if (message) {
       event.message.own_reactions = message.own_reactions;
     }
+  }
+
+  _hydrateMembers(members: ChannelMemberResponse<StreamChatGenerics>[]) {
+    this.state.members = members.reduce((acc, member) => {
+      if (member.user) {
+        acc[member.user.id] = member;
+      }
+      return acc;
+    }, {} as ChannelState<StreamChatGenerics>['members']);
   }
 
   _disconnect() {

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -74,9 +74,17 @@ export class Thread<SCG extends ExtendableGenerics = DefaultGenerics> {
   private failedRepliesMap: Map<string, FormatMessageResponse<SCG>> = new Map();
 
   constructor({ client, threadData }: { client: StreamChat<SCG>; threadData: ThreadResponse<SCG> }) {
+    const channel = client.channel(threadData.channel.type, threadData.channel.id, {
+      name: threadData.channel.name,
+    });
+
+    if (threadData.channel.members) {
+      channel._hydrateMembers(threadData.channel.members);
+    }
+
     this.state = new StateStore<ThreadState<SCG>>({
       active: false,
-      channel: client.channel(threadData.channel.type, threadData.channel.id),
+      channel,
       createdAt: new Date(threadData.created_at),
       deletedAt: threadData.deleted_at ? new Date(threadData.deleted_at) : null,
       isLoading: false,

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -46,7 +46,7 @@ describe('Threads 2.0', () => {
   beforeEach(() => {
     client = new StreamChat('apiKey');
     client._setUser({ id: TEST_USER_ID });
-    channelResponse = generateChannel({ channel: { id: uuidv4() } }).channel as ChannelResponse;
+    channelResponse = generateChannel({ channel: { id: uuidv4(), name: 'Test channel' } }).channel as ChannelResponse;
     channel = client.channel(channelResponse.type, channelResponse.id);
     parentMessageResponse = generateMsg() as MessageResponse;
     threadManager = new ThreadManager({ client });
@@ -57,7 +57,7 @@ describe('Threads 2.0', () => {
       const thread = new Thread({ client, threadData: generateThread(channelResponse, parentMessageResponse) });
 
       expect(thread.id).to.equal(parentMessageResponse.id);
-      expect(thread.channel.data).to.be.empty;
+      expect(thread.channel.data?.name).to.equal(channelResponse.name);
     });
 
     describe('Methods', () => {


### PR DESCRIPTION
Previously, `Thread` instance created an unitized `Channel` instance for the parent channel. The idea was that when the thread is rendered, it will be rendered inside the `Channel` component which will take care of initializing the instance.

However, it makes sense to expect at least _some_ data in this channel instance: its name and members. This data is available in the thread response which is used to construct a `Thread` instance.

So now we try to hydrate the channel instance with whatever data we have. This fixes at least one known bug: channel names were not rendered in thread list view unless channel was previously queried.

Before:

![Screenshot 2024-09-10 at 16 39 13](https://github.com/user-attachments/assets/43147c34-9a6e-4e59-9d8e-176d0663b109)

After:

![Screenshot 2024-09-10 at 17 02 10](https://github.com/user-attachments/assets/124ce798-d58a-40b7-89a2-5e2a64180d0d)