### PR TITLE
chore: return linting CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,5 +15,8 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
+      - name: Commit message lint
+        run: echo "${{ github.event.pull_request.title }}" | yarn commitlinter
+
       - name: Lint
         run: yarn lint


### PR DESCRIPTION
## Motivation

Repository `stream-chat-js` serves to publish JS library `stream-chat` that follows the semver versioning. This is the standard for the public libraries. In order to be able to follow semver versioning, the developers need to know, whether the merged PRs represent features, chores, fixes etc. Based on that the developer that performs the new version release actually calculates the next version number. 

Removal of linter, that controls the PR title compatibility with [conventional commit rules](https://www.conventionalcommits.org/en/v1.0.0/) leads to:

- confusion to those that release the library
- the automation process that builds the changelog
- confusion to the integrators that read the commit history
- sabotage for future automation of the whole release process

For integration to close the Linear issues can be used [this documentation](https://linear.app/docs/github?tabs=206cad22125a#link-to-a-linear-issue).
