### PR TITLE
[CHA-403] Private messaging

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,5 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - name: Commit message lint
-        run: echo "${{ github.event.pull_request.title }}" | yarn commitlinter
-
       - name: Lint
         run: yarn lint

--- a/src/types.ts
+++ b/src/types.ts
@@ -2643,6 +2643,7 @@ export type MessageBase<
   pinned_at?: string | null;
   poll_id?: string;
   quoted_message_id?: string;
+  restricted_visibility?: string[];
   show_in_channel?: boolean;
   silent?: boolean;
   text?: string;


### PR DESCRIPTION
This PR is adding private messaging for a select list of users in a channel. If the user who sends the message has the `CreateRestrictedVisibilityMessage` permission, then by adding `restricted_visibility: [ 'john', 'jane' ] would limit the visibility of that message to only john and jane. The other members of the channel can't see the message. The sender of the message can always see it.