### PR TITLE
fix: update membership object on member events

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1553,11 +1553,19 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         break;
       case 'member.added':
       case 'member.updated':
-        if (event.member?.user_id) {
+        if (event.member?.user) {
           channelState.members = {
             ...channelState.members,
-            [event.member.user_id]: event.member,
+            [event.member.user.id]: event.member,
           };
+        }
+
+        if (
+          typeof channelState.membership.user?.id === 'string' &&
+          typeof event.member?.user?.id === 'string' &&
+          event.member.user.id === channelState.membership.user.id
+        ) {
+          channelState.membership = event.member;
         }
         break;
       case 'member.removed':
@@ -1569,6 +1577,8 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
           delete newMembers[event.user.id];
 
           channelState.members = newMembers;
+
+          // TODO?: unset membership
         }
         break;
       case 'notification.mark_unread': {
@@ -1710,7 +1720,10 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       }
     }
 
-    this.state.membership = state.membership || {};
+    this.state.membership = {
+      ...this.state.membership,
+      ...state.membership,
+    };
 
     const messages = state.messages || [];
     if (!this.state.messages) {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Update membership object on member events and adjust how membership object is constructed during initialization (partial channel responses sometimes do not contain this information and during re-initialization this value gets overwritten with nothing).