### PR TITLE
fix: premature channels state consumption in ChannelManager

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -290,7 +290,7 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
       });
       const nextChannels = await this.client.queryChannels(filters, sort, options, this.stateOptions);
       const { channels } = this.state.getLatestValue();
-      const newChannels = uniqBy([...(channels || []), ...nextChannels], 'cid');
+      const newChannels = uniqBy<Channel<SCG>>([...(channels || []), ...nextChannels], 'cid');
       const newOptions = { ...options, offset: newChannels.length };
 
       this.state.partialNext({

--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -284,17 +284,17 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
     }
 
     try {
-      const { limit } = { ...DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS, ...options };
+      const { offset, limit } = { ...DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS, ...options };
       this.state.partialNext({
         pagination: { ...pagination, isLoading: false, isLoadingNext: true },
       });
       const nextChannels = await this.client.queryChannels(filters, sort, options, this.stateOptions);
       const { channels } = this.state.getLatestValue();
-      const newChannels = uniqBy<Channel<SCG>>([...(channels || []), ...nextChannels], 'cid');
-      const newOptions = { ...options, offset: newChannels.length };
+      const newOffset = offset + (nextChannels?.length ?? 0);
+      const newOptions = { ...options, offset: newOffset };
 
       this.state.partialNext({
-        channels: newChannels,
+        channels: uniqBy<Channel<SCG>>([...(channels || []), ...nextChannels], 'cid'),
         pagination: {
           ...pagination,
           hasNext: (nextChannels?.length ?? 0) >= limit,

--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -315,9 +315,11 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
 
   private notificationAddedToChannelHandler = async (event: Event<SCG>) => {
     const { id, type, members } = event?.channel ?? {};
+
     if (!type || !this.options.allowNotLoadedChannelPromotionForEvent?.['notification.added_to_channel']) {
       return;
     }
+
     const channel = await getAndWatchChannel({
       client: this.client,
       id,
@@ -330,6 +332,7 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
       }, []),
       type,
     });
+
     const { pagination, channels } = this.state.getLatestValue();
     if (!channels) {
       return;
@@ -417,10 +420,7 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
   private notificationNewMessageHandler = async (event: Event<SCG>) => {
     const { id, type } = event?.channel ?? {};
 
-    const { channels, pagination } = this.state.getLatestValue();
-    const { filters, sort } = pagination ?? {};
-
-    if (!channels || !id || !type) {
+    if (!id || !type) {
       return;
     }
 
@@ -430,10 +430,14 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
       type,
     });
 
+    const { channels, pagination } = this.state.getLatestValue();
+    const { filters, sort } = pagination ?? {};
+
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
 
     if (
+      !channels ||
       (considerArchivedChannels && isTargetChannelArchived && !filters.archived) ||
       (considerArchivedChannels && !isTargetChannelArchived && filters.archived) ||
       !this.options.allowNotLoadedChannelPromotionForEvent?.['notification.message_new']
@@ -451,11 +455,9 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
   };
 
   private channelVisibleHandler = async (event: Event<SCG>) => {
-    const { channels, pagination } = this.state.getLatestValue();
-    const { sort, filters } = pagination ?? {};
     const { channel_type: channelType, channel_id: channelId } = event;
 
-    if (!channels || !channelType || !channelId) {
+    if (!channelType || !channelId) {
       return;
     }
 
@@ -465,10 +467,14 @@ export class ChannelManager<SCG extends ExtendableGenerics = DefaultGenerics> {
       type: event.channel_type,
     });
 
+    const { channels, pagination } = this.state.getLatestValue();
+    const { sort, filters } = pagination ?? {};
+
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
 
     if (
+      !channels ||
       (considerArchivedChannels && isTargetChannelArchived && !filters.archived) ||
       (considerArchivedChannels && !isTargetChannelArchived && filters.archived) ||
       !this.options.allowNotLoadedChannelPromotionForEvent?.['channel.visible']

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -611,7 +611,7 @@ const get = <T>(obj: T, path: string): unknown =>
   }, obj);
 
 // works exactly the same as lodash.uniqBy
-export const uniqBy = <T>(array: T[], iteratee: ((item: T) => unknown) | keyof T): T[] => {
+export const uniqBy = <T>(array: unknown, iteratee: ((item: T) => unknown) | keyof T): T[] => {
   if (!Array.isArray(array)) return [];
 
   const seen = new Map<unknown, boolean>();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -602,6 +602,27 @@ export const throttle = <T extends (...args: unknown[]) => unknown>(
   };
 };
 
+const get = <T>(obj: T, path: string): unknown =>
+  path.split('.').reduce<unknown>((acc, key) => {
+    if (acc && typeof acc === 'object' && key in acc) {
+      return (acc as Record<string, unknown>)[key];
+    }
+    return undefined;
+  }, obj);
+
+// works exactly the same as lodash.uniqBy
+export const uniqBy = <T>(array: T[], iteratee: ((item: T) => unknown) | keyof T): T[] => {
+  if (!Array.isArray(array)) return [];
+
+  const seen = new Map<unknown, boolean>();
+  return array.filter((item) => {
+    const key = typeof iteratee === 'function' ? iteratee(item) : get(item, iteratee as string);
+    if (seen.has(key)) return false;
+    seen.set(key, true);
+    return true;
+  });
+};
+
 type MessagePaginationUpdatedParams<StreamChatGenerics extends ExtendableGenerics = DefaultGenerics> = {
   parentSet: MessageSet;
   requestedPageSize: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -614,11 +614,11 @@ const get = <T>(obj: T, path: string): unknown =>
 export const uniqBy = <T>(array: T[] | unknown, iteratee: ((item: T) => unknown) | keyof T): T[] => {
   if (!Array.isArray(array)) return [];
 
-  const seen = new Map<unknown, boolean>();
+  const seen = new Set<unknown>();
   return array.filter((item) => {
     const key = typeof iteratee === 'function' ? iteratee(item) : get(item, iteratee as string);
     if (seen.has(key)) return false;
-    seen.set(key, true);
+    seen.add(key);
     return true;
   });
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -611,7 +611,7 @@ const get = <T>(obj: T, path: string): unknown =>
   }, obj);
 
 // works exactly the same as lodash.uniqBy
-export const uniqBy = <T>(array: unknown, iteratee: ((item: T) => unknown) | keyof T): T[] => {
+export const uniqBy = <T>(array: T[] | unknown, iteratee: ((item: T) => unknown) | keyof T): T[] => {
   if (!Array.isArray(array)) return [];
 
   const seen = new Map<unknown, boolean>();

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -600,7 +600,7 @@ describe('ChannelManager', () => {
             hasNext: true,
             isLoading: false,
             isLoadingNext: false,
-            options: { limit: 10, offset: 25 },
+            options: { limit: 10, offset: 20 },
             sort: { asc: 1 },
           },
         });
@@ -667,6 +667,10 @@ describe('ChannelManager', () => {
         stateChangeSpy.resetHistory();
 
         await channelManager.loadNext();
+
+        const { channels: channelsAfterFirstPagination } = channelManager.state.getLatestValue();
+        expect(channelsAfterFirstPagination.length).to.equal(23);
+
         await channelManager.loadNext();
 
         const { channels } = channelManager.state.getLatestValue();
@@ -689,7 +693,7 @@ describe('ChannelManager', () => {
             hasNext: true,
             isLoading: false,
             isLoadingNext: false,
-            options: { limit: 10, offset: 23 },
+            options: { limit: 10, offset: 20 },
             sort: { asc: 1 },
           },
         });

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -16,7 +16,7 @@ import { generateChannel } from './test-utils/generateChannel';
 import { getClientWithUser } from './test-utils/getClient';
 import * as Utils from '../../src/utils';
 
-describe.only('ChannelManager', () => {
+describe('ChannelManager', () => {
   let client: StreamChat;
   let channelManager: ChannelManager;
   let channelsResponse: ChannelAPIResponse[];
@@ -651,7 +651,7 @@ describe.only('ChannelManager', () => {
         expect(channels.length).to.equal(20);
       });
 
-      it.only('should properly deduplicate when paginating if channels latter pages have been promoted and reached', async () => {
+      it('should properly deduplicate when paginating if channels latter pages have been promoted and reached', async () => {
         await channelManager.queryChannels({ filterA: true }, { asc: 1 }, { limit: 10, offset: 0 });
         channelManager.state.next((prevState) => ({
           ...prevState,
@@ -1142,7 +1142,7 @@ describe.only('ChannelManager', () => {
 
         await clock.runAllAsync();
 
-        expect(getAndWatchChannelStub.called).to.be.false;
+        expect(getAndWatchChannelStub.called).to.be.true;
         expect(setChannelsStub.called).to.be.false;
       });
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

There was an unfortunate bug with the pagination logic in the new `ChannelManager` that somehow evaded me in the last PR. The offset was not being calculated properly, particularly in cases where:

- We might have `state.channels` receive updates from something other than pagination (WS events for instance) and it will then contain either broken pagination or duplicate values when actually paginating (for example if a WS event arrives as the query is being executed)
- The state might also change since there's nothing from preventing it (`setChannels` is `public`)
- Any other case really between 2 `loadNext()` invocations

For this purpose, when running the queries we always calculate the offset through `state.channels.length` and we make sure to run `state.getLatestValue()` as late as possible, particularly when there are HTTP calls involved (we can ignore the other instances of this happening).

In addition to fixing `loadNext()`, the relevant WS event handlers have also been fixed (ones that run asynchronously) to make sure the most up to date state is always there. 

## Changelog

-
