### PR TITLE
fix: message duplication when some messages have the same creation timestamp

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -354,6 +354,7 @@ export class Thread<SCG extends ExtendableGenerics = DefaultGenerics> {
       sortedArray: replies,
       sortDirection: 'ascending',
       selectValueToCompare: (reply) => reply.created_at.getTime(),
+      selectKey: (reply) => reply.id,
     });
 
     const actualIndex =


### PR DESCRIPTION
To reproduce an existing bug:
1. Have several (3+) messages with the same creation timestamp in a channel (you can send them quickly with the server-side API)
2. Set up a situation when channels are queried twice (e.g. `<StrictMode />` is enabled and the effect in `ChannelList` runs twice)
3. Observe duplicating messages

The issue is that when inserting items into a sorted array with duplicating creation date, the insertion index points next to a fairly random message with the same creation date. That is not necessarily the message with same id, it could be any other message with the same creation id. So, instead of updating an existing message, we add it again.

This is fixed by performing an additional look-around when inserting a message, searching for the message with the same creation date and the same id. It adds very little overhead, since the search range is very limited. If the message with the same key is found, it is returned as an insertion index.