### PR TITLE
fix: initial load threads edge case

### DIFF
--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -208,7 +208,9 @@ export class ThreadManager<SCG extends ExtendableGenerics = DefaultGenerics> {
         },
       }));
 
-      const response = await this.queryThreads({ limit: Math.min(limit, MAX_QUERY_THREADS_LIMIT) || MAX_QUERY_THREADS_LIMIT });
+      const response = await this.queryThreads({
+        limit: Math.min(limit, MAX_QUERY_THREADS_LIMIT) || MAX_QUERY_THREADS_LIMIT,
+      });
 
       const currentThreads = this.threadsById;
       const nextThreads: Thread<SCG>[] = [];

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -208,7 +208,7 @@ export class ThreadManager<SCG extends ExtendableGenerics = DefaultGenerics> {
         },
       }));
 
-      const response = await this.queryThreads({ limit: Math.min(limit, MAX_QUERY_THREADS_LIMIT) });
+      const response = await this.queryThreads({ limit: Math.min(limit, MAX_QUERY_THREADS_LIMIT) || MAX_QUERY_THREADS_LIMIT });
 
       const currentThreads = this.threadsById;
       const nextThreads: Thread<SCG>[] = [];

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1099,6 +1099,14 @@ describe('Threads 2.0', () => {
       });
 
       describe('reload', () => {
+        it('reloads with a default limit if both threads and unseenThreadIds are empty', async () => {
+          threadManager.state.partialNext(({
+            threads: [],
+            unseenThreadIds: [],
+          }));
+          await threadManager.reload();
+          expect(stubbedQueryThreads.calledWithMatch({ limit: 25 })).to.be.true;
+        })
         it('skips reload if there were no updates since the latest reload', async () => {
           threadManager.state.partialNext({ ready: true });
           await threadManager.reload();

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1100,13 +1100,13 @@ describe('Threads 2.0', () => {
 
       describe('reload', () => {
         it('reloads with a default limit if both threads and unseenThreadIds are empty', async () => {
-          threadManager.state.partialNext(({
+          threadManager.state.partialNext({
             threads: [],
             unseenThreadIds: [],
-          }));
+          });
           await threadManager.reload();
           expect(stubbedQueryThreads.calledWithMatch({ limit: 25 })).to.be.true;
-        })
+        });
         it('skips reload if there were no updates since the latest reload', async () => {
           threadManager.state.partialNext({ ready: true });
           await threadManager.reload();


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

There is currently a weird behaviour on the thread query-ing endpoint in the backend where if you call it with `{ limit: 0}` it skips the pagination entirely and returns all of the threads. While things aren't initialized yet, it is entirely possible that both `threads.length` and `unseenThreadIds.length` are `0`, hence the issue occurring (typically on the first ever load of the thread list).

This PR takes care that this doesn't happen and the `limit` is never `0`.

## Changelog

-
