### PR TITLE
fix: add image property to UserResponse type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -841,13 +841,15 @@ export type UpdateUsersAPIResponse = APIResponse & {
   users: { [key: string]: UserResponse };
 };
 
-export type UserResponse = User & {
-  image?: string;
+export type UserResponse = CustomUserData & {
+  id: string;
+  anon?: boolean;
   banned?: boolean;
   blocked_user_ids?: string[];
   created_at?: string;
   deactivated_at?: string;
   deleted_at?: string;
+  image?: string;
   language?: TranslationLanguages | '';
   last_active?: string;
   name?: string;
@@ -856,8 +858,11 @@ export type UserResponse = User & {
   privacy_settings?: PrivacySettings;
   push_notifications?: PushNotificationSettings;
   revoke_tokens_issued_before?: string;
+  role?: string;
   shadow_banned?: boolean;
+  teams?: string[];
   updated_at?: string;
+  username?: string;
 };
 
 export type PrivacySettings = {
@@ -2906,14 +2911,10 @@ export type UpdatedMessage = Omit<MessageResponse, 'mentioned_users' | 'type'> &
   type?: MessageLabel;
 };
 
-export type User = CustomUserData & {
-  id: string;
-  anon?: boolean;
-  name?: string;
-  role?: string;
-  teams?: string[];
-  username?: string;
-};
+/**
+ * @description type alias for UserResponse
+ */
+export type User = UserResponse;
 
 export type TaskResponse = {
   task_id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -842,6 +842,7 @@ export type UpdateUsersAPIResponse = APIResponse & {
 };
 
 export type UserResponse = User & {
+  image?: string;
   banned?: boolean;
   blocked_user_ids?: string[];
   created_at?: string;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Property `image` is considered a regular property according to the OpenAPI specification.