### PR TITLE
Adjust _hydrateMembers method to merge objects instead of overriding

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1748,12 +1748,19 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
   }
 
   _hydrateMembers(members: ChannelMemberResponse<StreamChatGenerics>[]) {
-    this.state.members = members.reduce((acc, member) => {
+    if (!members.length) return;
+
+    const newMembersById = members.reduce<ChannelState<StreamChatGenerics>['members']>((membersById, member) => {
       if (member.user) {
-        acc[member.user.id] = member;
+        membersById[member.user.id] = member;
       }
-      return acc;
-    }, {} as ChannelState<StreamChatGenerics>['members']);
+      return membersById;
+    }, {});
+
+    this.state.members = {
+      ...this.state.members,
+      ...newMembersById,
+    };
   }
 
   _disconnect() {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Fixes: https://github.com/GetStream/stream-chat-react/issues/2538

If the channel has been already established and exists within cache, hydrating channel members from thread response which was queried with limited amount of members (or zero even) will results in members property override, deleting previously known members.