### PR TITLE
fix: properly encode user agent on WS connection

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -189,7 +189,9 @@ export class StableWSConnection<StreamChatGenerics extends ExtendableGenerics = 
 
     return `${this.client.wsBaseURL}/connect?json=${qs}&api_key=${
       this.client.key
-    }&authorization=${token}&stream-auth-type=${this.client.getAuthType()}&X-Stream-Client=${this.client.getUserAgent()}`;
+    }&authorization=${token}&stream-auth-type=${this.client.getAuthType()}&X-Stream-Client=${encodeURIComponent(
+      this.client.getUserAgent(),
+    )}`;
   };
 
   /**

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -78,12 +78,12 @@ describe('connection', function () {
 		});
 
 		it('should properly encode X-Stream-Client', () => {
-			const userAgent = 'agent|val=foo bar'
-			client.userAgent = userAgent
+			const userAgent = 'agent|val=foo bar';
+			client.userAgent = userAgent;
 			const url = ws._buildUrl();
 
-			expect(url).to.contain(encodeURIComponent(userAgent))
-		})
+			expect(url).to.contain(encodeURIComponent(userAgent));
+		});
 
 		it('should not include device if not there', function () {
 			ws.client.options.device = undefined;

--- a/test/unit/connection.js
+++ b/test/unit/connection.js
@@ -77,6 +77,14 @@ describe('connection', function () {
 			expect(data.device).to.deep.equal(device);
 		});
 
+		it('should properly encode X-Stream-Client', () => {
+			const userAgent = 'agent|val=foo bar'
+			client.userAgent = userAgent
+			const url = ws._buildUrl();
+
+			expect(url).to.contain(encodeURIComponent(userAgent))
+		})
+
 		it('should not include device if not there', function () {
 			ws.client.options.device = undefined;
 			const { query } = url.parse(ws._buildUrl(), true);


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

With the recent changes to the user agent resolution within our LLC, encoding the uri component properly during building the WS url was missed. This works just fine if you're already connected, however it will fail if you're trying to connect another user.

In the current state of the LLC it would only affect React Native as the other SDKs do not yet add the extra params. 

## Changelog

-
