### PR TITLE
fix: allow hydrating thread's channel with an empty members list

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -77,10 +77,7 @@ export class Thread<SCG extends ExtendableGenerics = DefaultGenerics> {
     const channel = client.channel(threadData.channel.type, threadData.channel.id, {
       name: threadData.channel.name,
     });
-
-    if (threadData.channel.members) {
-      channel._hydrateMembers(threadData.channel.members);
-    }
+    channel._hydrateMembers(threadData.channel.members ?? []);
 
     this.state = new StateStore<ThreadState<SCG>>({
       active: false,


### PR DESCRIPTION
🚂 #1354 

An empty members list should also be used to hydrate a thread's channel. One case when empty members list is meaningful is requesting with `member_limit: 0`.