### PR TITLE
feat: add support for archiving channels

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -645,6 +645,50 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   /**
+   * archive - archives the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.archives();
+   *
+   * example server side:
+   * await channel.archive({user_id: userId});
+   *
+   */
+  async archive(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for archiving a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { archived: true } });
+    return resp.channel_member;
+  }
+
+  /**
+   * unarchive - unarchives the current channel
+   * @param {{ user_id?: string }} opts user_id if called server side
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response
+   *
+   * example:
+   * await channel.unarchive();
+   *
+   * example server side:
+   * await channel.unarchive({user_id: userId});
+   *
+   */
+  async unarchive(opts: { user_id?: string } = {}) {
+    const cli = this.getClient();
+    const uid = opts.user_id || cli.userID;
+    if (!uid) {
+      throw Error('A user_id is required for unarchiving a channel');
+    }
+    const resp = await this.partialUpdateMember(uid, { set: { archived: false } });
+    return resp.channel_member;
+  }
+
+  /**
    * pin - pins the current channel
    * @param {{ user_id?: string }} opts user_id if called server side
    * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} The server response

--- a/src/types.ts
+++ b/src/types.ts
@@ -1501,6 +1501,9 @@ export type ChannelFilters<StreamChatGenerics extends ExtendableGenerics = Defau
               userType: StreamChatGenerics['userType'];
             }>[Key]
           >;
+    } & {
+      archived?: boolean;
+      pinned?: boolean;
     }
 >;
 
@@ -1814,7 +1817,8 @@ export type ReactionSortBase<StreamChatGenerics extends ExtendableGenerics = Def
 
 export type ChannelSort<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
   | ChannelSortBase<StreamChatGenerics>
-  | Array<ChannelSortBase<StreamChatGenerics>>;
+  | Array<ChannelSortBase<StreamChatGenerics>>
+  | { pinned_at: AscDesc };
 
 export type ChannelSortBase<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Sort<
   StreamChatGenerics['channelType']

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,11 +332,13 @@ export type ChannelMemberAPIResponse<StreamChatGenerics extends ExtendableGeneri
 };
 
 export type ChannelMemberUpdates = {
+  archived?: boolean;
   channel_role?: Role;
   pinned?: boolean;
 };
 
 export type ChannelMemberResponse<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
+  archived_at?: string;
   ban_expires?: string;
   banned?: boolean;
   channel_role?: Role;


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This adds support for archiving and un-archiving channels, similar to https://github.com/GetStream/stream-chat-js/pull/1378 for pinning.

## Changelog

- Add `channel.archive()` and `channel.unarchive()`
- Update typescript types for `queryChannels` to support pinning and archiving filter & sort options
