### PR TITLE
fix: multiple module augmentation fails in Angular

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,20 @@ export * from './thread_manager';
 export * from './token_manager';
 export * from './types';
 export * from './channel_manager';
-export * from './custom_types';
+// Don't use * here, that can break module augmentation https://github.com/microsoft/TypeScript/issues/46617
+export type {
+  CustomAttachmentData,
+  CustomChannelData,
+  CustomCommandData,
+  CustomEventData,
+  CustomMemberData,
+  CustomMessageData,
+  CustomPollOptionData,
+  CustomPollData,
+  CustomReactionData,
+  CustomUserData,
+  CustomThreadData,
+} from './custom_types';
 export {
   isOwnUser,
   chatCodes,


### PR DESCRIPTION
## CLA

- [] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [] Code changes are tested

## Description of the changes, What, Why and How?

When removing generics from stream-chat-angular I had an issue where augmenting the same custom interface (for example `CustomChannelData`) from two places (SDK and sample app) some changes were ignored (detailed description: https://getstream.slack.com/archives/C06CF5TKRGA/p1741163343794659).

Found this open GH issue for TypeScript: https://github.com/microsoft/TypeScript/issues/46617 

https://linear.app/stream/issue/ANG-31/drop-generics 

## Changelog

-
