### PR TITLE
fix: adjust ErrorFromResponse error class

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1181,20 +1181,17 @@ export class StreamChat {
     });
   }
 
-  errorFromResponse(
-    response: AxiosResponse<APIErrorResponse>,
-  ): ErrorFromResponse<APIErrorResponse> {
-    let err: ErrorFromResponse<APIErrorResponse>;
-    err = new ErrorFromResponse(`StreamChat error HTTP code: ${response.status}`);
-    if (response.data && response.data.code) {
-      err = new Error(
-        `StreamChat error code ${response.data.code}: ${response.data.message}`,
-      );
-      err.code = response.data.code;
-    }
-    err.response = response;
-    err.status = response.status;
-    return err;
+  errorFromResponse(response: AxiosResponse<APIErrorResponse>) {
+    const message =
+      typeof response.data.code !== 'undefined'
+        ? `StreamChat error code ${response.data.code}: ${response.data.message}`
+        : `StreamChat error HTTP code: ${response.status}`;
+
+    return new ErrorFromResponse<APIErrorResponse>(message, {
+      code: response.data.code ?? null,
+      response,
+      status: response.status,
+    });
   }
 
   handleResponse<T>(response: AxiosResponse<T>) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3197,18 +3197,36 @@ type ErrorResponseDetails = {
 };
 
 export type APIErrorResponse = {
-  code: number;
   duration: string;
   message: string;
   more_info: string;
   StatusCode: number;
+  code?: number;
   details?: ErrorResponseDetails;
 };
 
 export class ErrorFromResponse<T> extends Error {
-  code?: number;
-  response?: AxiosResponse<T>;
-  status?: number;
+  public code: number | null;
+  public status: number;
+  public response: AxiosResponse<T>;
+
+  constructor(
+    message: string,
+    {
+      code,
+      status,
+      response,
+    }: {
+      code: ErrorFromResponse<T>['code'];
+      response: ErrorFromResponse<T>['response'];
+      status: ErrorFromResponse<T>['status'];
+    },
+  ) {
+    super(message);
+    this.code = code;
+    this.response = response;
+    this.status = status;
+  }
 }
 
 export type QueryPollsResponse = {


### PR DESCRIPTION
BREAKING CHANGE: `ErrorFromResponse` class constructor now requires second parameter (`status`, `response` and optionally `code`)