### PR TITLE
feat: add show_channels flag to campaigns

### DIFF
--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -21,6 +21,7 @@ export class Campaign<StreamChatGenerics extends ExtendableGenerics = DefaultGen
       sender_mode: this.data?.sender_mode,
       channel_template: this.data?.channel_template,
       create_channels: this.data?.create_channels,
+      show_channels: this.data?.show_channels,
       description: this.data?.description,
       name: this.data?.name,
       user_ids: this.data?.user_ids,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3074,6 +3074,7 @@ export type CampaignData = {
   segment_ids?: string[];
   sender_id?: string;
   sender_mode?: 'exclude' | 'include' | null;
+  show_channels?: boolean;
   skip_push?: boolean;
   skip_webhook?: boolean;
   user_ids?: string[];


### PR DESCRIPTION
## Linear

- https://linear.app/stream/issue/CHA-214/handle-hidden-channels-as-part-of-campaigns

## Summary

Introduce a new `show_channels` flag to let campaigns show the hidden channels.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
