### PR TITLE
fix: add event fields on creating campaign

### DIFF
--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -23,9 +23,9 @@ export class Campaign<StreamChatGenerics extends ExtendableGenerics = DefaultGen
       create_channels: this.data?.create_channels,
       description: this.data?.description,
       name: this.data?.name,
-      user_ids: this.data?.user_ids,
-      skip_webhook: this.data?.skip_webhook,
       skip_push: this.data?.skip_push,
+      skip_webhook: this.data?.skip_webhook,
+      user_ids: this.data?.user_ids,
     };
 
     const result = await this.client.createCampaign(body);

--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -24,6 +24,8 @@ export class Campaign<StreamChatGenerics extends ExtendableGenerics = DefaultGen
       description: this.data?.description,
       name: this.data?.name,
       user_ids: this.data?.user_ids,
+      skip_webhook: this.data?.skip_webhook,
+      skip_push: this.data?.skip_push,
     };
 
     const result = await this.client.createCampaign(body);


### PR DESCRIPTION
## Ticket

- https://linear.app/stream/issue/REACT-346/missing-event-related-fields-when-creating-campaigns

## Summary 

Add `skip_push` and `skip_webhook` params to campaign creation call.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
