### PR TITLE
fix: adding message to an empty message list

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,8 +384,10 @@ export function addToMessageList<T extends FormatMessageResponse>(
   }
 
   // for empty list just concat and return unless it's an update or deletion
-  if (!newMessages.length && addMessageToList) {
+  if (newMessages.length === 0 && addMessageToList) {
     return newMessages.concat(newMessage);
+  } else if (newMessages.length === 0) {
+    return newMessages;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -396,6 +398,8 @@ export function addToMessageList<T extends FormatMessageResponse>(
   // if message is newer than last item in the list concat and return unless it's an update or deletion
   if (messageIsNewest && addMessageToList) {
     return newMessages.concat(newMessage);
+  } else if (newMessages.length === 0) {
+    return newMessages;
   }
 
   // find the closest index to push the new message


### PR DESCRIPTION
The refactor of the `addToMessageList` function made in #1330 contained an unfortunate error which prevents adding a message to an empty message list.

See:
- https://github.com/GetStream/stream-chat-js/pull/1330/files#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351L331-R388
- https://github.com/GetStream/stream-chat-js/pull/1330/files#diff-39b2554fd18da165b59a6351b1aafff3714e2a80c1435f2de9706355b4d32351R397-R399