### PR TITLE
fix: make initial message pagination state pesimistic

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
 export const DEFAULT_QUERY_CHANNELS_MESSAGE_LIST_PAGE_SIZE = 25;
 export const DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE = 100;
 
-export const DEFAULT_MESSAGE_SET_PAGINATION = { hasNext: true, hasPrev: true };
+export const DEFAULT_MESSAGE_SET_PAGINATION = { hasNext: false, hasPrev: false };

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1272,7 +1272,7 @@ describe('Channel.query', async () => {
 		mock.restore();
 	});
 
-	it('should not update pagination for queried message set', async () => {
+	it('should update pagination for queried message set to prevent more pagination', async () => {
 		const client = await getClientWithUser();
 		const channel = client.channel('messaging', uuidv4());
 		const mockedChannelQueryResponse = {
@@ -1283,11 +1283,11 @@ describe('Channel.query', async () => {
 		mock.expects('post').returns(Promise.resolve(mockedChannelQueryResponse));
 		await channel.query();
 		expect(channel.state.messageSets.length).to.be.equal(1);
-		expect(channel.state.messageSets[0].pagination).to.eql({ hasNext: true, hasPrev: true });
+		expect(channel.state.messageSets[0].pagination).to.eql({ hasNext: false, hasPrev: true });
 		mock.restore();
 	});
 
-	it('should update pagination for queried message set to prevent more pagination', async () => {
+	it('should not update pagination for queried message set', async () => {
 		const client = await getClientWithUser();
 		const channel = client.channel('messaging', uuidv4());
 		const mockedChannelQueryResponse = {
@@ -1298,7 +1298,7 @@ describe('Channel.query', async () => {
 		mock.expects('post').returns(Promise.resolve(mockedChannelQueryResponse));
 		await channel.query();
 		expect(channel.state.messageSets.length).to.be.equal(1);
-		expect(channel.state.messageSets[0].pagination).to.eql({ hasNext: true, hasPrev: false });
+		expect(channel.state.messageSets[0].pagination).to.eql({ hasNext: false, hasPrev: false });
 		mock.restore();
 	});
 });


### PR DESCRIPTION
## Goal

The message set, when initiated, should receive pesimistic pagination indicators, meaning that it should expect there is no more data to load. This is of course adjusted with the first channel(s) query. It is logical, that in order the message list that paginates over messages to be showed, first the channel data has to be queried.