### PR TITLE
fix(search): missing thread_participants in message

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -60,6 +60,7 @@ import {
   AscDesc,
   PartialUpdateMemberAPIResponse,
   AIState,
+  MessageOptions,
 } from './types';
 import { Role } from './permissions';
 import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from './constants';
@@ -237,6 +238,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       client_id?: string;
       connection_id?: string;
       message_filter_conditions?: MessageFilters<StreamChatGenerics>;
+      message_options?: MessageOptions;
       query?: string;
     } = {},
   ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1713,6 +1713,10 @@ export type MessageFilters<StreamChatGenerics extends ExtendableGenerics = Defau
     }
 >;
 
+export type MessageOptions = {
+  include_thread_participants?: boolean;
+};
+
 export type PrimitiveFilter<ObjectType> = ObjectType | null;
 
 export type QueryFilter<ObjectType = string> = NonNullable<ObjectType> extends string | number | boolean
@@ -2738,6 +2742,7 @@ export type SearchPayload<StreamChatGenerics extends ExtendableGenerics = Defaul
   connection_id?: string;
   filter_conditions?: ChannelFilters<StreamChatGenerics>;
   message_filter_conditions?: MessageFilters<StreamChatGenerics>;
+  message_options?: MessageOptions;
   query?: string;
   sort?: Array<{
     direction: AscDesc;


### PR DESCRIPTION
## Link to issue

- https://linear.app/stream/issue/CHA-365/missing-thread-participants-data-in-streamio-query

## Related PR

- https://github.com/GetStream/chat/pull/7674

## Summary

Enable the `Channel.search` to enrich `thread_participants` in found messages.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Changelog

-
