### PR TITLE
[CHA-855] - Refactoring partial update member

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -310,7 +310,24 @@ export class Channel<StreamChatGenerics extends ExtendableGenerics = DefaultGene
     );
   }
 
+   /**
+   * updateMemberPartial - Partial update a member
+   *
+   * @param {PartialUpdateMember<StreamChatGenerics>}  updates
+   * @param {{ user_id?: string }} [options] Option object, {user_id: 'jane'} to optionally specify the user id
+
+   * @return {Promise<ChannelMemberResponse<StreamChatGenerics>>} Updated member
+   */
+  async updateMemberPartial(updates: PartialUpdateMember<StreamChatGenerics>, options?: { userId?: string }) {
+    const q = options?.userId ? `?user_id=${options.userId}` : '';
+    return await this.getClient().patch<PartialUpdateMemberAPIResponse<StreamChatGenerics>>(
+      this._channelURL() + `/member${q}`,
+      updates,
+    );
+  }
+
   /**
+   * @deprecated Use `updateMemberPartial` instead
    * partialUpdateMember - Partial update a member
    *
    * @param {string} user_id member user id


### PR DESCRIPTION
Creating a new endpoint /channels/{type}/{id}/member for partially updating members, this endpoint is functionally the same as /channels/{type}/{id}/member/{id} (which is now deprecated). The user id is automatically provided for clientside request, so it doesn't make sense to have it as a mandatory field in the url path. The new endpoint optionally accepts ?user_id=...

At some point we must sunset the deprecated endpoint