### PR TITLE
perf: targeted events

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -932,8 +932,9 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     set.add(factory);
 
     return () => {
+      // @ts-expect-error
       set.delete(factory);
-
+      // @ts-expect-error
       if (!set.size) {
         this.targetFactoriesByType.delete(eventType);
       }

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -63,9 +63,11 @@ export type ThreadReadState<SCG extends ExtendableGenerics = DefaultGenerics> = 
 >;
 
 // TODO: figure out generics here
+// @ts-expect-error
 const messageNewFactory: TargetFactory<DefaultGenerics, 'message.new'> = (event) => {
   return event.parent_id ? `message.new-${event.parent_id}` : null;
 };
+// @ts-expect-error
 const threadMessageReadFactory: TargetFactory<DefaultGenerics, 'message.read'> = (event) => {
   return event.thread ? `message.read-${event.thread.parent_message_id}` : null;
 };


### PR DESCRIPTION
### The Why

Targeted events are a runtime extension of event types - by default we provide a limited set of types which we can hook onto but say you have 1000 instances of a Thread BFF which have and manage their own state by hooking onto these events. Each of these instances registers around 10 event listeners but incoming events are usually only meant for one specific instance (based on `messageId`) so that's 1000 instances listening times two (two of those 10 listeners per instance are of the same type) - that's 2k function calls out of which only two will actually process the incoming data because the data was meant for them, the rest will exit early - this approach seems wasteful and at larger scale might slow applications down a quite a bit.

### The Solution

We can reduce the amount of calls by directly targeting what handlers to call by constructing a special type runtime:

fig.1:
```js
// current approach
"message.new": [L1, L2, L3... L2000]
// targeted event approach
"message.new-<parentMessageId>": [L1, L2]
```

In Thread class we know, that for certain handlers we'd only like to run them if the event payload matches `parentMessageId` (new incoming reply), we don't care about the rest.

So knowing the `parentMessageId` at the `Thread` construction time, we can register our handlers with our pre-defined type:

```ts
client.on(`message.new-${parentMessageId}`, (event) => {
    // handle event payload
})
```

At the same time we should register the `factory` function which instructs the dispatcher how to construct the special type based on the incoming event and store it for the specific type. These factories should be either static methods or simply live outside class scope so their signatures are the same across instances as their outputs should only depend on the input event argument and pre-defined factors (such as event types).

```ts
// lives outside class
const messageNewFactory: TargetFactory<DefaultGenerics, 'message.new'> = (event) => {
  return event.parent_id ? `message.new-${event.parent_id}` : null;
};

// register mechanism uses Set under the hood so only one factory-per-signature is accounted for
this.client.registerTargetFactory('message.new', messageNewFactory)
```

Now when it comes to dispatching the handlers, the dispatcher pulls in registered factories by incoming event type, runs them all and after looks for handlers stored by type (now using custom types) and since only two of such event handlers were registered for that type, it runs only two (refer to fig.1). Total of 3 function calls (including the factory call) instead of 2000.