### PR TITLE
feat(threads): handle custom data

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2754,20 +2754,10 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @param {boolean} options.watch Subscribes the user to the channels of the threads.
    * @param {number}  options.participant_limit Limits the number of participants returned per threads.
    * @param {number}  options.reply_limit Limits the number of replies returned per threads.
-   * @param {boolean} asJSON If set to true, returns JSON response instead of array of Thread instances.
    *
    * @returns {{ threads: Thread<StreamChatGenerics>[], next: string }} Returns the list of threads and the next cursor.
    */
-
-  async queryThreads(
-    options: QueryThreadsOptions | undefined,
-    asJSON: true,
-  ): Promise<QueryThreadsAPIResponse<StreamChatGenerics>>;
-  async queryThreads(
-    options?: QueryThreadsOptions,
-    asJSON?: false,
-  ): Promise<{ next: string | undefined; threads: Thread<StreamChatGenerics>[] }>;
-  async queryThreads(options: QueryThreadsOptions = {}, asJSON = false) {
+  async queryThreads(options: QueryThreadsOptions = {}) {
     const optionsWithDefaults = {
       limit: 10,
       participant_limit: 10,
@@ -2780,10 +2770,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       `${this.baseURL}/threads`,
       optionsWithDefaults,
     );
-
-    if (asJSON) {
-      return response;
-    }
 
     return {
       threads: response.threads.map(
@@ -2801,17 +2787,10 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
    * @param {boolean}           options.watch Subscribes the user to the channel of the thread.
    * @param {number}            options.participant_limit Limits the number of participants returned per threads.
    * @param {number}            options.reply_limit Limits the number of replies returned per threads.
-   * @param {boolean}           asJSON If set to true, returns JSON response instead of Thread instance.
    *
    * @returns {Thread<StreamChatGenerics>} Returns the thread.
    */
-  async getThread(
-    messageId: string,
-    options: GetThreadOptions | undefined,
-    asJSON: true,
-  ): Promise<ThreadResponse<StreamChatGenerics>>;
-  async getThread(messageId: string, options?: GetThreadOptions, asJSON?: false): Promise<Thread<StreamChatGenerics>>;
-  async getThread(messageId: string, options: GetThreadOptions = {}, asJSON = false) {
+  async getThread(messageId: string, options: GetThreadOptions = {}) {
     if (!messageId) {
       throw Error('Please specify the messageId when calling getThread');
     }
@@ -2827,10 +2806,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       `${this.baseURL}/threads/${encodeURIComponent(messageId)}`,
       optionsWithDefaults,
     );
-
-    if (asJSON) {
-      return response.thread;
-    }
 
     return new Thread<StreamChatGenerics>({ client: this, threadData: response.thread });
   }
@@ -2860,6 +2835,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       'reply_count',
       'participants',
       'channel',
+      'custom',
     ];
 
     for (const key in { ...partialThreadObject.set, ...partialThreadObject.unset }) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -188,7 +188,6 @@ import {
   TestPushDataInput,
   TestSNSDataInput,
   TestSQSDataInput,
-  ThreadResponse,
   TokenOrProvider,
   UnBanUserOptions,
   UpdateChannelOptions,

--- a/src/client.ts
+++ b/src/client.ts
@@ -270,6 +270,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   defaultWSTimeoutWithFallback: number;
   defaultWSTimeout: number;
   private nextRequestAbortController: AbortController | null = null;
+  public readonly customPropertyKeys: NonNullable<StreamChatOptions['customPropertyKeys']>;
 
   /**
    * Initialize a client
@@ -363,6 +364,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     this.defaultWSTimeout = 15 * 1000;
 
     this.axiosInstance.defaults.paramsSerializer = axiosParamsSerializer;
+    this.customPropertyKeys = options?.customPropertyKeys ?? { thread: [] };
 
     /**
      * logger function should accept 3 parameters:

--- a/src/client.ts
+++ b/src/client.ts
@@ -269,7 +269,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
   defaultWSTimeoutWithFallback: number;
   defaultWSTimeout: number;
   private nextRequestAbortController: AbortController | null = null;
-  public readonly customPropertyKeys: NonNullable<StreamChatOptions['customPropertyKeys']>;
 
   /**
    * Initialize a client
@@ -363,7 +362,6 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
     this.defaultWSTimeout = 15 * 1000;
 
     this.axiosInstance.defaults.paramsSerializer = axiosParamsSerializer;
-    this.customPropertyKeys = options?.customPropertyKeys ?? { thread: [] };
 
     /**
      * logger function should accept 3 parameters:

--- a/src/events.ts
+++ b/src/events.ts
@@ -38,6 +38,7 @@ export const EVENT_MAP = {
   'reaction.deleted': true,
   'reaction.new': true,
   'reaction.updated': true,
+  'thread.updated': true,
   'typing.start': true,
   'typing.stop': true,
   'user.banned': true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -534,6 +534,7 @@ export interface ThreadResponse<SCG extends ExtendableGenerics = DefaultGenerics
   parent_message_id: string;
   title: string;
   updated_at: string;
+  active_participant_count?: number;
   created_by?: UserResponse<SCG>;
   deleted_at?: string;
   last_message_at?: string;
@@ -1174,17 +1175,6 @@ export type StreamChatOptions = AxiosRequestConfig & {
    */
   baseURL?: string;
   browser?: boolean;
-  /**
-   * To access your custom data from `StateStore` you'll need to declare your custom property names for each feature.
-   * At the moment this is only needed for the Thread class. To get full type support make sure to merge interface
-   * declarations too.
-   */
-  customPropertyKeys?: {
-    /**
-     * Interface declaration for custom object properties: `ThreadResponseCustomData`
-     */
-    thread: (keyof ThreadResponseCustomData)[];
-  };
   device?: BaseDeviceFields;
   enableInsights?: boolean;
   /** experimental feature, please contact support if you want this feature enabled for you */

--- a/src/types.ts
+++ b/src/types.ts
@@ -520,6 +520,7 @@ export type GetMessageAPIResponse<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = SendMessageAPIResponse<StreamChatGenerics>;
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ThreadResponseCustomData {}
 
 export interface ThreadResponse<SCG extends ExtendableGenerics = DefaultGenerics> extends ThreadResponseCustomData {
@@ -1173,6 +1174,17 @@ export type StreamChatOptions = AxiosRequestConfig & {
    */
   baseURL?: string;
   browser?: boolean;
+  /**
+   * To access your custom data from `StateStore` you'll need to declare your custom property names for each feature.
+   * At the moment this is only needed for the Thread class. To get full type support make sure to merge interface
+   * declarations too.
+   */
+  customPropertyKeys?: {
+    /**
+     * Interface declaration for custom object properties: `ThreadResponseCustomData`
+     */
+    thread: (keyof ThreadResponseCustomData)[];
+  };
   device?: BaseDeviceFields;
   enableInsights?: boolean;
   /** experimental feature, please contact support if you want this feature enabled for you */
@@ -1199,17 +1211,6 @@ export type StreamChatOptions = AxiosRequestConfig & {
   // Set the instance of StableWSConnection on chat client. Its purely for testing purpose and should
   // not be used in production apps.
   wsConnection?: StableWSConnection;
-  /**
-   * To access your custom data from `StateStore` you'll need to declare your custom property names for each feature.
-   * At the moment this is only needed for the Thread class. To get full type support make sure to merge interface
-   * declarations too.
-   */
-  customPropertyKeys?: {
-    /**
-     * Interface declaration for custom object properties: `ThreadResponseCustomData`
-     */
-    thread: (keyof ThreadResponseCustomData)[];
-  };
 };
 
 export type SyncOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -520,7 +520,9 @@ export type GetMessageAPIResponse<
   StreamChatGenerics extends ExtendableGenerics = DefaultGenerics
 > = SendMessageAPIResponse<StreamChatGenerics>;
 
-export interface ThreadResponse<SCG extends ExtendableGenerics = DefaultGenerics> {
+export interface ThreadResponseCustomData {}
+
+export interface ThreadResponse<SCG extends ExtendableGenerics = DefaultGenerics> extends ThreadResponseCustomData {
   // FIXME: according to OpenAPI, `channel` could be undefined but since cid is provided I'll asume that it's wrong
   channel: ChannelResponse<SCG>;
   channel_cid: string;
@@ -547,6 +549,8 @@ export interface ThreadResponse<SCG extends ExtendableGenerics = DefaultGenerics
     user?: UserResponse<SCG>;
     user_id?: string;
   }>;
+  // TODO: when moving to API v2 we should do this instead
+  // custom: ThreadResponseCustomData;
 }
 
 // TODO: Figure out a way to strongly type set and unset.
@@ -1195,6 +1199,17 @@ export type StreamChatOptions = AxiosRequestConfig & {
   // Set the instance of StableWSConnection on chat client. Its purely for testing purpose and should
   // not be used in production apps.
   wsConnection?: StableWSConnection;
+  /**
+   * To access your custom data from `StateStore` you'll need to declare your custom property names for each feature.
+   * At the moment this is only needed for the Thread class. To get full type support make sure to merge interface
+   * declarations too.
+   */
+  customPropertyKeys?: {
+    /**
+     * Interface declaration for custom object properties: `ThreadResponseCustomData`
+     */
+    thread: (keyof ThreadResponseCustomData)[];
+  };
 };
 
 export type SyncOptions = {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -596,33 +596,9 @@ describe('Threads 2.0', () => {
           expect(stateAfter.title).to.eq('B');
         });
 
-        it('ignores custom data when keys are missing from "StreamChat.customPropertyKeys.thread"', () => {
-          const customKey = uuidv4();
-          const thread = createTestThread({ [customKey]: 1 });
-          thread.registerSubscriptions();
-
-          const stateBefore = thread.state.getLatestValue();
-
-          expect(stateBefore.custom).to.not.have.property(customKey);
-
-          client.dispatchEvent({
-            type: 'thread.updated',
-            thread: generateThreadResponse(channelResponse, generateMsg({ id: parentMessageResponse.id }), {
-              [customKey]: 2,
-            }),
-          });
-
-          const stateAfter = thread.state.getLatestValue();
-
-          expect(stateAfter.custom).to.not.have.property(customKey);
-        });
-
-        it('properly handles custom data when keys are defined in "StreamChat.customPropertyKeys.thread"', () => {
+        it('properly handles custom data', () => {
           const customKey1 = uuidv4();
           const customKey2 = uuidv4();
-
-          // @ts-expect-error keys should be declared within `ThreadResponseCustomData` interface through interface merging
-          client.customPropertyKeys.thread = [customKey1, customKey2];
 
           const thread = createTestThread({ [customKey1]: 1, [customKey2]: { key: 1 } });
           thread.registerSubscriptions();

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -570,7 +570,6 @@ describe('Threads 2.0', () => {
           expect(stateBefore.title).to.eq('A');
 
           client.dispatchEvent({
-            // @ts-expect-error
             type: 'thread.updated',
             thread: generateThreadResponse(channelResponse, generateMsg(), { title: 'B' }),
           });
@@ -587,7 +586,6 @@ describe('Threads 2.0', () => {
           expect(stateBefore.title).to.eq('A');
 
           client.dispatchEvent({
-            // @ts-expect-error
             type: 'thread.updated',
             thread: generateThreadResponse(channelResponse, generateMsg({ id: parentMessageResponse.id }), {
               title: 'B',
@@ -596,6 +594,55 @@ describe('Threads 2.0', () => {
 
           const stateAfter = thread.state.getLatestValue();
           expect(stateAfter.title).to.eq('B');
+        });
+
+        it('ignores custom data when keys are missing from "StreamChat.customPropertyKeys.thread"', () => {
+          const customKey = uuidv4();
+          const thread = createTestThread({ [customKey]: 1 });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+
+          expect(stateBefore.custom).to.not.have.property(customKey);
+
+          client.dispatchEvent({
+            type: 'thread.updated',
+            thread: generateThreadResponse(channelResponse, generateMsg({ id: parentMessageResponse.id }), {
+              [customKey]: 2,
+            }),
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+
+          expect(stateAfter.custom).to.not.have.property(customKey);
+        });
+
+        it('properly handles custom data when keys are defined in "StreamChat.customPropertyKeys.thread"', () => {
+          const customKey1 = uuidv4();
+          const customKey2 = uuidv4();
+
+          // @ts-expect-error keys should be declared within `ThreadResponseCustomData` interface through interface merging
+          client.customPropertyKeys.thread = [customKey1, customKey2];
+
+          const thread = createTestThread({ [customKey1]: 1, [customKey2]: { key: 1 } });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+
+          expect(stateBefore.custom).to.have.keys([customKey1, customKey2]);
+          expect(stateBefore.custom[customKey1]).to.equal(1);
+
+          client.dispatchEvent({
+            type: 'thread.updated',
+            thread: generateThreadResponse(channelResponse, generateMsg({ id: parentMessageResponse.id }), {
+              [customKey1]: 2,
+            }),
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+
+          expect(stateAfter.custom).to.not.have.property(customKey2);
+          expect(stateAfter.custom[customKey1]).to.equal(2);
         });
       });
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

- ~allow querying thread-related data as pure objects instead of instances of `Thread` class~ (discarded)
- handle `thread.updated` within `Thread` class and consider custom fields

### Custom fields

`Thread` class now handles custom data by sifting through `ThreadResponse` keys, skipping reserved ones and storing custom keys with associated data within `ThreadState.custom` object.  For type support, declaration file has to be created and `ThreadResponseCustomData` has to be extended:

```ts
// yourFile.d.ts

import 'stream-chat';

declare module 'stream-chat' {
  interface ThreadResponseCustomData {
    myCustomProperty: string;
    myOtherCustomProperty: { meta: Array<{ key: number }> };
  }
}
```

When the `Thread` is instantiated, the custom properties can be accessed from the state:

```ts
const thread = await client.getThread('messageId');

const { custom } = thread.state.getLatestValue();

console.log(custom.myCustomProperty, custom.myOtherCustomProperty);
```

Fixes: GetStream/stream-chat-react#2592