### PR TITLE
fix: change subscribeWithSelector API declaration

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -36,13 +36,23 @@ export class StateStore<T extends Record<string, unknown>> {
     };
   };
 
-  public subscribeWithSelector = <O extends readonly unknown[]>(selector: (nextValue: T) => O, handler: Handler<O>) => {
+  public subscribeWithSelector = <O extends Readonly<Record<string, unknown>> & { length?: never }>(
+    selector: (nextValue: T) => O,
+    handler: Handler<O>,
+  ) => {
     // begin with undefined to reduce amount of selector calls
     let selectedValues: O | undefined;
 
     const wrappedHandler: Handler<T> = (nextValue) => {
       const newlySelectedValues = selector(nextValue);
-      const hasUpdatedValues = selectedValues?.some((value, index) => value !== newlySelectedValues[index]) ?? true;
+
+      let hasUpdatedValues = !selectedValues;
+
+      for (const key in selectedValues) {
+        if (selectedValues[key] === newlySelectedValues[key]) continue;
+        hasUpdatedValues = true;
+        break;
+      }
 
       if (!hasUpdatedValues) return;
 

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -197,8 +197,11 @@ export class Thread<SCG extends ExtendableGenerics = DefaultGenerics> {
 
   private subscribeMarkActiveThreadRead = () => {
     return this.state.subscribeWithSelector(
-      (nextValue) => [nextValue.active, ownUnreadCountSelector(this.client.userID)(nextValue)],
-      ([active, unreadMessageCount]) => {
+      (nextValue) => ({
+        active: nextValue.active,
+        unreadMessageCount: ownUnreadCountSelector(this.client.userID)(nextValue),
+      }),
+      ({ active, unreadMessageCount }) => {
         if (!active || !unreadMessageCount) return;
         this.throttledMarkAsRead();
       },
@@ -207,8 +210,8 @@ export class Thread<SCG extends ExtendableGenerics = DefaultGenerics> {
 
   private subscribeReloadActiveStaleThread = () =>
     this.state.subscribeWithSelector(
-      (nextValue) => [nextValue.active, nextValue.isStateStale],
-      ([active, isStateStale]) => {
+      (nextValue) => ({ active: nextValue.active, isStateStale: nextValue.isStateStale }),
+      ({ active, isStateStale }) => {
         if (active && isStateStale) {
           this.reload();
         }

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -119,9 +119,9 @@ export class ThreadManager<SCG extends ExtendableGenerics = DefaultGenerics> {
 
   private subscribeManageThreadSubscriptions = () =>
     this.state.subscribeWithSelector(
-      (nextValue) => [nextValue.threads] as const,
-      ([nextThreads], prev) => {
-        const [prevThreads = []] = prev ?? [];
+      (nextValue) => ({ threads: nextValue.threads } as const),
+      ({ threads: nextThreads }, prev) => {
+        const { threads: prevThreads = [] } = prev ?? {};
         // Thread instance was removed if there's no thread with the given id at all,
         // or it was replaced with a new instance
         const removedThreads = prevThreads.filter((thread) => thread !== this.threadsById[thread.id]);
@@ -133,8 +133,8 @@ export class ThreadManager<SCG extends ExtendableGenerics = DefaultGenerics> {
 
   private subscribeReloadOnActivation = () =>
     this.state.subscribeWithSelector(
-      (nextValue) => [nextValue.active],
-      ([active]) => {
+      (nextValue) => ({ active: nextValue.active }),
+      ({ active }) => {
         if (active) this.reload();
       },
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -963,10 +963,10 @@ export type CreateChannelOptions<StreamChatGenerics extends ExtendableGenerics =
   reminders?: boolean;
   replies?: boolean;
   search?: boolean;
+  skip_last_msg_update_for_system_msgs?: boolean;
   typing_events?: boolean;
   uploads?: boolean;
   url_enrichment?: boolean;
-  skip_last_msg_update_for_system_msgs?: boolean;
 };
 
 export type CreateCommandOptions<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1322,14 +1322,17 @@ describe('Threads 2.0', () => {
             },
           }));
           const spy = sinon.spy();
-          threadManager.state.subscribeWithSelector((nextValue) => [nextValue.pagination.isLoadingNext], spy);
+          threadManager.state.subscribeWithSelector(
+            (nextValue) => ({ isLoadingNext: nextValue.pagination.isLoadingNext }),
+            spy,
+          );
           spy.resetHistory();
 
           await threadManager.loadNextPage();
 
           expect(spy.callCount).to.equal(2);
-          expect(spy.firstCall.calledWith([true])).to.be.true;
-          expect(spy.lastCall.calledWith([false])).to.be.true;
+          expect(spy.firstCall.calledWith({ isLoadingNext: true })).to.be.true;
+          expect(spy.lastCall.calledWith({ isLoadingNext: false })).to.be.true;
         });
 
         it('updates thread list and pagination', async () => {


### PR DESCRIPTION
## CLA

As discussed with @oliverlaz and @arnautov-anton , the current API of the state store seems very brittle for integrators and something that is very prone to errors (that we cannot easily catch). Because of that, we've decided to change the state store's API so that it no longer returns an array of sorted properties, but rather an object with named properties. 

The way the API changes is as follows:

Previously: 
```
const selector = (nextValue: SomeState) => [nextValue.nameFromState] as const;
```

```
const selector = (nextValue: SomeState) => ({ explicitName: nextValue.nameFromState } as const);
```

and then use it by:

```
const { explicitName } = { ... }
```

This way, we will never be completely dependant on keeping the order of the array proper and not have to worry about adding new properties to maintain the order. 

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
