### PR TITLE
fix: [REACT-353] unify pinned_at & archived_at nullish values

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1618,22 +1618,36 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
         }
         break;
       case 'member.added':
-      case 'member.updated':
-        if (event.member?.user) {
+      case 'member.updated': {
+        const memberCopy: ChannelMemberResponse = {
+          ...event.member,
+        };
+
+        if (memberCopy.pinned_at === null) {
+          delete memberCopy.pinned_at;
+        }
+
+        if (memberCopy.archived_at === null) {
+          delete memberCopy.archived_at;
+        }
+
+        if (memberCopy?.user) {
           channelState.members = {
             ...channelState.members,
-            [event.member.user.id]: event.member,
+            [memberCopy.user.id]: memberCopy,
           };
         }
 
+        const currentUserId = this.getClient().userID;
         if (
-          typeof channelState.membership.user?.id === 'string' &&
-          typeof event.member?.user?.id === 'string' &&
-          event.member.user.id === channelState.membership.user.id
+          typeof currentUserId === 'string' &&
+          typeof memberCopy?.user?.id === 'string' &&
+          memberCopy.user.id === currentUserId
         ) {
-          channelState.membership = event.member;
+          channelState.membership = memberCopy;
         }
         break;
+      }
       case 'member.removed':
         if (event.user?.id) {
           const newMembers = {

--- a/test/unit/channel.js
+++ b/test/unit/channel.js
@@ -1,4 +1,4 @@
-import chai from 'chai';
+import chai, { use } from 'chai';
 import { v4 as uuidv4 } from 'uuid';
 
 import { generateChannel } from './test-utils/generateChannel';
@@ -206,6 +206,53 @@ describe('Channel _handleChannelEvent', function () {
 		client.userMuteStatus = (targetId) => targetId.startsWith('mute');
 		channel = client.channel('messaging', 'id');
 		channel.initialized = true;
+	});
+
+	it('member.updated/member.added are being handled properly (ChannelState.membership & ChannelState.members)', () => {
+		expect(channel.state.members).to.be.empty;
+		expect(channel.state.membership).to.be.empty;
+
+		const currentMember = generateMember({
+			user,
+			pinned_at: new Date().toISOString(),
+			archived_at: new Date().toISOString(),
+		});
+
+		const otherMember = generateMember({
+			user: { id: 'user-other' },
+		});
+
+		channel._handleChannelEvent({
+			type: 'member.added',
+			user,
+			member: currentMember,
+		});
+
+		expect(channel.state.members).to.have.property(user.id);
+		expect(channel.state.members[user.id]).to.deep.equal(currentMember);
+		expect(channel.state.membership).to.deep.equal(currentMember);
+
+		channel._handleChannelEvent({
+			type: 'member.added',
+			user,
+			member: otherMember,
+		});
+
+		expect(channel.state.members).to.have.keys([user.id, otherMember.user.id]);
+		expect(channel.state.members[otherMember.user.id]).to.deep.equal(otherMember);
+		expect(channel.state.members[user.id]).to.deep.equal(currentMember);
+		expect(channel.state.membership).to.deep.equal(currentMember);
+
+		const currentMemberUpdated = generateMember({ user, pinned_at: null, archived_at: null });
+
+		channel._handleChannelEvent({
+			type: 'member.updated',
+			user,
+			member: currentMemberUpdated,
+		});
+
+		expect(channel.state.membership).to.not.have.keys(['pinned_at', 'archived_at']);
+		expect(channel.state.membership).to.equal(channel.state.members[user.id]);
 	});
 
 	it('message.new does not reset the unreadCount for current user messages', function () {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Event handler for `member.updated` receives a `member` object which contains `archived_at` and `pinned_at` with `null` values if unarchive/unpin actions are called - to make matters for our integrators easier, the only nullish value for these would be `undefined`. I'll keep the types unchanged (#1515) as the `ChannelMemberResponse` used in the `Event` type is still correct.