### PR TITLE
fix: move `pinned_at` sort option to `ChannelSortBase`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1943,8 +1943,7 @@ export type ReactionSortBase<StreamChatGenerics extends ExtendableGenerics = Def
 
 export type ChannelSort<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> =
   | ChannelSortBase<StreamChatGenerics>
-  | Array<ChannelSortBase<StreamChatGenerics>>
-  | { pinned_at: AscDesc };
+  | Array<ChannelSortBase<StreamChatGenerics>>;
 
 export type ChannelSortBase<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = Sort<
   StreamChatGenerics['channelType']
@@ -1954,6 +1953,7 @@ export type ChannelSortBase<StreamChatGenerics extends ExtendableGenerics = Defa
   last_message_at?: AscDesc;
   last_updated?: AscDesc;
   member_count?: AscDesc;
+  pinned_at?: AscDesc;
   unread_count?: AscDesc;
   updated_at?: AscDesc;
 };


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Move `pinned_at` sort option to `ChannelSortBase`.