### PR TITLE
feat: add support for channel pinning and archiving

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -645,6 +645,94 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   /**
+   * archive - archives the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.archives();
+   *
+   * example server side:
+   * await channel.archive({user_id: userId});
+   *
+   */
+  async archive(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for archiving a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { archived: true } });
+    return resp.channel_member;
+  }
+
+  /**
+   * unarchive - unarchives the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.unpin();
+   *
+   * example server side:
+   * await channel.unpin({user_id: userId});
+   *
+   */
+  async unarchive(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for unarchiving a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { archived: false } });
+    return resp.channel_member;
+  }
+
+  /**
+   * pin - pins the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.pin();
+   *
+   * example server side:
+   * await channel.pin({user_id: userId});
+   *
+   */
+  async pin(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for pinning a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { pinned: true } });
+    return resp.channel_member;
+  }
+
+  /**
+   * unpin - unpins the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.unpin();
+   *
+   * example server side:
+   * await channel.unpin({user_id: userId});
+   *
+   */
+  async unpin(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for unpinning a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { pinned: false } });
+    return resp.channel_member;
+  }
+
+  /**
    * muteStatus - returns the mute status for the current channel
    * @return {{ muted: boolean; createdAt: Date | null; expiresAt: Date | null }} { muted: true | false, createdAt: Date | null, expiresAt: Date | null}
    */

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -57,6 +57,7 @@ import {
   PollVoteData,
   SendMessageOptions,
   AscDesc,
+  PartialUpdateMemberAPIResponse,
 } from './types';
 import { Role } from './permissions';
 import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from './constants';
@@ -313,7 +314,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       throw Error('Please specify the user id');
     }
 
-    return await this.getClient().patch<ChannelMemberResponse<StreamChatGenerics>>(
+    return await this.getClient().patch<PartialUpdateMemberAPIResponse<StreamChatGenerics>>(
       this._channelURL() + `/member/${encodeURIComponent(user_id)}`,
       updates,
     );

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -308,7 +308,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
    *
    * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} Updated member
    */
-  async partialUpdateMember(user_id: string, updates: PartialUpdateMember<StreamChatGenerics>) {
+  async partialUpdateMember(user_id: string, updates: PartialUpdateMember) {
     if (!user_id) {
       throw Error('Please specify the user id');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -977,10 +977,10 @@ export type CreateChannelOptions<StreamChatGenerics extends ExtendableGenerics =
   reminders?: boolean;
   replies?: boolean;
   search?: boolean;
+  skip_last_msg_update_for_system_msgs?: boolean;
   typing_events?: boolean;
   uploads?: boolean;
   url_enrichment?: boolean;
-  skip_last_msg_update_for_system_msgs?: boolean;
 };
 
 export type CreateCommandOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,10 +332,13 @@ export type ChannelMemberAPIResponse<StreamChatGenerics extends ExtendableGeneri
 };
 
 export type ChannelMemberUpdates = {
+  archived?: boolean;
   channel_role?: Role;
+  pinned?: boolean;
 };
 
 export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
+  archived_at?: string;
   ban_expires?: string;
   banned?: boolean;
   channel_role?: Role;
@@ -345,6 +348,7 @@ export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics 
   invited?: boolean;
   is_moderator?: boolean;
   notifications_muted?: boolean;
+  pinned_at?: string;
   role?: string;
   shadow_banned?: boolean;
   status?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1501,6 +1501,9 @@ export type ChannelFilters<StreamChatGenerics extends ExtendableGenerics = Defau
               userType: StreamChatGenerics['userType'];
             }>[Key]
           >;
+    } & {
+      archived?: boolean;
+      pinned?: boolean;
     }
 >;
 
@@ -1808,7 +1811,8 @@ export type ReactionSortBase<StreamChatGenerics extends ExtendableGenerics = Def
 
 export type ChannelSort<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
   | ChannelSortBase<StreamChatGenerics>
-  | Array<ChannelSortBase<StreamChatGenerics>>;
+  | Array<ChannelSortBase<StreamChatGenerics>>
+  | { pinned_at: AscDesc };
 
 export type ChannelSortBase<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Sort<
   StreamChatGenerics['channelType']

--- a/src/types.ts
+++ b/src/types.ts
@@ -357,6 +357,12 @@ export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics 
   user_id?: string;
 };
 
+export type PartialUpdateMemberAPIResponse<
+  StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
+> = APIResponse & {
+  channel_member: ChannelMemberResponse<StreamChatGenerics>;
+};
+
 export type CheckPushResponse = APIResponse & {
   device_errors?: {
     [deviceID: string]: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,10 @@ export type ChannelMemberAPIResponse<StreamChatGenerics extends ExtendableGeneri
   members: ChannelMemberResponse<StreamChatGenerics>[];
 };
 
+export type ChannelMemberUpdates = {
+  channel_role?: Role;
+};
+
 export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   ban_expires?: string;
   banned?: boolean;
@@ -2485,9 +2489,9 @@ export type PartialUpdateChannel<StreamChatGenerics extends ExtendableGenerics =
   unset?: Array<keyof ChannelResponse<StreamChatGenerics>>;
 };
 
-export type PartialUpdateMember<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
-  set?: Partial<ChannelMemberResponse<StreamChatGenerics>>;
-  unset?: Array<keyof ChannelMemberResponse<StreamChatGenerics>>;
+export type PartialUpdateMember = {
+  set?: ChannelMemberUpdates;
+  unset?: Array<keyof ChannelMemberUpdates>;
 };
 
 export type PartialUserUpdate<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This adds support for pinning and archiving channels. The channel pin is stored on the user-channel relationship (channel membership). The backend API endpoint for this is not yet live.

## Changelog

- Fix `partialUpdateMember` returning a type without the `channel_member` key that's returned from the API
- Add support for pinning channels using `updateMemberPartial` (just TS type update)
- Add `channel.archive()` and `channel.unarchive()`
- Add `channel.pin()` and `channel.unpin()`
- Add support for added filter and sort fields in `queryChannels`