### PR TITLE
fix: remove pinned_at from the updateMessage api

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2705,6 +2705,7 @@ export class StreamChat<StreamChatGenerics extends ExtendableGenerics = DefaultG
       'type',
       'updated_at',
       'user',
+      'pinned_at',
       '__html',
     ];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2896,6 +2896,7 @@ export type ReservedMessageFields =
   | 'reply_count'
   | 'type'
   | 'updated_at'
+  | 'pinned_at'
   | 'user'
   | '__html';
 

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -459,7 +459,7 @@ describe('updateMessage should maintain data integrity', () => {
 			silent: updatedMessage.silent,
 			status: updatedMessage.status,
 			text: updatedMessage.text,
-		}
+		};
 
 		expect(postSpy.args[0][1].message).to.deep.equal(messageInQuery);
 	});

--- a/test/unit/client.js
+++ b/test/unit/client.js
@@ -388,9 +388,14 @@ describe('Client deleteUsers', () => {
 	});
 });
 
-describe('updateMessage should ensure sanity of `mentioned_users`', () => {
+describe('updateMessage should maintain data integrity', () => {
+	let client;
+
+	beforeEach(async () => {
+		client = await getClientWithUser();
+	});
+
 	it('should convert mentioned_users from array of user objects to array of userIds', async () => {
-		const client = await getClientWithUser();
 		client.post = (url, config) => {
 			expect(typeof config.message.mentioned_users[0]).to.be.equal('string');
 			expect(config.message.mentioned_users[0]).to.be.equal('uthred');
@@ -414,7 +419,6 @@ describe('updateMessage should ensure sanity of `mentioned_users`', () => {
 	});
 
 	it('should allow empty mentioned_users', async () => {
-		const client = await getClientWithUser();
 		client.post = (url, config) => {
 			expect(config.message.mentioned_users[0]).to.be.equal(undefined);
 		};
@@ -435,6 +439,29 @@ describe('updateMessage should ensure sanity of `mentioned_users`', () => {
 				mentioned_users: undefined,
 			}),
 		);
+	});
+
+	it('should remove reserved and volatile fields before running the update', async () => {
+		const postSpy = sinon.stub(client, 'post');
+		const updatedMessage = generateMsg({
+			text: 'test message',
+			pinned_at: new Date().toISOString(),
+			mentioned_users: undefined,
+		});
+
+		await client.updateMessage(updatedMessage);
+
+		const messageInQuery = {
+			attachments: updatedMessage.attachments,
+			mentioned_users: updatedMessage.mentioned_users,
+			reaction_counts: updatedMessage.reaction_counts,
+			reaction_scores: updatedMessage.reaction_scores,
+			silent: updatedMessage.silent,
+			status: updatedMessage.status,
+			text: updatedMessage.text,
+		}
+
+		expect(postSpy.args[0][1].message).to.deep.equal(messageInQuery);
 	});
 });
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Whenever using the `updateMessage` API, we rely on updating the entire message object with most of its values left unchanged and only some of them mutating. This generally works fine as the backend does updates in a smart way (i.e it won't update a field if its value hasn't changed). However, since natively Javascript dates go down to milliseconds and server-side they are stored until microseconds, there is a discrepancy between these 2 values and the `pinned_at` value is considered different; hence causing things to malfunction.

For example, if a user does not have pinning permissions in a specific channel and someone else pins a message, they won't be able to update it due to the fact that it will be considered as an update to the `pinned_at` date as well - throwing an error. Similarly to how we handle other dates (`created_at`, `updated_at` etc), we disregard this value for the time being. 

For a more long-term solution, it would be prudent if we:

- Store dates as strings and only convert them to dates whenever needed (this still has some odd edge cases that we'd need to take into account)
- Possibly rely on `partialUpdateMessage` rather than `updateMessage` for features like message editing in order to avoid broken behaviour (however, using the vanilla API would still not work)

So, for the time being we ignore `pinned_at` from the API.

More information in [this Slack thread](https://getstream.slack.com/archives/C04SDJ3BC6Q/p1739524298745469).

## Changelog

-
