### PR TITLE
fix: merge custom data with current one rather than override

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1971,8 +1971,8 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     if (cid in this.activeChannels && !this.activeChannels[cid].disconnected) {
       const channel = this.activeChannels[cid];
       if (Object.keys(custom).length > 0) {
-        channel.data = custom;
-        channel._data = custom;
+        channel.data = { ...channel.data, ...custom };
+        channel._data = { ...channel._data, ...custom };
       }
       return channel;
     }

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -779,6 +779,17 @@ describe('Channels - Constructor', function () {
 		done();
 	});
 
+	it('custom data merges to the right with current data', function (done) {
+		let channel = client.channel('messaging', 'brand_new_123', { cool: true });
+		expect(channel.cid).to.eql('messaging:brand_new_123');
+		expect(channel.id).to.eql('brand_new_123');
+		expect(channel.data).to.eql({ cool: true });
+		channel = client.channel('messaging', 'brand_new_123', { custom_cool: true });
+		console.log(channel.data)
+		expect(channel.data).to.eql({ cool: true, custom_cool: true });
+		done();
+	});
+
 	it('default options', function (done) {
 		const channel = client.channel('messaging', '123');
 		expect(channel.cid).to.eql('messaging:123');

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -785,7 +785,7 @@ describe('Channels - Constructor', function () {
 		expect(channel.id).to.eql('brand_new_123');
 		expect(channel.data).to.eql({ cool: true });
 		channel = client.channel('messaging', 'brand_new_123', { custom_cool: true });
-		console.log(channel.data)
+		console.log(channel.data);
 		expect(channel.data).to.eql({ cool: true, custom_cool: true });
 		done();
 	});


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR solves an issue where whenever custom data is being passed to an already existing channel, `channel.data` would be overwritten rather than merged with the custom data. This makes sure that this situation doesn't happen and that the channel is kept in tact regardless of what we passed.

## Changelog

-
