### PR TITLE
fix: improper poll state overwrite

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1211,7 +1211,7 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
       }),
     };
 
-    this.getClient().polls.hydratePollCache(messageSet.messages, true);
+    this.getClient().polls.hydratePollCache(state.messages, true);
 
     const areCapabilitiesChanged =
       [...(state.channel.own_capabilities || [])].sort().join() !==

--- a/src/client.ts
+++ b/src/client.ts
@@ -1690,7 +1690,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
             logger: this.logger,
           }),
         };
-        this.polls.hydratePollCache(updatedMessagesSet.messages, true);
+        this.polls.hydratePollCache(channelState.messages, true);
       }
 
       channels.push(c);

--- a/src/poll_manager.ts
+++ b/src/poll_manager.ts
@@ -2,7 +2,7 @@ import type { StreamChat } from './client';
 import type {
   CreatePollData,
   DefaultGenerics,
-  ExtendableGenerics,
+  ExtendableGenerics, MessageResponse,
   PollResponse,
   PollSort,
   QueryPollsFilters,
@@ -90,7 +90,7 @@ export class PollManager<SCG extends ExtendableGenerics = DefaultGenerics> {
     };
   };
 
-  public hydratePollCache = (messages: FormatMessageResponse<SCG>[], overwriteState?: boolean) => {
+  public hydratePollCache = (messages: FormatMessageResponse<SCG>[] | MessageResponse<SCG>[], overwriteState?: boolean) => {
     for (const message of messages) {
       if (!message.poll) {
         continue;

--- a/src/poll_manager.ts
+++ b/src/poll_manager.ts
@@ -2,7 +2,8 @@ import type { StreamChat } from './client';
 import type {
   CreatePollData,
   DefaultGenerics,
-  ExtendableGenerics, MessageResponse,
+  ExtendableGenerics,
+  MessageResponse,
   PollResponse,
   PollSort,
   QueryPollsFilters,
@@ -90,7 +91,10 @@ export class PollManager<SCG extends ExtendableGenerics = DefaultGenerics> {
     };
   };
 
-  public hydratePollCache = (messages: FormatMessageResponse<SCG>[] | MessageResponse<SCG>[], overwriteState?: boolean) => {
+  public hydratePollCache = (
+    messages: FormatMessageResponse<SCG>[] | MessageResponse<SCG>[],
+    overwriteState?: boolean,
+  ) => {
     for (const message of messages) {
       if (!message.poll) {
         continue;

--- a/test/unit/poll_manager.test.ts
+++ b/test/unit/poll_manager.test.ts
@@ -15,8 +15,6 @@ import {
   PollResponse,
   StreamChat,
 } from '../../src';
-import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from '../../src/constants';
-import { channel } from 'node:diagnostics_channel';
 
 const TEST_USER_ID = 'observer';
 

--- a/test/unit/poll_manager.test.ts
+++ b/test/unit/poll_manager.test.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
+import { v4 as uuidv4 } from 'uuid';
 
+import { generateChannel } from './test-utils/generateChannel';
 import { generateMsg } from './test-utils/generateMessage';
 import { mockChannelQueryResponse } from './test-utils/mockChannelQueryResponse';
 
 import sinon from 'sinon';
 import {
-  EventTypes,
+  ChannelResponse,
+  EventTypes, formatMessage,
   FormatMessageResponse,
   MessageResponse,
   Poll,
@@ -13,6 +16,7 @@ import {
   PollResponse,
   StreamChat,
 } from '../../src';
+import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from '../../src/constants';
 
 const TEST_USER_ID = 'observer';
 
@@ -188,6 +192,64 @@ describe('PollManager', () => {
       expect(client.polls.data).to.be.empty;
       expect(client.polls.data).not.to.be.null;
     });
+
+    it('populates pollCache on client.queryChannels invocation', async () => {
+      const mockedChannelsQueryResponse = [];
+
+      let pollMessages: MessageResponse[] = [];
+      for (let ci = 0; ci < 5; ci++) {
+        const { messages, pollMessages: onlyPollMessages } = generateRandomMessagesWithPolls(5, `_${ci}`);
+        pollMessages = pollMessages.concat(onlyPollMessages);
+        mockedChannelsQueryResponse.push(generateChannel({ channel: { id: uuidv4() }, messages}));
+      }
+      const mock = sinon.mock(client);
+      const spy = sinon.spy(client.polls, 'hydratePollCache');
+      mock.expects('post').returns(Promise.resolve({ channels: mockedChannelsQueryResponse }));
+      await client.queryChannels({})
+      expect(client.polls.data.size).to.equal(pollMessages.length);
+      expect(spy.callCount).to.be.equal(5);
+      for (let i = 0; i < 5; i++) {
+        expect(spy.calledWith(mockedChannelsQueryResponse[i].messages.map(formatMessage), true)).to.be.true;
+      }
+    })
+
+    it('populates pollCache on channel.query invocation', async () => {
+      const channel = client.channel('messaging', uuidv4());
+      const { messages, pollMessages } = generateRandomMessagesWithPolls(5, ``);
+      const mockedChannelQueryResponse = {
+        ...mockChannelQueryResponse,
+        messages,
+      };
+      const mock = sinon.mock(client);
+      const spy = sinon.spy(client.polls, 'hydratePollCache');
+      mock.expects('post').returns(Promise.resolve(mockedChannelQueryResponse));
+      await channel.query();
+      expect(client.polls.data.size).to.equal(pollMessages.length);
+      expect(spy.calledOnce).to.be.true;
+      expect(spy.calledWith(mockedChannelQueryResponse.messages, true)).to.be.true;
+    })
+
+    it('populates pollCache with new messages only on channel.query invocation', async () => {
+      const channel = client.channel('messaging', uuidv4());
+      const { messages: prevMessages, pollMessages: prevPollMessages } = generateRandomMessagesWithPolls(5, `_prev`)
+      channel.state.addMessagesSorted(prevMessages)
+      const { messages, pollMessages } = generateRandomMessagesWithPolls(5, ``);
+      const mockedChannelQueryResponse = {
+        ...mockChannelQueryResponse,
+        messages,
+      };
+      const mock = sinon.mock(client);
+      const spy = sinon.spy(client.polls, 'hydratePollCache');
+      mock.expects('post').returns(Promise.resolve(mockedChannelQueryResponse));
+      client.polls.hydratePollCache(prevMessages);
+      await channel.query();
+      expect(client.polls.data.size).to.equal(prevPollMessages.length + pollMessages.length);
+      expect(spy.calledTwice).to.be.true;
+      expect(spy.calledWith(mockedChannelQueryResponse.messages, true)).to.be.true;
+      expect(spy.args[0][0]).to.deep.equal(prevMessages);
+      expect(spy.args[1][0]).to.deep.equal(mockedChannelQueryResponse.messages);
+      expect(spy.calledWith([...prevMessages, ...messages], true)).to.be.false;
+    })
 
     it('populates pollCache on client.hydrateActiveChannels', async () => {
       const mockedChannelsQueryResponse = [];

--- a/test/unit/poll_manager.test.ts
+++ b/test/unit/poll_manager.test.ts
@@ -211,7 +211,7 @@ describe('PollManager', () => {
       }
     });
 
-    it.only('populates pollCache only with new messages on client.queryChannels invocation', async () => {
+    it('populates pollCache only with new messages on client.queryChannels invocation', async () => {
       let channels = [];
       let pollMessages: MessageResponse[] = [];
       const spy = sinon.spy(client.polls, 'hydratePollCache');

--- a/test/unit/poll_manager.test.ts
+++ b/test/unit/poll_manager.test.ts
@@ -8,7 +8,8 @@ import { mockChannelQueryResponse } from './test-utils/mockChannelQueryResponse'
 import sinon from 'sinon';
 import {
   ChannelResponse,
-  EventTypes, formatMessage,
+  EventTypes,
+  formatMessage,
   FormatMessageResponse,
   MessageResponse,
   Poll,
@@ -200,18 +201,18 @@ describe('PollManager', () => {
       for (let ci = 0; ci < 5; ci++) {
         const { messages, pollMessages: onlyPollMessages } = generateRandomMessagesWithPolls(5, `_${ci}`);
         pollMessages = pollMessages.concat(onlyPollMessages);
-        mockedChannelsQueryResponse.push(generateChannel({ channel: { id: uuidv4() }, messages}));
+        mockedChannelsQueryResponse.push(generateChannel({ channel: { id: uuidv4() }, messages }));
       }
       const mock = sinon.mock(client);
       const spy = sinon.spy(client.polls, 'hydratePollCache');
       mock.expects('post').returns(Promise.resolve({ channels: mockedChannelsQueryResponse }));
-      await client.queryChannels({})
+      await client.queryChannels({});
       expect(client.polls.data.size).to.equal(pollMessages.length);
       expect(spy.callCount).to.be.equal(5);
       for (let i = 0; i < 5; i++) {
         expect(spy.calledWith(mockedChannelsQueryResponse[i].messages.map(formatMessage), true)).to.be.true;
       }
-    })
+    });
 
     it('populates pollCache on channel.query invocation', async () => {
       const channel = client.channel('messaging', uuidv4());
@@ -227,12 +228,12 @@ describe('PollManager', () => {
       expect(client.polls.data.size).to.equal(pollMessages.length);
       expect(spy.calledOnce).to.be.true;
       expect(spy.calledWith(mockedChannelQueryResponse.messages, true)).to.be.true;
-    })
+    });
 
     it('populates pollCache with new messages only on channel.query invocation', async () => {
       const channel = client.channel('messaging', uuidv4());
-      const { messages: prevMessages, pollMessages: prevPollMessages } = generateRandomMessagesWithPolls(5, `_prev`)
-      channel.state.addMessagesSorted(prevMessages)
+      const { messages: prevMessages, pollMessages: prevPollMessages } = generateRandomMessagesWithPolls(5, `_prev`);
+      channel.state.addMessagesSorted(prevMessages);
       const { messages, pollMessages } = generateRandomMessagesWithPolls(5, ``);
       const mockedChannelQueryResponse = {
         ...mockChannelQueryResponse,
@@ -249,7 +250,7 @@ describe('PollManager', () => {
       expect(spy.args[0][0]).to.deep.equal(prevMessages);
       expect(spy.args[1][0]).to.deep.equal(mockedChannelQueryResponse.messages);
       expect(spy.calledWith([...prevMessages, ...messages], true)).to.be.false;
-    })
+    });
 
     it('populates pollCache on client.hydrateActiveChannels', async () => {
       const mockedChannelsQueryResponse = [];

--- a/test/unit/poll_manager.test.ts
+++ b/test/unit/poll_manager.test.ts
@@ -218,7 +218,10 @@ describe('PollManager', () => {
       let pollMessages: MessageResponse[] = [];
       const spy = sinon.spy(client.polls, 'hydratePollCache');
       for (let ci = 0; ci < 5; ci++) {
-        const { messages: prevMessages, pollMessages: prevPollMessages } = generateRandomMessagesWithPolls(5, `_prev_${ci}`);
+        const { messages: prevMessages, pollMessages: prevPollMessages } = generateRandomMessagesWithPolls(
+          5,
+          `_prev_${ci}`,
+        );
         pollMessages = pollMessages.concat(prevPollMessages);
         const channelResponse = generateChannel({ channel: { id: uuidv4() }, messages: prevMessages });
         channels.push(channelResponse);


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

This PR fixes a case of overwriting the poll cache when we should not do that. Essentially, hydrating all messages in `messageSet.messages` whenever `channel.query` is invoked does 2 things:

- Takes in all of the new messages and hydrates the cache with them (they do not exist in the cache yet)
- Also takes in the old messages, which were used as a basis to paginate on top of and rehydrates the cache with them (they already existed in the cache before)

The problem here is; since we do not update `message.poll` objects at all, but rather use them as an ID reference towards the cache - these polls are stale (since they're retrieved from the stale state and not as an HTTP response). The state is then overwritten with the stale data until we query all messages again.

The bug is particularly noticeable if we do some state changes to a poll (for example vote on it, add some answers or similar) and then paginate elsewhere within the messages (up or down). We can see that the poll will reset back to the state it had on the initial load.

## Changelog

-
