### PR TITLE
fix: add team to reviewqueue filter types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3543,6 +3543,8 @@ export type ReviewQueueFilters = QueryFilters<
     has_text?: boolean;
   } & {
     has_video?: boolean;
+  } & {
+    team?: string;
   }
 >;
 


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

- Add team to review queue filter types
