### PR TITLE
refactor: general code cleanup (Threads/Polls/MessageComposer)

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -20,6 +20,7 @@ import {
   shouldConsiderPinnedChannels,
   uniqBy,
 } from './utils';
+import { WithSubscriptions } from './utils/WithSubscriptions';
 
 export type ChannelManagerPagination = {
   filters: ChannelFilters;
@@ -142,10 +143,9 @@ export const DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS = {
  *
  * @internal
  */
-export class ChannelManager {
+export class ChannelManager extends WithSubscriptions {
   public readonly state: StateStore<ChannelManagerState>;
   private client: StreamChat;
-  private unsubscribeFunctions: Set<() => void> = new Set();
   private eventHandlers: Map<string, EventHandlerType> = new Map();
   private eventHandlerOverrides: Map<string, EventHandlerOverrideType> = new Map();
   private options: ChannelManagerOptions = {};
@@ -160,6 +160,8 @@ export class ChannelManager {
     eventHandlerOverrides?: ChannelManagerEventHandlerOverrides;
     options?: ChannelManagerOptions;
   }) {
+    super();
+
     this.client = client;
     this.state = new StateStore<ChannelManagerState>({
       channels: [],
@@ -606,20 +608,16 @@ export class ChannelManager {
   };
 
   public registerSubscriptions = () => {
-    if (this.unsubscribeFunctions.size) {
+    
+    if (this.hasSubscriptions) {
       // Already listening for events and changes
       return;
     }
 
     for (const eventType of Object.keys(channelManagerEventToHandlerMapping)) {
-      this.unsubscribeFunctions.add(
+      this.addUnsubscribeFunction(
         this.client.on(eventType, this.subscriptionOrOverride).unsubscribe,
       );
     }
-  };
-
-  public unregisterSubscriptions = () => {
-    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
-    this.unsubscribeFunctions.clear();
   };
 }

--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -608,7 +608,6 @@ export class ChannelManager extends WithSubscriptions {
   };
 
   public registerSubscriptions = () => {
-    
     if (this.hasSubscriptions) {
       // Already listening for events and changes
       return;

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -71,10 +71,35 @@ const initState = ({
 export class AttachmentManager {
   readonly state: StateStore<AttachmentManagerState>;
   readonly composer: MessageComposer;
+  private attachmentsByIdGetterCache: {
+    attachmentsById: Record<string, LocalAttachment>;
+    attachments: LocalAttachment[];
+  };
 
   constructor({ composer, message }: AttachmentManagerOptions) {
     this.composer = composer;
     this.state = new StateStore<AttachmentManagerState>(initState({ message }));
+    this.attachmentsByIdGetterCache = { attachmentsById: {}, attachments: [] };
+  }
+
+  get attachmentsById() {
+    const { attachments } = this.state.getLatestValue();
+
+    if (attachments !== this.attachmentsByIdGetterCache.attachments) {
+      this.attachmentsByIdGetterCache.attachments = attachments;
+      this.attachmentsByIdGetterCache.attachmentsById = attachments.reduce<
+        Record<string, LocalAttachment>
+      >((newAttachmentsById, attachment) => {
+        // should never happen but does not hurt to check
+        if (!attachment.localMetadata.id) return newAttachmentsById;
+
+        newAttachmentsById[attachment.localMetadata.id] ??= attachment;
+
+        return newAttachmentsById;
+      }, {});
+    }
+
+    return this.attachmentsByIdGetterCache.attachmentsById;
   }
 
   get client() {
@@ -176,44 +201,47 @@ export class AttachmentManager {
     this.state.next(initState({ message }));
   };
 
-  getAttachmentIndex = (localId: string) =>
-    this.attachments.findIndex(
-      (attachment) =>
-        attachment.localMetadata.id && localId === attachment.localMetadata?.id,
-    );
+  getAttachmentIndex = (localId: string) => {
+    const attachmentsById = this.attachmentsById;
+
+    return this.attachments.indexOf(attachmentsById[localId]);
+  };
 
   upsertAttachments = (attachmentsToUpsert: LocalAttachment[]) => {
     if (!attachmentsToUpsert.length) return;
-    const stateAttachments = this.attachments;
-    const attachments = [...this.attachments];
-    attachmentsToUpsert.forEach((upsertedAttachment) => {
-      const attachmentIndex = this.getAttachmentIndex(
-        upsertedAttachment.localMetadata.id,
-      );
 
-      if (attachmentIndex === -1) {
-        const localAttachment = ensureIsLocalAttachment(upsertedAttachment);
-        if (localAttachment) attachments.push(localAttachment);
+    const currentAttachments = this.attachments;
+    const newAttachments = [...currentAttachments];
+
+    attachmentsToUpsert.forEach((attachment) => {
+      const targetAttachmentIndex = this.getAttachmentIndex(attachment.localMetadata?.id);
+
+      if (targetAttachmentIndex < 0) {
+        const localAttachment = ensureIsLocalAttachment(attachment);
+        if (localAttachment) newAttachments.push(localAttachment);
       } else {
+        // do not re-organize newAttachments array otherwise indexing would no longer work
+        // replace in place only with the attachments with the same id's
         const merged = mergeWithDiff<LocalAttachment>(
-          stateAttachments[attachmentIndex] ?? {},
-          upsertedAttachment,
+          currentAttachments[targetAttachmentIndex],
+          attachment,
         );
         const updatesOnMerge = merged.diff && Object.keys(merged.diff.children).length;
         if (updatesOnMerge) {
           const localAttachment = ensureIsLocalAttachment(merged.result);
-          if (localAttachment) attachments.splice(attachmentIndex, 1, localAttachment);
+          if (localAttachment)
+            newAttachments.splice(targetAttachmentIndex, 1, localAttachment);
         }
       }
     });
 
-    this.state.partialNext({ attachments });
+    this.state.partialNext({ attachments: newAttachments });
   };
 
   removeAttachments = (localAttachmentIds: string[]) => {
     this.state.partialNext({
       attachments: this.attachments.filter(
-        (att) => !localAttachmentIds.includes(att.localMetadata?.id),
+        (attachment) => !localAttachmentIds.includes(attachment.localMetadata?.id),
       ),
     });
   };

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -41,17 +41,16 @@ export type AttachmentManagerConfig = {
   /** Function that allows to customize the upload request. */
   doUploadRequest?: UploadRequestFn;
 };
-export type LinkPreviewConfig = {
-  /** Custom function to react to link preview dismissal */
-  onLinkPreviewDismissed?: (linkPreview: LinkPreview) => void;
-};
-export type LinkPreviewsManagerConfig = LinkPreviewConfig & {
+
+export type LinkPreviewsManagerConfig = {
   /** Number of milliseconds to debounce firing the URL enrichment queries when typing. The default value is 1500(ms). */
   debounceURLEnrichmentMs: number;
   /** Allows for toggling the URL enrichment and link previews in `MessageInput`. By default, the feature is disabled. */
   enabled: boolean;
   /** Custom function to identify URLs in a string and request OG data */
   findURLFn: (text: string) => string[];
+  /** Custom function to react to link preview dismissal */
+  onLinkPreviewDismissed?: (linkPreview: LinkPreview) => void;
 };
 
 export type MessageComposerConfig = {

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -371,10 +371,6 @@ export class MessageComposer extends WithSubscriptions {
     this.addUnsubscribeFunction(this.subscribeCustomDataManagerStateChanged());
     this.addUnsubscribeFunction(this.subscribeMessageComposerStateChanged());
     this.addUnsubscribeFunction(this.subscribeMessageComposerConfigStateChanged());
-    if (this.config.drafts.enabled) {
-      this.addUnsubscribeFunction(this.subscribeDraftUpdated());
-      this.addUnsubscribeFunction(this.subscribeDraftDeleted());
-    }
 
     return this.unregisterSubscriptions;
   };

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -478,8 +478,7 @@ export class MessageComposer extends WithSubscriptions {
           return;
         }
 
-        const [previousText] = previousSelection;
-        if (!this.linkPreviewsManager.enabled || currentText === previousText) return;
+        if (!this.linkPreviewsManager.enabled) return;
 
         if (!currentText) {
           this.linkPreviewsManager.clearPreviews();

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -26,6 +26,10 @@ import type {
 import type { StreamChat } from '../client';
 import type { MessageComposerConfig } from './configuration/types';
 import type { DeepPartial } from '../types.utility';
+import type { Unsubscribe } from '../store';
+import { WithSubscriptions } from '../utils/WithSubscriptions';
+
+type UnregisterSubscriptions = Unsubscribe;
 
 export type LastComposerChange = { draftUpdate: number | null; stateUpdate: number };
 
@@ -109,7 +113,7 @@ const initState = (
 
 const noop = () => undefined;
 
-export class MessageComposer {
+export class MessageComposer extends WithSubscriptions {
   readonly channel: Channel;
   readonly state: StateStore<MessageComposerState>;
   readonly editingAuditState: StateStore<EditingAuditState>;
@@ -126,14 +130,14 @@ export class MessageComposer {
   customDataManager: CustomDataManager;
   // todo: mediaRecorder: MediaRecorderController;
 
-  private unsubscribeFunctions: Set<() => void> = new Set();
-
   constructor({
     composition,
     config,
     compositionContext,
     client,
   }: MessageComposerOptions) {
+    super();
+
     this.compositionContext = compositionContext;
 
     this.configState = new StateStore<MessageComposerConfig>(
@@ -342,6 +346,7 @@ export class MessageComposer {
       lastChange: { ...this.lastChange, stateUpdate: new Date().getTime() },
     });
   }
+
   private logDraftUpdateTimestamp() {
     if (!this.config.drafts.enabled) return;
     const timestamp = new Date().getTime();
@@ -350,34 +355,28 @@ export class MessageComposer {
     });
   }
 
-  public registerSubscriptions = () => {
-    if (this.unsubscribeFunctions.size) {
+  public registerSubscriptions = (): UnregisterSubscriptions => {
+    if (this.hasSubscriptions) {
       // Already listening for events and changes
       return noop;
     }
-    this.unsubscribeFunctions.add(this.subscribeMessageComposerSetupStateChange());
-    this.unsubscribeFunctions.add(this.subscribeMessageUpdated());
-    this.unsubscribeFunctions.add(this.subscribeMessageDeleted());
+    this.addUnsubscribeFunction(this.subscribeMessageComposerSetupStateChange());
+    this.addUnsubscribeFunction(this.subscribeMessageUpdated());
+    this.addUnsubscribeFunction(this.subscribeMessageDeleted());
 
-    this.unsubscribeFunctions.add(this.subscribeTextComposerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribeAttachmentManagerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribeLinkPreviewsManagerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribePollComposerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribeCustomDataManagerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribeMessageComposerStateChanged());
-    this.unsubscribeFunctions.add(this.subscribeMessageComposerConfigStateChanged());
+    this.addUnsubscribeFunction(this.subscribeTextComposerStateChanged());
+    this.addUnsubscribeFunction(this.subscribeAttachmentManagerStateChanged());
+    this.addUnsubscribeFunction(this.subscribeLinkPreviewsManagerStateChanged());
+    this.addUnsubscribeFunction(this.subscribePollComposerStateChanged());
+    this.addUnsubscribeFunction(this.subscribeCustomDataManagerStateChanged());
+    this.addUnsubscribeFunction(this.subscribeMessageComposerStateChanged());
+    this.addUnsubscribeFunction(this.subscribeMessageComposerConfigStateChanged());
     if (this.config.drafts.enabled) {
-      this.unsubscribeFunctions.add(this.subscribeDraftUpdated());
-      this.unsubscribeFunctions.add(this.subscribeDraftDeleted());
+      this.addUnsubscribeFunction(this.subscribeDraftUpdated());
+      this.addUnsubscribeFunction(this.subscribeDraftDeleted());
     }
 
     return this.unregisterSubscriptions;
-  };
-
-  // TODO: maybe make these private across the SDK
-  public unregisterSubscriptions = () => {
-    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
-    this.unsubscribeFunctions.clear();
   };
 
   private subscribeMessageUpdated = () => {
@@ -452,38 +451,50 @@ export class MessageComposer {
         !draft ||
         !!draft.parent_id !== !!this.threadId ||
         draft.channel_cid !== this.channel.cid
-      )
+      ) {
         return;
+      }
 
       this.logDraftUpdateTimestamp();
+
       if (this.compositionIsEmpty) {
         return;
       }
+
       this.clear();
     }).unsubscribe;
 
   private subscribeTextComposerStateChanged = () =>
-    this.textComposer.state.subscribe((nextValue, previousValue) => {
-      if (previousValue && nextValue.text !== previousValue?.text) {
+    this.textComposer.state.subscribeWithSelector(
+      ({ text }) => [text] as const,
+      ([currentText], previousSelection) => {
+        // do not handle on initial subscription
+        if (typeof previousSelection === 'undefined') return;
+
         this.logStateUpdateTimestamp();
+
         if (this.compositionIsEmpty) {
           this.deleteDraft();
           return;
         }
-      }
-      if (!this.linkPreviewsManager.enabled || nextValue.text === previousValue?.text)
-        return;
-      if (!nextValue.text) {
-        this.linkPreviewsManager.clearPreviews();
-      } else {
-        this.linkPreviewsManager.findAndEnrichUrls(nextValue.text);
-      }
-    });
+
+        const [previousText] = previousSelection;
+        if (!this.linkPreviewsManager.enabled || currentText === previousText) return;
+
+        if (!currentText) {
+          this.linkPreviewsManager.clearPreviews();
+        } else {
+          this.linkPreviewsManager.findAndEnrichUrls(currentText);
+        }
+      },
+    );
 
   private subscribeAttachmentManagerStateChanged = () =>
-    this.attachmentManager.state.subscribe((nextValue, previousValue) => {
+    this.attachmentManager.state.subscribe((_, previousValue) => {
       if (typeof previousValue === 'undefined') return;
+
       this.logStateUpdateTimestamp();
+
       if (this.compositionIsEmpty) {
         this.deleteDraft();
         return;
@@ -491,9 +502,11 @@ export class MessageComposer {
     });
 
   private subscribeLinkPreviewsManagerStateChanged = () =>
-    this.linkPreviewsManager.state.subscribe((nextValue, previousValue) => {
+    this.linkPreviewsManager.state.subscribe((_, previousValue) => {
       if (typeof previousValue === 'undefined') return;
+
       this.logStateUpdateTimestamp();
+
       if (this.compositionIsEmpty) {
         this.deleteDraft();
         return;
@@ -501,9 +514,11 @@ export class MessageComposer {
     });
 
   private subscribePollComposerStateChanged = () =>
-    this.pollComposer.state.subscribe((nextValue, previousValue) => {
+    this.pollComposer.state.subscribe((_, previousValue) => {
       if (typeof previousValue === 'undefined') return;
+
       this.logStateUpdateTimestamp();
+
       if (this.compositionIsEmpty) {
         this.deleteDraft();
         return;
@@ -514,6 +529,7 @@ export class MessageComposer {
     this.customDataManager.state.subscribe((nextValue, previousValue) => {
       if (
         typeof previousValue !== 'undefined' &&
+        // FIXME: is this check really necessary?
         !this.customDataManager.isMessageDataEqual(nextValue, previousValue)
       ) {
         this.logStateUpdateTimestamp();
@@ -521,25 +537,28 @@ export class MessageComposer {
     });
 
   private subscribeMessageComposerStateChanged = () =>
-    this.state.subscribe((nextValue, previousValue) => {
+    this.state.subscribe((_, previousValue) => {
       if (typeof previousValue === 'undefined') return;
+
       this.logStateUpdateTimestamp();
+
       if (this.compositionIsEmpty) {
         this.deleteDraft();
-        return;
       }
     });
 
   private subscribeMessageComposerConfigStateChanged = () =>
-    this.configState.subscribe((nextValue) => {
-      const { text } = nextValue;
-      if (this.textComposer.text === '' && text.defaultValue) {
-        this.textComposer.insertText({
-          text: text.defaultValue,
-          selection: { start: 0, end: 0 },
-        });
-      }
-    });
+    this.configState.subscribeWithSelector(
+      ({ text }) => [text] as const,
+      ([currentText]) => {
+        if (this.textComposer.text === '' && currentText.defaultValue) {
+          this.textComposer.insertText({
+            text: currentText.defaultValue,
+            selection: { start: 0, end: 0 },
+          });
+        }
+      },
+    );
 
   setQuotedMessage = (quotedMessage: LocalMessage | null) => {
     this.state.partialNext({ quotedMessage });
@@ -560,6 +579,7 @@ export class MessageComposer {
 
   compose = async (): Promise<MessageComposerMiddlewareValue['state'] | undefined> => {
     const created_at = this.editedMessage?.created_at ?? new Date();
+
     const text = '';
     const result = await this.compositionMiddlewareExecutor.execute({
       eventName: 'compose',
@@ -587,6 +607,7 @@ export class MessageComposer {
         sendOptions: {},
       },
     });
+
     if (result.status === 'discard') return;
 
     return result.state;
@@ -600,6 +621,7 @@ export class MessageComposer {
       },
     });
     if (status === 'discard') return;
+
     return state;
   };
 

--- a/src/poll.ts
+++ b/src/poll.ts
@@ -90,7 +90,6 @@ export class Poll {
   public readonly state: StateStore<PollState>;
   public id: string;
   private client: StreamChat;
-  private unsubscribeFunctions: Set<() => void> = new Set();
 
   constructor({ client, poll }: PollInitOptions) {
     this.client = client;

--- a/src/store.ts
+++ b/src/store.ts
@@ -46,25 +46,30 @@ export class StateStore<T extends Record<string, unknown>> {
     handler: Handler<O>,
   ) => {
     // begin with undefined to reduce amount of selector calls
-    let selectedValues: O | undefined;
+    let previouslySelectedValues: O | undefined;
 
     const wrappedHandler: Handler<T> = (nextValue) => {
       const newlySelectedValues = selector(nextValue);
 
-      let hasUpdatedValues = !selectedValues;
+      let hasUpdatedValues = typeof previouslySelectedValues === 'undefined';
 
-      for (const key in selectedValues) {
-        if (selectedValues[key] === newlySelectedValues[key]) continue;
+      for (const key in previouslySelectedValues) {
+        if (previouslySelectedValues[key] === newlySelectedValues[key]) continue;
         hasUpdatedValues = true;
         break;
       }
 
       if (!hasUpdatedValues) return;
 
-      const oldSelectedValues = selectedValues;
-      selectedValues = newlySelectedValues;
+      // save a copy of previouslySelectedValues before running
+      // handler - if previouslySelectedValues are set to 
+      // newlySelectedValues after the handler call, there's a chance
+      // that it'll never get set as handler can throw and flow might
+      // go out of sync
+      const previouslySelectedValuesCopy = previouslySelectedValues;
+      previouslySelectedValues = newlySelectedValues;
 
-      handler(newlySelectedValues, oldSelectedValues);
+      handler(newlySelectedValues, previouslySelectedValuesCopy);
     };
 
     return this.subscribe(wrappedHandler);

--- a/src/store.ts
+++ b/src/store.ts
@@ -62,7 +62,7 @@ export class StateStore<T extends Record<string, unknown>> {
       if (!hasUpdatedValues) return;
 
       // save a copy of previouslySelectedValues before running
-      // handler - if previouslySelectedValues are set to 
+      // handler - if previouslySelectedValues are set to
       // newlySelectedValues after the handler call, there's a chance
       // that it'll never get set as handler can throw and flow might
       // go out of sync

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -19,6 +19,7 @@ import type { Channel } from './channel';
 import type { StreamChat } from './client';
 import type { CustomThreadData } from './custom_types';
 import { MessageComposer } from './messageComposer';
+import { WithSubscriptions } from './utils/WithSubscriptions';
 
 type QueryRepliesOptions = {
   sort?: { created_at: AscDesc }[];
@@ -108,13 +109,12 @@ const constructCustomDataObject = <T extends ThreadResponse>(threadData: T) => {
   return custom;
 };
 
-export class Thread {
+export class Thread extends WithSubscriptions {
   public readonly state: StateStore<ThreadState>;
   public readonly id: string;
   public readonly messageComposer: MessageComposer;
 
   private client: StreamChat;
-  private unsubscribeFunctions: Set<() => void> = new Set();
   private failedRepliesMap: Map<string, LocalMessage> = new Map();
 
   constructor({
@@ -124,6 +124,8 @@ export class Thread {
     client: StreamChat;
     threadData: ThreadResponse;
   }) {
+    super();
+
     const channel = client.channel(threadData.channel.type, threadData.channel.id, {
       // @ts-expect-error name is a "custom" property
       name: threadData.channel.name,
@@ -259,19 +261,19 @@ export class Thread {
   };
 
   public registerSubscriptions = () => {
-    if (this.unsubscribeFunctions.size) {
+    if (this.hasSubscriptions) {
       // Thread is already listening for events and changes
       return;
     }
 
-    this.unsubscribeFunctions.add(this.subscribeThreadUpdated());
-    this.unsubscribeFunctions.add(this.subscribeMarkActiveThreadRead());
-    this.unsubscribeFunctions.add(this.subscribeReloadActiveStaleThread());
-    this.unsubscribeFunctions.add(this.subscribeMarkThreadStale());
-    this.unsubscribeFunctions.add(this.subscribeNewReplies());
-    this.unsubscribeFunctions.add(this.subscribeRepliesRead());
-    this.unsubscribeFunctions.add(this.subscribeMessageDeleted());
-    this.unsubscribeFunctions.add(this.subscribeMessageUpdated());
+    this.addUnsubscribeFunction(this.subscribeThreadUpdated());
+    this.addUnsubscribeFunction(this.subscribeMarkActiveThreadRead());
+    this.addUnsubscribeFunction(this.subscribeReloadActiveStaleThread());
+    this.addUnsubscribeFunction(this.subscribeMarkThreadStale());
+    this.addUnsubscribeFunction(this.subscribeNewReplies());
+    this.addUnsubscribeFunction(this.subscribeRepliesRead());
+    this.addUnsubscribeFunction(this.subscribeMessageDeleted());
+    this.addUnsubscribeFunction(this.subscribeMessageUpdated());
   };
 
   private subscribeThreadUpdated = () =>
@@ -446,8 +448,7 @@ export class Thread {
   };
 
   public unregisterSubscriptions = () => {
-    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
-    this.unsubscribeFunctions.clear();
+    super.unregisterSubscriptions();
     this.state.partialNext({ isStateStale: true });
   };
 

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -448,8 +448,9 @@ export class Thread extends WithSubscriptions {
   };
 
   public unregisterSubscriptions = () => {
-    super.unregisterSubscriptions();
+    const symbol = super.unregisterSubscriptions();
     this.state.partialNext({ isStateStale: true });
+    return symbol;
   };
 
   public deleteReplyLocally = ({ message }: { message: MessageResponse }) => {

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -4,6 +4,7 @@ import { throttle } from './utils';
 import type { StreamChat } from './client';
 import type { Thread } from './thread';
 import type { Event, OwnUserResponse, QueryThreadsOptions } from './types';
+import { WithSubscriptions } from './utils/WithSubscriptions';
 
 const DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION = 1000;
 const MAX_QUERY_THREADS_LIMIT = 25;
@@ -43,10 +44,9 @@ export type ThreadManagerPagination = {
   nextCursor: string | null;
 };
 
-export class ThreadManager {
+export class ThreadManager extends WithSubscriptions {
   public readonly state: StateStore<ThreadManagerState>;
   private client: StreamChat;
-  private unsubscribeFunctions: Set<() => void> = new Set();
   private threadsByIdGetterCache: {
     threads: ThreadManagerState['threads'];
     threadsById: Record<string, Thread | undefined>;
@@ -56,6 +56,8 @@ export class ThreadManager {
   // private threadCache: Record<string, Thread | undefined> = {};
 
   constructor({ client }: { client: StreamChat }) {
+    super();
+
     this.client = client;
     this.state = new StateStore<ThreadManagerState>(THREAD_MANAGER_INITIAL_STATE);
 
@@ -96,14 +98,14 @@ export class ThreadManager {
   };
 
   public registerSubscriptions = () => {
-    if (this.unsubscribeFunctions.size) return;
+    if (this.hasSubscriptions) return;
 
-    this.unsubscribeFunctions.add(this.subscribeUnreadThreadsCountChange());
-    this.unsubscribeFunctions.add(this.subscribeManageThreadSubscriptions());
-    this.unsubscribeFunctions.add(this.subscribeReloadOnActivation());
-    this.unsubscribeFunctions.add(this.subscribeNewReplies());
-    this.unsubscribeFunctions.add(this.subscribeRecoverAfterConnectionDrop());
-    this.unsubscribeFunctions.add(this.subscribeChannelDeleted());
+    this.addUnsubscribeFunction(this.subscribeUnreadThreadsCountChange());
+    this.addUnsubscribeFunction(this.subscribeManageThreadSubscriptions());
+    this.addUnsubscribeFunction(this.subscribeReloadOnActivation());
+    this.addUnsubscribeFunction(this.subscribeNewReplies());
+    this.addUnsubscribeFunction(this.subscribeRecoverAfterConnectionDrop());
+    this.addUnsubscribeFunction(this.subscribeChannelDeleted());
   };
 
   private subscribeUnreadThreadsCountChange = () => {
@@ -217,8 +219,7 @@ export class ThreadManager {
     this.state
       .getLatestValue()
       .threads.forEach((thread) => thread.unregisterSubscriptions());
-    this.unsubscribeFunctions.forEach((cleanupFunction) => cleanupFunction());
-    this.unsubscribeFunctions.clear();
+    super.unregisterSubscriptions();
   };
 
   public reload = async ({ force = false } = {}) => {

--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -219,7 +219,7 @@ export class ThreadManager extends WithSubscriptions {
     this.state
       .getLatestValue()
       .threads.forEach((thread) => thread.unregisterSubscriptions());
-    super.unregisterSubscriptions();
+    return super.unregisterSubscriptions();
   };
 
   public reload = async ({ force = false } = {}) => {

--- a/src/utils/WithSubscriptions.ts
+++ b/src/utils/WithSubscriptions.ts
@@ -1,0 +1,42 @@
+import type { Unsubscribe } from '../store';
+
+/**
+ * @private
+ * Class to use as a template for subscribable entities.
+ */
+export abstract class WithSubscriptions {
+  private unsubscribeFunctions: Set<Unsubscribe> = new Set();
+
+  public abstract registerSubscriptions(): void;
+
+  /**
+   * Returns a boolean, provides information of whether `registerSubscriptions`
+   * method has already been called for this instance.
+   */
+  public get hasSubscriptions() {
+    return this.unsubscribeFunctions.size > 0;
+  }
+
+  public addUnsubscribeFunction(unsubscribeFunction: Unsubscribe) {
+    this.unsubscribeFunctions.add(unsubscribeFunction);
+  }
+
+  /**
+   * If you re-declare `unregisterSubscriptions` method within your class
+   * make sure to run the original too.
+   *
+   * @example 
+   * ```ts
+   * class T {
+   *  public unregisterSubscriptions = () => {
+   *    super.unregisterSubscriptions();
+   *    this.customThing();
+   *  }
+   * }
+   * ```
+   */
+  public unregisterSubscriptions() {
+    this.unsubscribeFunctions.forEach((unsubscribe) => unsubscribe());
+    this.unsubscribeFunctions.clear();
+  }
+}

--- a/src/utils/WithSubscriptions.ts
+++ b/src/utils/WithSubscriptions.ts
@@ -6,6 +6,12 @@ import type { Unsubscribe } from '../store';
  */
 export abstract class WithSubscriptions {
   private unsubscribeFunctions: Set<Unsubscribe> = new Set();
+  /**
+   * Workaround for the missing TS keyword - ensures that inheritants
+   * overriding `unregisterSubscriptions` call the base method and return
+   * its unique symbol value.
+   */
+  private static symbol = Symbol(WithSubscriptions.name);
 
   public abstract registerSubscriptions(): void;
 
@@ -25,18 +31,21 @@ export abstract class WithSubscriptions {
    * If you re-declare `unregisterSubscriptions` method within your class
    * make sure to run the original too.
    *
-   * @example 
+   * @example
    * ```ts
-   * class T {
+   * class T extends WithSubscriptions {
+   *  ...
    *  public unregisterSubscriptions = () => {
-   *    super.unregisterSubscriptions();
    *    this.customThing();
+   *    return super.unregisterSubscriptions();
    *  }
    * }
    * ```
    */
-  public unregisterSubscriptions() {
+  public unregisterSubscriptions(): typeof WithSubscriptions.symbol {
     this.unsubscribeFunctions.forEach((unsubscribe) => unsubscribe());
     this.unsubscribeFunctions.clear();
+
+    return WithSubscriptions.symbol;
   }
 }

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -1055,5 +1055,43 @@ describe('MessageComposer', () => {
         spy.mockRestore();
       });
     });
+
+    it('should toggle the registration of draft WS event subscriptions when drafts are disabled / enabled', () => {
+      const { messageComposer } = setup({
+        config: { drafts: { enabled: false } },
+      });
+
+      const unsubscribeDraftUpdated = vi.fn();
+      const unsubscribeDraftDeleted = vi.fn();
+
+      // @ts-expect-error - we are testing private properties
+      const subscribeDraftUpdatedSpy = vi
+        .spyOn(messageComposer, 'subscribeDraftUpdated')
+        .mockImplementation(() => unsubscribeDraftUpdated);
+      // @ts-expect-error - we are testing private properties
+      const subscribeDraftDeletedSpy = vi
+        .spyOn(messageComposer, 'subscribeDraftDeleted')
+        .mockImplementation(() => unsubscribeDraftDeleted);
+
+      messageComposer.registerSubscriptions();
+
+      expect(subscribeDraftUpdatedSpy).not.toHaveBeenCalled();
+      expect(subscribeDraftDeletedSpy).not.toHaveBeenCalled();
+
+      messageComposer.updateConfig({ drafts: { enabled: true } });
+
+      expect(subscribeDraftUpdatedSpy).toHaveBeenCalledTimes(1);
+      expect(subscribeDraftDeletedSpy).toHaveBeenCalledTimes(1);
+
+      subscribeDraftUpdatedSpy.mockClear();
+      subscribeDraftDeletedSpy.mockClear();
+
+      messageComposer.updateConfig({ drafts: { enabled: false } });
+
+      expect(unsubscribeDraftUpdated).toHaveBeenCalledTimes(1);
+      expect(unsubscribeDraftDeleted).toHaveBeenCalledTimes(1);
+      expect(subscribeDraftUpdatedSpy).not.toHaveBeenCalled();
+      expect(subscribeDraftDeletedSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Introduces private `WithSubscriptions` abstract class as a base for all of our new entities.
