### PR TITLE
feat: middleware handler API improvement

### DIFF
--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -34,7 +34,7 @@ export type AttachmentManagerConfig = {
   maxNumberOfFilesPerMessage: number;
   /**
    * Array of one or more file types, or unique file type specifiers (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/accept#unique_file_type_specifiers),
-   * describing which file types to allow to select when uploading files.
+   * describing which file types are allowed to be selected when uploading files.
    */
   acceptedFiles: string[];
   // todo: refactor this. We want a pipeline where it would be possible to customize the preparation, upload, and post-upload steps.

--- a/src/messageComposer/index.ts
+++ b/src/messageComposer/index.ts
@@ -9,3 +9,4 @@ export * from './middleware';
 export * from './pollComposer';
 export * from './textComposer';
 export * from './types';
+export type { CustomTextComposerSuggestion } from './types.custom';

--- a/src/messageComposer/linkPreviewsManager.ts
+++ b/src/messageComposer/linkPreviewsManager.ts
@@ -18,7 +18,7 @@ export interface ILinkPreviewsManager {
 }
 
 export enum LinkPreviewStatus {
-  /** Link preview has been dismissed using MessageInputContextValue.dismissLinkPreview **/
+  /** Link preview has been dismissed using **/
   DISMISSED = 'dismissed',
   /** Link preview could not be loaded, the enrichment request has failed. **/
   FAILED = 'failed',

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -563,8 +563,9 @@ export class MessageComposer {
   compose = async (): Promise<MessageComposerMiddlewareValue['state'] | undefined> => {
     const created_at = this.editedMessage?.created_at ?? new Date();
     const text = '';
-    const result = await this.compositionMiddlewareExecutor.execute('compose', {
-      state: {
+    const result = await this.compositionMiddlewareExecutor.execute({
+      eventName: 'compose',
+      initialValue: {
         message: {
           id: this.id,
           parent_id: this.threadId ?? undefined,
@@ -594,14 +595,12 @@ export class MessageComposer {
   };
 
   composeDraft = async () => {
-    const { state, status } = await this.draftCompositionMiddlewareExecutor.execute(
-      'compose',
-      {
-        state: {
-          draft: { id: this.id, parent_id: this.threadId ?? undefined, text: '' },
-        },
+    const { state, status } = await this.draftCompositionMiddlewareExecutor.execute({
+      eventName: 'compose',
+      initialValue: {
+        draft: { id: this.id, parent_id: this.threadId ?? undefined, text: '' },
       },
-    );
+    });
     if (status === 'discard') return;
     return state;
   };

--- a/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
@@ -31,7 +31,10 @@ import {
   createDraftCustomDataCompositionMiddleware,
 } from './customData';
 
-export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<MessageComposerMiddlewareValueState> {
+export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<
+  MessageComposerMiddlewareValueState,
+  'compose'
+> {
   constructor({ composer }: MessageComposerMiddlewareExecutorOptions) {
     super();
     // todo: document how to add custom data to a composed message using middleware
@@ -48,7 +51,10 @@ export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<Messag
   }
 }
 
-export class MessageDraftComposerMiddlewareExecutor extends MiddlewareExecutor<MessageDraftComposerMiddlewareValueState> {
+export class MessageDraftComposerMiddlewareExecutor extends MiddlewareExecutor<
+  MessageDraftComposerMiddlewareValueState,
+  'compose'
+> {
   constructor({ composer }: MessageDraftComposerMiddlewareExecutorOptions) {
     super();
     // todo: document how to add custom data to a composed message using middleware

--- a/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
@@ -22,7 +22,7 @@ import {
 import { createCompositionDataCleanupMiddleware } from './cleanData';
 import type {
   MessageComposerMiddlewareExecutorOptions,
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageDraftComposerMiddlewareExecutorOptions,
   MessageDraftComposerMiddlewareValueState,
 } from './types';
@@ -32,7 +32,7 @@ import {
 } from './customData';
 
 export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   'compose'
 > {
   constructor({ composer }: MessageComposerMiddlewareExecutorOptions) {

--- a/src/messageComposer/middleware/messageComposer/attachments.ts
+++ b/src/messageComposer/middleware/messageComposer/attachments.ts
@@ -3,7 +3,7 @@ import type { Attachment } from '../../../types';
 import type { MessageComposer } from '../../messageComposer';
 import type { LocalAttachment } from '../../types';
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -25,7 +25,7 @@ export const createAttachmentsCompositionMiddleware = (
       next,
       discard,
       forward,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const { attachmentManager } = composer;
       if (!attachmentManager) return forward();
 

--- a/src/messageComposer/middleware/messageComposer/cleanData.ts
+++ b/src/messageComposer/middleware/messageComposer/cleanData.ts
@@ -6,8 +6,8 @@ import type { MessageComposerMiddlewareValueState } from './types';
 export const createCompositionDataCleanupMiddleware = (composer: MessageComposer) => ({
   id: 'stream-io/message-composer-middleware/data-cleanup',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
   }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
     const common = {
       type: composer.editedMessage?.type ?? 'regular',
@@ -17,26 +17,23 @@ export const createCompositionDataCleanupMiddleware = (composer: MessageComposer
       ? toUpdatedMessagePayload(composer.editedMessage)
       : undefined;
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        localMessage: formatMessage({
-          ...composer.editedMessage,
-          ...input.state.localMessage,
-          ...common,
-          user: composer.client.user,
-        }),
-        message: {
-          ...editedMessagePayloadToBeSent,
-          ...input.state.message,
-          ...common,
-        },
-        sendOptions:
-          composer.editedMessage && input.state.sendOptions?.skip_enrich_url
-            ? { skip_enrich_url: input.state.sendOptions?.skip_enrich_url }
-            : input.state.sendOptions,
+    return next({
+      ...state,
+      localMessage: formatMessage({
+        ...composer.editedMessage,
+        ...state.localMessage,
+        ...common,
+        user: composer.client.user,
+      }),
+      message: {
+        ...editedMessagePayloadToBeSent,
+        ...state.message,
+        ...common,
       },
+      sendOptions:
+        composer.editedMessage && state.sendOptions?.skip_enrich_url
+          ? { skip_enrich_url: state.sendOptions?.skip_enrich_url }
+          : state.sendOptions,
     });
   },
 });

--- a/src/messageComposer/middleware/messageComposer/cleanData.ts
+++ b/src/messageComposer/middleware/messageComposer/cleanData.ts
@@ -2,7 +2,7 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 import { formatMessage, toUpdatedMessagePayload } from '../../../utils';
 import type { MessageComposer } from '../../messageComposer';
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
 } from './types';
 
@@ -14,7 +14,7 @@ export const createCompositionDataCleanupMiddleware = (
     compose: ({
       state,
       next,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const common = {
         type: composer.editedMessage?.type ?? 'regular',
       };

--- a/src/messageComposer/middleware/messageComposer/cleanData.ts
+++ b/src/messageComposer/middleware/messageComposer/cleanData.ts
@@ -1,39 +1,46 @@
 import type { MiddlewareHandlerParams } from '../../../middleware';
 import { formatMessage, toUpdatedMessagePayload } from '../../../utils';
 import type { MessageComposer } from '../../messageComposer';
-import type { MessageComposerMiddlewareValueState } from './types';
+import type {
+  MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
+} from './types';
 
-export const createCompositionDataCleanupMiddleware = (composer: MessageComposer) => ({
+export const createCompositionDataCleanupMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/data-cleanup',
-  compose: ({
-    state,
-    next,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    const common = {
-      type: composer.editedMessage?.type ?? 'regular',
-    };
+  handlers: {
+    compose: ({
+      state,
+      next,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      const common = {
+        type: composer.editedMessage?.type ?? 'regular',
+      };
 
-    const editedMessagePayloadToBeSent = composer.editedMessage
-      ? toUpdatedMessagePayload(composer.editedMessage)
-      : undefined;
+      const editedMessagePayloadToBeSent = composer.editedMessage
+        ? toUpdatedMessagePayload(composer.editedMessage)
+        : undefined;
 
-    return next({
-      ...state,
-      localMessage: formatMessage({
-        ...composer.editedMessage,
-        ...state.localMessage,
-        ...common,
-        user: composer.client.user,
-      }),
-      message: {
-        ...editedMessagePayloadToBeSent,
-        ...state.message,
-        ...common,
-      },
-      sendOptions:
-        composer.editedMessage && state.sendOptions?.skip_enrich_url
-          ? { skip_enrich_url: state.sendOptions?.skip_enrich_url }
-          : state.sendOptions,
-    });
+      return next({
+        ...state,
+        localMessage: formatMessage({
+          ...composer.editedMessage,
+          ...state.localMessage,
+          ...common,
+          user: composer.client.user,
+        }),
+        message: {
+          ...editedMessagePayloadToBeSent,
+          ...state.message,
+          ...common,
+        },
+        sendOptions:
+          composer.editedMessage && state.sendOptions?.skip_enrich_url
+            ? { skip_enrich_url: state.sendOptions?.skip_enrich_url }
+            : state.sendOptions,
+      });
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -1,57 +1,65 @@
 import { textIsEmpty } from '../../textComposer';
 import type {
   MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
+  MessageDraftCompositionMiddleware,
 } from './types';
 import type { MessageComposer } from '../../messageComposer';
 import type { MiddlewareHandlerParams } from '../../../middleware';
 
-export const createCompositionValidationMiddleware = (composer: MessageComposer) => ({
+export const createCompositionValidationMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/data-validation',
-  compose: async ({
-    state,
-    discard,
-    forward,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    const { maxLengthOnSend } = composer.config.text ?? {};
-    const inputText = state.message.text ?? '';
-    const isEmptyMessage =
-      textIsEmpty(inputText) &&
-      !state.message.attachments?.length &&
-      !state.message.poll_id;
+  handlers: {
+    compose: async ({
+      state,
+      discard,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      const { maxLengthOnSend } = composer.config.text ?? {};
+      const inputText = state.message.text ?? '';
+      const isEmptyMessage =
+        textIsEmpty(inputText) &&
+        !state.message.attachments?.length &&
+        !state.message.poll_id;
 
-    const hasExceededMaxLength =
-      typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend;
+      const hasExceededMaxLength =
+        typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend;
 
-    if (isEmptyMessage || !composer.lastChangeOriginIsLocal || hasExceededMaxLength) {
-      return await discard();
-    }
+      if (isEmptyMessage || !composer.lastChangeOriginIsLocal || hasExceededMaxLength) {
+        return await discard();
+      }
 
-    return await forward();
+      return await forward();
+    },
   },
 });
 
 export const createDraftCompositionValidationMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageDraftCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/draft-data-validation',
-  compose: async ({
-    state,
-    discard,
-    forward,
-  }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    const hasData =
-      !textIsEmpty(state.draft.text ?? '') ||
-      state.draft.attachments?.length ||
-      state.draft.poll_id ||
-      state.draft.quoted_message_id;
+  handlers: {
+    compose: async ({
+      state,
+      discard,
+      forward,
+    }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
+      const hasData =
+        !textIsEmpty(state.draft.text ?? '') ||
+        state.draft.attachments?.length ||
+        state.draft.poll_id ||
+        state.draft.quoted_message_id;
 
-    const shouldCreateDraft = composer.lastChangeOriginIsLocal && hasData;
+      const shouldCreateDraft = composer.lastChangeOriginIsLocal && hasData;
 
-    if (!shouldCreateDraft) {
-      return await discard();
-    }
+      if (!shouldCreateDraft) {
+        return await discard();
+      }
 
-    return await forward();
+      return await forward();
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -1,6 +1,6 @@
 import { textIsEmpty } from '../../textComposer';
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -17,7 +17,7 @@ export const createCompositionValidationMiddleware = (
       state,
       discard,
       forward,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const { maxLengthOnSend } = composer.config.text ?? {};
       const inputText = state.message.text ?? '';
       const isEmptyMessage =

--- a/src/messageComposer/middleware/messageComposer/customData.ts
+++ b/src/messageComposer/middleware/messageComposer/customData.ts
@@ -1,7 +1,7 @@
 import type { MiddlewareHandlerParams } from '../../../middleware';
 import type { MessageComposer } from '../../messageComposer';
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -16,7 +16,7 @@ export const createCustomDataCompositionMiddleware = (
       state,
       next,
       forward,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const data = composer.customDataManager.customMessageData;
       if (!data) return forward();
 

--- a/src/messageComposer/middleware/messageComposer/customData.ts
+++ b/src/messageComposer/middleware/messageComposer/customData.ts
@@ -2,51 +2,59 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 import type { MessageComposer } from '../../messageComposer';
 import type {
   MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
+  MessageDraftCompositionMiddleware,
 } from './types';
 
-export const createCustomDataCompositionMiddleware = (composer: MessageComposer) => ({
+export const createCustomDataCompositionMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/custom-data',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    const data = composer.customDataManager.customMessageData;
-    if (!data) return forward();
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      const data = composer.customDataManager.customMessageData;
+      if (!data) return forward();
 
-    return next({
-      ...state,
-      localMessage: {
-        ...state.localMessage,
-        ...data,
-      },
-      message: {
-        ...state.message,
-        ...data,
-      },
-    });
+      return next({
+        ...state,
+        localMessage: {
+          ...state.localMessage,
+          ...data,
+        },
+        message: {
+          ...state.message,
+          ...data,
+        },
+      });
+    },
   },
 });
 
 export const createDraftCustomDataCompositionMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageDraftCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/draft-custom-data',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    const data = composer.customDataManager.customMessageData;
-    if (!data) return forward();
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
+      const data = composer.customDataManager.customMessageData;
+      if (!data) return forward();
 
-    return next({
-      ...state,
-      draft: {
-        ...state.draft,
-        ...data,
-      },
-    });
+      return next({
+        ...state,
+        draft: {
+          ...state.draft,
+          ...data,
+        },
+      });
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/customData.ts
+++ b/src/messageComposer/middleware/messageComposer/customData.ts
@@ -8,24 +8,22 @@ import type {
 export const createCustomDataCompositionMiddleware = (composer: MessageComposer) => ({
   id: 'stream-io/message-composer-middleware/custom-data',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
+    forward,
   }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
     const data = composer.customDataManager.customMessageData;
-    if (!data) return nextHandler(input);
+    if (!data) return forward();
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        localMessage: {
-          ...input.state.localMessage,
-          ...data,
-        },
-        message: {
-          ...input.state.message,
-          ...data,
-        },
+    return next({
+      ...state,
+      localMessage: {
+        ...state.localMessage,
+        ...data,
+      },
+      message: {
+        ...state.message,
+        ...data,
       },
     });
   },
@@ -36,20 +34,18 @@ export const createDraftCustomDataCompositionMiddleware = (
 ) => ({
   id: 'stream-io/message-composer-middleware/draft-custom-data',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
+    forward,
   }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
     const data = composer.customDataManager.customMessageData;
-    if (!data) return nextHandler(input);
+    if (!data) return forward();
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        draft: {
-          ...input.state.draft,
-          ...data,
-        },
+    return next({
+      ...state,
+      draft: {
+        ...state.draft,
+        ...data,
       },
     });
   },

--- a/src/messageComposer/middleware/messageComposer/linkPreviews.ts
+++ b/src/messageComposer/middleware/messageComposer/linkPreviews.ts
@@ -4,83 +4,92 @@ import type { Attachment } from '../../../types';
 import type { MessageComposer } from '../../messageComposer';
 import type {
   MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
+  MessageDraftCompositionMiddleware,
 } from './types';
 
-export const createLinkPreviewsCompositionMiddleware = (composer: MessageComposer) => ({
+export const createLinkPreviewsCompositionMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/link-previews',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    const { linkPreviewsManager } = composer;
-    if (!linkPreviewsManager) return forward();
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      const { linkPreviewsManager } = composer;
+      if (!linkPreviewsManager) return forward();
 
-    linkPreviewsManager.cancelURLEnrichment();
-    const someLinkPreviewsLoading = linkPreviewsManager.loadingPreviews.length > 0;
-    const someLinkPreviewsDismissed = linkPreviewsManager.dismissedPreviews.length > 0;
-    const linkPreviews =
-      linkPreviewsManager.loadingPreviews.length > 0
-        ? []
-        : linkPreviewsManager.loadedPreviews.map((preview) =>
-            LinkPreviewsManager.getPreviewData(preview),
-          );
+      linkPreviewsManager.cancelURLEnrichment();
+      const someLinkPreviewsLoading = linkPreviewsManager.loadingPreviews.length > 0;
+      const someLinkPreviewsDismissed = linkPreviewsManager.dismissedPreviews.length > 0;
+      const linkPreviews =
+        linkPreviewsManager.loadingPreviews.length > 0
+          ? []
+          : linkPreviewsManager.loadedPreviews.map((preview) =>
+              LinkPreviewsManager.getPreviewData(preview),
+            );
 
-    const attachments: Attachment[] = (state.message.attachments ?? []).concat(
-      linkPreviews,
-    );
+      const attachments: Attachment[] = (state.message.attachments ?? []).concat(
+        linkPreviews,
+      );
 
-    // prevent introducing attachments array into the payload sent to the server
-    if (!attachments.length) return forward();
+      // prevent introducing attachments array into the payload sent to the server
+      if (!attachments.length) return forward();
 
-    const sendOptions = { ...state.sendOptions };
-    const skip_enrich_url =
-      (!someLinkPreviewsLoading && linkPreviews.length > 0) || someLinkPreviewsDismissed;
-    if (skip_enrich_url) {
-      sendOptions.skip_enrich_url = true;
-    }
+      const sendOptions = { ...state.sendOptions };
+      const skip_enrich_url =
+        (!someLinkPreviewsLoading && linkPreviews.length > 0) ||
+        someLinkPreviewsDismissed;
+      if (skip_enrich_url) {
+        sendOptions.skip_enrich_url = true;
+      }
 
-    return next({
-      ...state,
-      message: {
-        ...state.message,
-        attachments,
-      },
-      localMessage: {
-        ...state.localMessage,
-        attachments,
-      },
-      sendOptions,
-    });
+      return next({
+        ...state,
+        message: {
+          ...state.message,
+          attachments,
+        },
+        localMessage: {
+          ...state.localMessage,
+          attachments,
+        },
+        sendOptions,
+      });
+    },
   },
 });
 
 export const createDraftLinkPreviewsCompositionMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageDraftCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/draft-link-previews',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    const { linkPreviewsManager } = composer;
-    if (!linkPreviewsManager) return forward();
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
+      const { linkPreviewsManager } = composer;
+      if (!linkPreviewsManager) return forward();
 
-    linkPreviewsManager.cancelURLEnrichment();
-    const linkPreviews = linkPreviewsManager.loadedPreviews.map((preview) =>
-      LinkPreviewsManager.getPreviewData(preview),
-    );
+      linkPreviewsManager.cancelURLEnrichment();
+      const linkPreviews = linkPreviewsManager.loadedPreviews.map((preview) =>
+        LinkPreviewsManager.getPreviewData(preview),
+      );
 
-    if (!linkPreviews.length) return forward();
+      if (!linkPreviews.length) return forward();
 
-    return next({
-      ...state,
-      draft: {
-        ...state.draft,
-        attachments: (state.draft.attachments ?? []).concat(linkPreviews),
-      },
-    });
+      return next({
+        ...state,
+        draft: {
+          ...state.draft,
+          attachments: (state.draft.attachments ?? []).concat(linkPreviews),
+        },
+      });
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/linkPreviews.ts
+++ b/src/messageComposer/middleware/messageComposer/linkPreviews.ts
@@ -3,7 +3,7 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 import type { Attachment } from '../../../types';
 import type { MessageComposer } from '../../messageComposer';
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -18,7 +18,7 @@ export const createLinkPreviewsCompositionMiddleware = (
       state,
       next,
       forward,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const { linkPreviewsManager } = composer;
       if (!linkPreviewsManager) return forward();
 

--- a/src/messageComposer/middleware/messageComposer/messageComposerState.ts
+++ b/src/messageComposer/middleware/messageComposer/messageComposerState.ts
@@ -1,5 +1,5 @@
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -16,7 +16,7 @@ export const createMessageComposerStateCompositionMiddleware = (
     compose: ({
       state,
       next,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
       if (composer.quotedMessage) {
         payload.quoted_message_id = composer.quotedMessage.id;

--- a/src/messageComposer/middleware/messageComposer/messageComposerState.ts
+++ b/src/messageComposer/middleware/messageComposer/messageComposerState.ts
@@ -1,6 +1,8 @@
 import type {
   MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
+  MessageDraftCompositionMiddleware,
 } from './types';
 import type { MessageComposer } from '../../messageComposer';
 import type { LocalMessage, LocalMessageBase } from '../../../types';
@@ -8,57 +10,61 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 
 export const createMessageComposerStateCompositionMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/own-state',
-  compose: ({
-    state,
-    next,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
-    if (composer.quotedMessage) {
-      payload.quoted_message_id = composer.quotedMessage.id;
-    }
-    if (composer.pollId) {
-      payload.poll_id = composer.pollId;
-    }
+  handlers: {
+    compose: ({
+      state,
+      next,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
+      if (composer.quotedMessage) {
+        payload.quoted_message_id = composer.quotedMessage.id;
+      }
+      if (composer.pollId) {
+        payload.poll_id = composer.pollId;
+      }
 
-    return next({
-      ...state,
-      localMessage: {
-        ...state.localMessage,
-        ...payload,
-        quoted_message: (composer.quotedMessage as LocalMessageBase) ?? undefined,
-      },
-      message: {
-        ...state.message,
-        ...payload,
-      },
-    });
+      return next({
+        ...state,
+        localMessage: {
+          ...state.localMessage,
+          ...payload,
+          quoted_message: (composer.quotedMessage as LocalMessageBase) ?? undefined,
+        },
+        message: {
+          ...state.message,
+          ...payload,
+        },
+      });
+    },
   },
 });
 
 export const createDraftMessageComposerStateCompositionMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageDraftCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/draft-own-state',
-  compose: ({
-    state,
-    next,
-  }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
-    if (composer.quotedMessage) {
-      payload.quoted_message_id = composer.quotedMessage.id;
-    }
-    if (composer.pollId) {
-      payload.poll_id = composer.pollId;
-    }
+  handlers: {
+    compose: ({
+      state,
+      next,
+    }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
+      const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
+      if (composer.quotedMessage) {
+        payload.quoted_message_id = composer.quotedMessage.id;
+      }
+      if (composer.pollId) {
+        payload.poll_id = composer.pollId;
+      }
 
-    return next({
-      ...state,
-      draft: {
-        ...state.draft,
-        ...payload,
-      },
-    });
+      return next({
+        ...state,
+        draft: {
+          ...state.draft,
+          ...payload,
+        },
+      });
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/messageComposerState.ts
+++ b/src/messageComposer/middleware/messageComposer/messageComposerState.ts
@@ -11,8 +11,8 @@ export const createMessageComposerStateCompositionMiddleware = (
 ) => ({
   id: 'stream-io/message-composer-middleware/own-state',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
   }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
     const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
     if (composer.quotedMessage) {
@@ -22,19 +22,16 @@ export const createMessageComposerStateCompositionMiddleware = (
       payload.poll_id = composer.pollId;
     }
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        localMessage: {
-          ...input.state.localMessage,
-          ...payload,
-          quoted_message: (composer.quotedMessage as LocalMessageBase) ?? undefined,
-        },
-        message: {
-          ...input.state.message,
-          ...payload,
-        },
+    return next({
+      ...state,
+      localMessage: {
+        ...state.localMessage,
+        ...payload,
+        quoted_message: (composer.quotedMessage as LocalMessageBase) ?? undefined,
+      },
+      message: {
+        ...state.message,
+        ...payload,
       },
     });
   },
@@ -45,8 +42,8 @@ export const createDraftMessageComposerStateCompositionMiddleware = (
 ) => ({
   id: 'stream-io/message-composer-middleware/draft-own-state',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
   }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
     const payload: Pick<LocalMessage, 'poll_id' | 'quoted_message_id'> = {};
     if (composer.quotedMessage) {
@@ -56,14 +53,11 @@ export const createDraftMessageComposerStateCompositionMiddleware = (
       payload.poll_id = composer.pollId;
     }
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        draft: {
-          ...input.state.draft,
-          ...payload,
-        },
+    return next({
+      ...state,
+      draft: {
+        ...state.draft,
+        ...payload,
       },
     });
   },

--- a/src/messageComposer/middleware/messageComposer/textComposer.ts
+++ b/src/messageComposer/middleware/messageComposer/textComposer.ts
@@ -8,10 +8,11 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 export const createTextComposerCompositionMiddleware = (composer: MessageComposer) => ({
   id: 'stream-io/message-composer-middleware/text-composition',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
+    forward,
   }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    if (!composer.textComposer) return nextHandler(input);
+    if (!composer.textComposer) return forward();
     const { mentionedUsers, text } = composer.textComposer;
     // Instead of checking if a user is still mentioned every time the text changes,
     // just filter out non-mentioned users before submit, which is cheaper
@@ -25,22 +26,19 @@ export const createTextComposerCompositionMiddleware = (composer: MessageCompose
     );
 
     // prevent introducing text and mentioned_users array into the payload sent to the server
-    if (!text && mentioned_users.length === 0) return nextHandler(input);
+    if (!text && mentioned_users.length === 0) return forward();
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        localMessage: {
-          ...input.state.localMessage,
-          mentioned_users,
-          text,
-        },
-        message: {
-          ...input.state.message,
-          mentioned_users: mentioned_users.map((u) => u.id),
-          text,
-        },
+    return next({
+      ...state,
+      localMessage: {
+        ...state.localMessage,
+        mentioned_users,
+        text,
+      },
+      message: {
+        ...state.message,
+        mentioned_users: mentioned_users.map((u) => u.id),
+        text,
       },
     });
   },
@@ -51,10 +49,11 @@ export const createDraftTextComposerCompositionMiddleware = (
 ) => ({
   id: 'stream-io/message-composer-middleware/draft-text-composition',
   compose: ({
-    input,
-    nextHandler,
+    state,
+    next,
+    forward,
   }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    if (!composer.textComposer) return nextHandler(input);
+    if (!composer.textComposer) return forward();
     const { maxLengthOnSend } = composer.config.text ?? {};
     const { mentionedUsers, text: inputText } = composer.textComposer;
     // Instead of checking if a user is still mentioned every time the text changes,
@@ -76,15 +75,12 @@ export const createDraftTextComposerCompositionMiddleware = (
         ? inputText.slice(0, maxLengthOnSend)
         : inputText;
 
-    return nextHandler({
-      ...input,
-      state: {
-        ...input.state,
-        draft: {
-          ...input.state.draft,
-          mentioned_users: mentioned_users?.map((u) => u.id),
-          text,
-        },
+    return next({
+      ...state,
+      draft: {
+        ...state.draft,
+        mentioned_users: mentioned_users?.map((u) => u.id),
+        text,
       },
     });
   },

--- a/src/messageComposer/middleware/messageComposer/textComposer.ts
+++ b/src/messageComposer/middleware/messageComposer/textComposer.ts
@@ -1,87 +1,95 @@
 import type {
   MessageComposerMiddlewareValueState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
+  MessageDraftCompositionMiddleware,
 } from './types';
 import type { MessageComposer } from '../../messageComposer';
 import type { MiddlewareHandlerParams } from '../../../middleware';
 
-export const createTextComposerCompositionMiddleware = (composer: MessageComposer) => ({
+export const createTextComposerCompositionMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/text-composition',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
-    if (!composer.textComposer) return forward();
-    const { mentionedUsers, text } = composer.textComposer;
-    // Instead of checking if a user is still mentioned every time the text changes,
-    // just filter out non-mentioned users before submit, which is cheaper
-    // and allows users to easily undo any accidental deletion
-    const mentioned_users = Array.from(
-      new Set(
-        mentionedUsers.filter(
-          ({ id, name }) => text.includes(`@${id}`) || text.includes(`@${name}`),
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+      if (!composer.textComposer) return forward();
+      const { mentionedUsers, text } = composer.textComposer;
+      // Instead of checking if a user is still mentioned every time the text changes,
+      // just filter out non-mentioned users before submit, which is cheaper
+      // and allows users to easily undo any accidental deletion
+      const mentioned_users = Array.from(
+        new Set(
+          mentionedUsers.filter(
+            ({ id, name }) => text.includes(`@${id}`) || text.includes(`@${name}`),
+          ),
         ),
-      ),
-    );
+      );
 
-    // prevent introducing text and mentioned_users array into the payload sent to the server
-    if (!text && mentioned_users.length === 0) return forward();
+      // prevent introducing text and mentioned_users array into the payload sent to the server
+      if (!text && mentioned_users.length === 0) return forward();
 
-    return next({
-      ...state,
-      localMessage: {
-        ...state.localMessage,
-        mentioned_users,
-        text,
-      },
-      message: {
-        ...state.message,
-        mentioned_users: mentioned_users.map((u) => u.id),
-        text,
-      },
-    });
+      return next({
+        ...state,
+        localMessage: {
+          ...state.localMessage,
+          mentioned_users,
+          text,
+        },
+        message: {
+          ...state.message,
+          mentioned_users: mentioned_users.map((u) => u.id),
+          text,
+        },
+      });
+    },
   },
 });
 
 export const createDraftTextComposerCompositionMiddleware = (
   composer: MessageComposer,
-) => ({
+): MessageDraftCompositionMiddleware => ({
   id: 'stream-io/message-composer-middleware/draft-text-composition',
-  compose: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
-    if (!composer.textComposer) return forward();
-    const { maxLengthOnSend } = composer.config.text ?? {};
-    const { mentionedUsers, text: inputText } = composer.textComposer;
-    // Instead of checking if a user is still mentioned every time the text changes,
-    // just filter out non-mentioned users before submit, which is cheaper
-    // and allows users to easily undo any accidental deletion
-    const mentioned_users = mentionedUsers.length
-      ? Array.from(
-          new Set(
-            mentionedUsers.filter(
-              ({ id, name }) =>
-                inputText.includes(`@${id}`) || inputText.includes(`@${name}`),
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageDraftComposerMiddlewareValueState>) => {
+      if (!composer.textComposer) return forward();
+      const { maxLengthOnSend } = composer.config.text ?? {};
+      const { mentionedUsers, text: inputText } = composer.textComposer;
+      // Instead of checking if a user is still mentioned every time the text changes,
+      // just filter out non-mentioned users before submit, which is cheaper
+      // and allows users to easily undo any accidental deletion
+      const mentioned_users = mentionedUsers.length
+        ? Array.from(
+            new Set(
+              mentionedUsers.filter(
+                ({ id, name }) =>
+                  inputText.includes(`@${id}`) || inputText.includes(`@${name}`),
+              ),
             ),
-          ),
-        )
-      : undefined;
+          )
+        : undefined;
 
-    const text =
-      typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend
-        ? inputText.slice(0, maxLengthOnSend)
-        : inputText;
+      const text =
+        typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend
+          ? inputText.slice(0, maxLengthOnSend)
+          : inputText;
 
-    return next({
-      ...state,
-      draft: {
-        ...state.draft,
-        mentioned_users: mentioned_users?.map((u) => u.id),
-        text,
-      },
-    });
+      return next({
+        ...state,
+        draft: {
+          ...state.draft,
+          mentioned_users: mentioned_users?.map((u) => u.id),
+          text,
+        },
+      });
+    },
   },
 });

--- a/src/messageComposer/middleware/messageComposer/textComposer.ts
+++ b/src/messageComposer/middleware/messageComposer/textComposer.ts
@@ -1,5 +1,5 @@
 import type {
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
@@ -16,7 +16,7 @@ export const createTextComposerCompositionMiddleware = (
       state,
       next,
       forward,
-    }: MiddlewareHandlerParams<MessageComposerMiddlewareValueState>) => {
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
       if (!composer.textComposer) return forward();
       const { mentionedUsers, text } = composer.textComposer;
       // Instead of checking if a user is still mentioned every time the text changes,

--- a/src/messageComposer/middleware/messageComposer/types.ts
+++ b/src/messageComposer/middleware/messageComposer/types.ts
@@ -8,14 +8,14 @@ import type {
 } from '../../../types';
 import type { MessageComposer } from '../../messageComposer';
 
-export type MessageComposerMiddlewareValueState = {
+export type MessageComposerMiddlewareState = {
   message: Message | UpdatedMessage;
   localMessage: LocalMessage;
   sendOptions: SendMessageOptions;
 };
 
 export type MessageComposerMiddlewareValue =
-  MiddlewareExecutionResult<MessageComposerMiddlewareValueState>;
+  MiddlewareExecutionResult<MessageComposerMiddlewareState>;
 
 export type MessageComposerMiddlewareExecutorOptions = {
   composer: MessageComposer;
@@ -30,7 +30,7 @@ export type MessageDraftComposerMiddlewareExecutorOptions = {
 };
 
 export type MessageCompositionMiddleware = Middleware<
-  MessageComposerMiddlewareValueState,
+  MessageComposerMiddlewareState,
   'compose'
 >;
 

--- a/src/messageComposer/middleware/messageComposer/types.ts
+++ b/src/messageComposer/middleware/messageComposer/types.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareExecutionResult } from '../../../middleware';
+import type { Middleware, MiddlewareExecutionResult } from '../../../middleware';
 import type {
   DraftMessagePayload,
   LocalMessage,
@@ -28,3 +28,13 @@ export type MessageDraftComposerMiddlewareValueState = {
 export type MessageDraftComposerMiddlewareExecutorOptions = {
   composer: MessageComposer;
 };
+
+export type MessageCompositionMiddleware = Middleware<
+  MessageComposerMiddlewareValueState,
+  'compose'
+>;
+
+export type MessageDraftCompositionMiddleware = Middleware<
+  MessageDraftComposerMiddlewareValueState,
+  'compose'
+>;

--- a/src/messageComposer/middleware/messageComposer/types.ts
+++ b/src/messageComposer/middleware/messageComposer/types.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareValue } from '../../../middleware';
+import type { MiddlewareExecutionResult } from '../../../middleware';
 import type {
   DraftMessagePayload,
   LocalMessage,
@@ -15,7 +15,7 @@ export type MessageComposerMiddlewareValueState = {
 };
 
 export type MessageComposerMiddlewareValue =
-  MiddlewareValue<MessageComposerMiddlewareValueState>;
+  MiddlewareExecutionResult<MessageComposerMiddlewareValueState>;
 
 export type MessageComposerMiddlewareExecutorOptions = {
   composer: MessageComposer;

--- a/src/messageComposer/middleware/pollComposer/PollComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/pollComposer/PollComposerMiddlewareExecutor.ts
@@ -11,14 +11,20 @@ export type PollComposerMiddlewareExecutorOptions = {
   composer: MessageComposer;
 };
 
-export class PollComposerCompositionMiddlewareExecutor extends MiddlewareExecutor<PollComposerCompositionMiddlewareValueState> {
+export class PollComposerCompositionMiddlewareExecutor extends MiddlewareExecutor<
+  PollComposerCompositionMiddlewareValueState,
+  'compose'
+> {
   constructor({ composer }: PollComposerMiddlewareExecutorOptions) {
     super();
     this.use([createPollCompositionValidationMiddleware(composer)]);
   }
 }
 
-export class PollComposerStateMiddlewareExecutor extends MiddlewareExecutor<PollComposerStateChangeMiddlewareValue> {
+export class PollComposerStateMiddlewareExecutor extends MiddlewareExecutor<
+  PollComposerStateChangeMiddlewareValue,
+  'handleFieldChange' | 'handleFieldBlur'
+> {
   constructor() {
     super();
     this.use([createPollComposerStateMiddleware()]);

--- a/src/messageComposer/middleware/pollComposer/PollComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/pollComposer/PollComposerMiddlewareExecutor.ts
@@ -3,7 +3,7 @@ import { createPollComposerStateMiddleware } from './state';
 import { createPollCompositionValidationMiddleware } from './composition';
 import type {
   PollComposerCompositionMiddlewareValueState,
-  PollComposerStateMiddlewareValueState,
+  PollComposerStateChangeMiddlewareValue,
 } from './types';
 import type { MessageComposer } from '../../messageComposer';
 
@@ -18,7 +18,7 @@ export class PollComposerCompositionMiddlewareExecutor extends MiddlewareExecuto
   }
 }
 
-export class PollComposerStateMiddlewareExecutor extends MiddlewareExecutor<PollComposerStateMiddlewareValueState> {
+export class PollComposerStateMiddlewareExecutor extends MiddlewareExecutor<PollComposerStateChangeMiddlewareValue> {
   constructor() {
     super();
     this.use([createPollComposerStateMiddleware()]);

--- a/src/messageComposer/middleware/pollComposer/composition.ts
+++ b/src/messageComposer/middleware/pollComposer/composition.ts
@@ -1,17 +1,21 @@
-import type { PollComposerCompositionMiddlewareValueState } from './types';
+import type { MiddlewareHandler, MiddlewareHandlerParams } from '../../../middleware';
 import type { MessageComposer } from '../../messageComposer';
-import type { Middleware } from '../../../middleware';
-import type { MiddlewareHandlerParams } from '../../../middleware';
+import type { PollComposerCompositionMiddlewareValueState } from './types';
+
+export type PollCompositionValidationMiddleware = {
+  id: string;
+  compose: MiddlewareHandler<PollComposerCompositionMiddlewareValueState>;
+};
 
 export const createPollCompositionValidationMiddleware = (
   composer: MessageComposer,
-): Middleware<PollComposerCompositionMiddlewareValueState> => ({
+): PollCompositionValidationMiddleware => ({
   id: 'stream-io/poll-composer-composition',
   compose: ({
-    input,
-    nextHandler,
+    discard,
+    forward,
   }: MiddlewareHandlerParams<PollComposerCompositionMiddlewareValueState>) => {
-    if (composer.pollComposer.canCreatePoll) return nextHandler(input);
-    return nextHandler({ ...input, status: 'discard' });
+    if (composer.pollComposer.canCreatePoll) return forward();
+    return discard();
   },
 });

--- a/src/messageComposer/middleware/pollComposer/composition.ts
+++ b/src/messageComposer/middleware/pollComposer/composition.ts
@@ -1,21 +1,23 @@
-import type { MiddlewareHandler, MiddlewareHandlerParams } from '../../../middleware';
+import type { Middleware, MiddlewareHandlerParams } from '../../../middleware';
 import type { MessageComposer } from '../../messageComposer';
 import type { PollComposerCompositionMiddlewareValueState } from './types';
 
-export type PollCompositionValidationMiddleware = {
-  id: string;
-  compose: MiddlewareHandler<PollComposerCompositionMiddlewareValueState>;
-};
+export type PollCompositionValidationMiddleware = Middleware<
+  PollComposerCompositionMiddlewareValueState,
+  'compose'
+>;
 
 export const createPollCompositionValidationMiddleware = (
   composer: MessageComposer,
 ): PollCompositionValidationMiddleware => ({
   id: 'stream-io/poll-composer-composition',
-  compose: ({
-    discard,
-    forward,
-  }: MiddlewareHandlerParams<PollComposerCompositionMiddlewareValueState>) => {
-    if (composer.pollComposer.canCreatePoll) return forward();
-    return discard();
+  handlers: {
+    compose: ({
+      discard,
+      forward,
+    }: MiddlewareHandlerParams<PollComposerCompositionMiddlewareValueState>) => {
+      if (composer.pollComposer.canCreatePoll) return forward();
+      return discard();
+    },
   },
 });

--- a/src/messageComposer/middleware/pollComposer/types.ts
+++ b/src/messageComposer/middleware/pollComposer/types.ts
@@ -1,4 +1,4 @@
-import type { MiddlewareValue } from '../../../middleware';
+import type { MiddlewareExecutionResult } from '../../../middleware';
 import type { CreatePollData, VotingVisibility } from '../../../types';
 
 export type PollComposerOption = {
@@ -50,9 +50,9 @@ export type PollComposerCompositionMiddlewareValueState = {
 };
 
 export type PollComposerCompositionMiddlewareValue =
-  MiddlewareValue<PollComposerCompositionMiddlewareValueState>;
+  MiddlewareExecutionResult<PollComposerCompositionMiddlewareValueState>;
 
-export type PollComposerStateMiddlewareValueState = {
+export type PollComposerStateChangeMiddlewareValue = {
   nextState: PollComposerState;
   previousState: PollComposerState;
   targetFields: Partial<{
@@ -63,4 +63,4 @@ export type PollComposerStateMiddlewareValueState = {
 };
 
 export type PollComposerStateMiddlewareValue =
-  MiddlewareValue<PollComposerStateMiddlewareValueState>;
+  MiddlewareExecutionResult<PollComposerStateChangeMiddlewareValue>;

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -101,7 +101,7 @@ export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
     this.client = channel.getClient();
     this.channel = channel;
     this.config = { mentionAllAppUsers, textComposerText };
-    // todo: how to propagate useMentionsTransliteration to change dynamically the setting? const { default: transliterate } = await import('@stream-io/transliterate');
+
     if (transliterate) {
       this.transliterate = transliterate;
     }

--- a/src/messageComposer/middleware/textComposer/textMiddlewareUtils.ts
+++ b/src/messageComposer/middleware/textComposer/textMiddlewareUtils.ts
@@ -1,4 +1,4 @@
-import type { TextSelection } from '../../types';
+import type { TextSelection } from './types';
 
 export const getTriggerCharWithToken = ({
   trigger,

--- a/src/messageComposer/middleware/textComposer/types.ts
+++ b/src/messageComposer/middleware/textComposer/types.ts
@@ -2,7 +2,7 @@ import type { MessageComposer } from '../../messageComposer';
 import type { CommandResponse, UserResponse } from '../../../types';
 import type { TokenizationPayload } from './textMiddlewareUtils';
 import type { SearchSource } from '../../../search_controller';
-import type { CustomSuggestion } from '../../types.custom';
+import type { CustomTextComposerSuggestion } from '../../types.custom';
 
 export type TextComposerSuggestion<T = unknown> = T & {
   id: string;
@@ -14,7 +14,7 @@ export type BaseSuggestion = {
 
 export type CommandSuggestion = BaseSuggestion & CommandResponse;
 export type UserSuggestion = BaseSuggestion & UserResponse & TokenizationPayload;
-export type CustomValidSuggestion = BaseSuggestion & CustomSuggestion;
+export type CustomValidSuggestion = BaseSuggestion & CustomTextComposerSuggestion;
 export type Suggestion = CommandSuggestion | UserSuggestion | CustomValidSuggestion;
 
 export type TextComposerMetadataByMiddlewareHandler<

--- a/src/messageComposer/middleware/textComposer/types.ts
+++ b/src/messageComposer/middleware/textComposer/types.ts
@@ -17,18 +17,6 @@ export type UserSuggestion = BaseSuggestion & UserResponse & TokenizationPayload
 export type CustomValidSuggestion = BaseSuggestion & CustomTextComposerSuggestion;
 export type Suggestion = CommandSuggestion | UserSuggestion | CustomValidSuggestion;
 
-export type TextComposerMetadataByMiddlewareHandler<
-  TSuggestion extends Suggestion = Suggestion,
-> = {
-  onChange: {
-    selection: TextSelection;
-    text: string;
-  };
-  onSuggestionItemSelect: {
-    selectedSuggestion: TSuggestion;
-  };
-};
-
 export type TextComposerMiddlewareOptions = {
   minChars: number;
   trigger: string;

--- a/src/messageComposer/middleware/textComposer/types.ts
+++ b/src/messageComposer/middleware/textComposer/types.ts
@@ -1,36 +1,54 @@
-import type { TextComposerState, TextComposerSuggestion } from '../../types';
-import type { MiddlewareValue } from '../../../middleware';
 import type { MessageComposer } from '../../messageComposer';
+import type { CommandResponse, UserResponse } from '../../../types';
+import type { TokenizationPayload } from './textMiddlewareUtils';
+import type { SearchSource } from '../../../search_controller';
+import type { CustomSuggestion } from '../../types.custom';
+
+export type TextComposerSuggestion<T = unknown> = T & {
+  id: string;
+};
+
+export type BaseSuggestion = {
+  id: string;
+};
+
+export type CommandSuggestion = BaseSuggestion & CommandResponse;
+export type UserSuggestion = BaseSuggestion & UserResponse & TokenizationPayload;
+export type CustomValidSuggestion = BaseSuggestion & CustomSuggestion;
+export type Suggestion = CommandSuggestion | UserSuggestion | CustomValidSuggestion;
+
+export type TextComposerMetadataByMiddlewareHandler<
+  TSuggestion extends Suggestion = Suggestion,
+> = {
+  onChange: {
+    selection: TextSelection;
+    text: string;
+  };
+  onSuggestionItemSelect: {
+    selectedSuggestion: TSuggestion;
+  };
+};
 
 export type TextComposerMiddlewareOptions = {
   minChars: number;
   trigger: string;
 };
 
-export type TextComposerMiddlewareValue = MiddlewareValue<TextComposerState>;
-
-export type TextComposerMiddlewareParams<T = unknown> = {
-  input: TextComposerMiddlewareValue;
-  nextHandler: (
-    input: TextComposerMiddlewareValue,
-  ) => Promise<TextComposerMiddlewareValue>;
-  selectedSuggestion?: TextComposerSuggestion<T>;
-};
-
-export type TextComposerMiddlewareHandler = (
-  params: TextComposerMiddlewareParams,
-) => Promise<TextComposerMiddlewareValue>;
-
-export type CustomTextComposerMiddleware = {
-  [key: string]: string | TextComposerMiddlewareHandler;
-};
-
-export type TextComposerMiddleware = CustomTextComposerMiddleware & {
-  id: string;
-  onChange?: string | TextComposerMiddlewareHandler;
-  onSuggestionItemSelect?: string | TextComposerMiddlewareHandler;
-};
-
 export type TextComposerMiddlewareExecutorOptions = {
   composer: MessageComposer;
+};
+
+export type Suggestions<T extends Suggestion = Suggestion> = {
+  query: string;
+  searchSource: SearchSource<T>;
+  trigger: string;
+};
+
+export type TextSelection = { end: number; start: number };
+
+export type TextComposerState<T extends Suggestion = Suggestion> = {
+  mentionedUsers: UserResponse[];
+  selection: TextSelection;
+  text: string;
+  suggestions?: Suggestions<T>;
 };

--- a/src/messageComposer/middleware/textComposer/validation.ts
+++ b/src/messageComposer/middleware/textComposer/validation.ts
@@ -1,24 +1,29 @@
+import type { MiddlewareHandlerParams } from '../../../middleware';
+import type { TextSelection } from './types';
+import type { TextComposerState } from './types';
 import type { MessageComposer } from '../../messageComposer';
-import type { TextComposerMiddlewareParams } from './types';
-import type { UserSuggestion } from './mentions';
 
 export const createTextComposerPreValidationMiddleware = (composer: MessageComposer) => ({
   id: 'stream-io/text-composer/pre-validation-middleware',
-  onChange: ({ input, nextHandler }: TextComposerMiddlewareParams<UserSuggestion>) => {
+  onChange: ({
+    state,
+    next,
+    forward,
+  }: MiddlewareHandlerParams<
+    TextComposerState,
+    {
+      selection: TextSelection;
+      text: string;
+    }
+  >) => {
     const { maxLengthOnEdit } = composer.config.text ?? {};
-    if (
-      typeof maxLengthOnEdit === 'number' &&
-      input.state.text.length > maxLengthOnEdit
-    ) {
-      input.state.text = input.state.text.slice(0, maxLengthOnEdit);
-      return nextHandler({
-        ...input,
-        state: {
-          ...input.state,
-          text: input.state.text,
-        },
+    if (typeof maxLengthOnEdit === 'number' && state.text.length > maxLengthOnEdit) {
+      state.text = state.text.slice(0, maxLengthOnEdit);
+      return next({
+        ...state,
+        text: state.text,
       });
     }
-    return nextHandler(input);
+    return forward();
   },
 });

--- a/src/messageComposer/middleware/textComposer/validation.ts
+++ b/src/messageComposer/middleware/textComposer/validation.ts
@@ -1,29 +1,29 @@
-import type { MiddlewareHandlerParams } from '../../../middleware';
-import type { TextSelection } from './types';
-import type { TextComposerState } from './types';
 import type { MessageComposer } from '../../messageComposer';
+import type { TextComposerMiddlewareExecutorState } from './TextComposerMiddlewareExecutor';
+import type { Suggestion } from './types';
+import type { Middleware } from '../../../middleware';
 
-export const createTextComposerPreValidationMiddleware = (composer: MessageComposer) => ({
+export type TextComposerPreValidationMiddleware = Middleware<
+  TextComposerMiddlewareExecutorState<Suggestion>,
+  'onChange' | 'onSuggestionItemSelect'
+>;
+
+export const createTextComposerPreValidationMiddleware = (
+  composer: MessageComposer,
+): TextComposerPreValidationMiddleware => ({
   id: 'stream-io/text-composer/pre-validation-middleware',
-  onChange: ({
-    state,
-    next,
-    forward,
-  }: MiddlewareHandlerParams<
-    TextComposerState,
-    {
-      selection: TextSelection;
-      text: string;
-    }
-  >) => {
-    const { maxLengthOnEdit } = composer.config.text ?? {};
-    if (typeof maxLengthOnEdit === 'number' && state.text.length > maxLengthOnEdit) {
-      state.text = state.text.slice(0, maxLengthOnEdit);
-      return next({
-        ...state,
-        text: state.text,
-      });
-    }
-    return forward();
+  handlers: {
+    onChange: ({ state, next, forward }) => {
+      const { maxLengthOnEdit } = composer.config.text ?? {};
+      if (typeof maxLengthOnEdit === 'number' && state.text.length > maxLengthOnEdit) {
+        state.text = state.text.slice(0, maxLengthOnEdit);
+        return next({
+          ...state,
+          text: state.text,
+        });
+      }
+      return forward();
+    },
+    onSuggestionItemSelect: ({ forward }) => forward(),
   },
 });

--- a/src/messageComposer/pollComposer.ts
+++ b/src/messageComposer/pollComposer.ts
@@ -103,24 +103,23 @@ export class PollComposer {
   };
 
   updateFields = async (data: UpdateFieldsData) => {
-    const { state, status } = await this.stateMiddlewareExecutor.execute(
-      'handleFieldChange',
-      {
-        state: {
-          nextState: { ...this.state.getLatestValue() },
-          previousState: { ...this.state.getLatestValue() },
-          targetFields: data,
-        },
+    const { state, status } = await this.stateMiddlewareExecutor.execute({
+      eventName: 'handleFieldChange',
+      initialValue: {
+        nextState: { ...this.state.getLatestValue() },
+        previousState: { ...this.state.getLatestValue() },
+        targetFields: data,
       },
-    );
+    });
 
     if (status === 'discard') return;
     this.state.next(state.nextState);
   };
 
   handleFieldBlur = async (field: keyof PollComposerState['data']) => {
-    const result = await this.stateMiddlewareExecutor.execute('handleFieldBlur', {
-      state: {
+    const result = await this.stateMiddlewareExecutor.execute({
+      eventName: 'handleFieldBlur',
+      initialValue: {
         nextState: { ...this.state.getLatestValue() },
         previousState: { ...this.state.getLatestValue() },
         targetFields: { [field]: this.state.getLatestValue().data[field] },
@@ -133,8 +132,9 @@ export class PollComposer {
 
   compose = async () => {
     const { data, errors } = this.state.getLatestValue();
-    const result = await this.compositionMiddlewareExecutor.execute('compose', {
-      state: {
+    const result = await this.compositionMiddlewareExecutor.execute({
+      eventName: 'compose',
+      initialValue: {
         data: {
           ...data,
           max_votes_allowed: data.max_votes_allowed

--- a/src/messageComposer/textComposer.ts
+++ b/src/messageComposer/textComposer.ts
@@ -261,10 +261,8 @@ export class TextComposer {
       eventName: 'onChange',
       initialValue: {
         ...this.state.getLatestValue(),
-        change: {
-          text,
-          selection,
-        },
+        text,
+        selection,
       },
     });
     if (output.status === 'discard') return;

--- a/src/messageComposer/textComposer.ts
+++ b/src/messageComposer/textComposer.ts
@@ -1,12 +1,10 @@
 import { TextComposerMiddlewareExecutor } from './middleware';
 import { StateStore } from '../store';
 import { logChatPromiseExecution } from '../utils';
-import type {
-  Suggestions,
-  TextComposerState,
-  TextComposerSuggestion,
-  TextSelection,
-} from './types';
+import type { TextComposerSuggestion } from './middleware/textComposer/types';
+import type { TextSelection } from './middleware/textComposer/types';
+import type { TextComposerState } from './middleware/textComposer/types';
+import type { Suggestions } from './middleware/textComposer/types';
 import type { MessageComposer } from './messageComposer';
 import type { DraftMessage, LocalMessage, UserResponse } from '../types';
 
@@ -259,11 +257,14 @@ export class TextComposer {
     text: string;
   }) => {
     if (!this.enabled) return;
-    const output = await this.middlewareExecutor.execute('onChange', {
-      state: {
+    const output = await this.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
         ...this.state.getLatestValue(),
-        text,
-        selection,
+        change: {
+          text,
+          selection,
+        },
       },
     });
     if (output.status === 'discard') return;
@@ -280,13 +281,15 @@ export class TextComposer {
   // todo: document how to register own middleware handler to simulate onSelectUser prop
   handleSelect = async (target: TextComposerSuggestion<unknown>) => {
     if (!this.enabled) return;
-    const output = await this.middlewareExecutor.execute(
-      'onSuggestionItemSelect',
-      {
-        state: this.state.getLatestValue(),
+    const output = await this.middlewareExecutor.execute({
+      eventName: 'onSuggestionItemSelect',
+      initialValue: {
+        ...this.state.getLatestValue(),
+        change: {
+          selectedSuggestion: target,
+        },
       },
-      target,
-    );
+    });
     if (output?.status === 'discard') return;
     this.state.next(output.state);
   };

--- a/src/messageComposer/types.custom.ts
+++ b/src/messageComposer/types.custom.ts
@@ -1,0 +1,5 @@
+export interface CustomSuggestion {}
+
+export interface CustomTextComposerState {}
+
+export interface CustomTextComposerMetadata {}

--- a/src/messageComposer/types.custom.ts
+++ b/src/messageComposer/types.custom.ts
@@ -1,5 +1,1 @@
-export interface CustomSuggestion {}
-
-export interface CustomTextComposerState {}
-
-export interface CustomTextComposerMetadata {}
+export interface CustomTextComposerSuggestion {}

--- a/src/messageComposer/types.ts
+++ b/src/messageComposer/types.ts
@@ -1,5 +1,4 @@
-import type { Attachment, FileUploadConfig, UserResponse } from '../types';
-import type { SearchSource } from '../search_controller';
+import type { Attachment, FileUploadConfig } from '../types';
 
 export type LocalAttachment = AnyLocalAttachment | LocalUploadAttachment;
 
@@ -141,24 +140,4 @@ export type FileReference = Pick<File, 'name' | 'size' | 'type'> & {
 
   // This is specially needed for video in camera roll
   thumb_url?: string;
-};
-
-type Id = string;
-export type MentionedUserMap = Map<Id, UserResponse>;
-export type TextSelection = { end: number; start: number };
-export type TextComposerSuggestion<T = unknown> = T & {
-  id: string;
-};
-
-export type Suggestions = {
-  query: string;
-  searchSource: SearchSource<TextComposerSuggestion>; // we do not want to limit the use of SearchSources
-  trigger: string;
-};
-
-export type TextComposerState = {
-  mentionedUsers: UserResponse[];
-  selection: TextSelection;
-  text: string;
-  suggestions?: Suggestions;
 };

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -540,7 +540,10 @@ describe('MessageComposer', () => {
 
       const result = await messageComposer.compose();
 
-      expect(spyExecute).toHaveBeenCalledWith('compose', expect.any(Object));
+      expect(spyExecute).toHaveBeenCalledWith({
+        eventName: 'compose',
+        initialValue: expect.any(Object),
+      });
       expect(result).toEqual(mockResult.state);
     });
 
@@ -559,7 +562,10 @@ describe('MessageComposer', () => {
 
       const result = await messageComposer.compose();
 
-      expect(spyExecute).toHaveBeenCalledWith('compose', expect.any(Object));
+      expect(spyExecute).toHaveBeenCalledWith({
+        eventName: 'compose',
+        initialValue: expect.any(Object),
+      });
       expect(result).toBeUndefined();
     });
 
@@ -583,7 +589,10 @@ describe('MessageComposer', () => {
 
       const result = await messageComposer.composeDraft();
 
-      expect(spyExecute).toHaveBeenCalledWith('compose', expect.any(Object));
+      expect(spyExecute).toHaveBeenCalledWith({
+        eventName: 'compose',
+        initialValue: expect.any(Object),
+      });
       expect(result).toEqual(mockResult.state);
     });
 
@@ -602,7 +611,10 @@ describe('MessageComposer', () => {
 
       const result = await messageComposer.composeDraft();
 
-      expect(spyExecute).toHaveBeenCalledWith('compose', expect.any(Object));
+      expect(spyExecute).toHaveBeenCalledWith({
+        eventName: 'compose',
+        initialValue: expect.any(Object),
+      });
       expect(result).toBeUndefined();
     });
 

--- a/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
@@ -8,6 +8,35 @@ import {
   LocalImageAttachment,
 } from '../../../../../src/messageComposer/types';
 import { createDraftAttachmentsCompositionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/attachments';
+import { MessageDraftComposerMiddlewareValueState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
+import { MessageComposerMiddlewareState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
+import { MiddlewareStatus } from '../../../../../src/middleware';
+
+const setup = (initialState: MessageComposerMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageComposerMiddlewareState) => ({ state }),
+    complete: async (state: MessageComposerMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setupDraft = (initialState: MessageDraftComposerMiddlewareValueState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageDraftComposerMiddlewareValueState) => ({ state }),
+    complete: async (state: MessageDraftComposerMiddlewareValueState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
 
 describe('AttachmentsMiddleware', () => {
   let channel: Channel;
@@ -104,34 +133,31 @@ describe('AttachmentsMiddleware', () => {
   });
 
   it('should handle message without attachments', async () => {
-    const result = await attachmentsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await attachmentsMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -155,34 +181,31 @@ describe('AttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue([attachment]);
 
-    const result = await attachmentsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [attachment],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await attachmentsMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [attachment],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(1);
@@ -219,34 +242,31 @@ describe('AttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue(attachments);
 
-    const result = await attachmentsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments,
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await attachmentsMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments,
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(2);
@@ -277,34 +297,31 @@ describe('AttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue([]);
 
-    const result = await attachmentsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [attachment],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await attachmentsMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [attachment],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -328,34 +345,31 @@ describe('AttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue([]);
 
-    const result = await attachmentsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [attachment],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await attachmentsMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [attachment],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -406,16 +420,13 @@ describe('DraftAttachmentsMiddleware', () => {
   });
 
   it('should handle draft without attachments', async () => {
-    const result = await draftAttachmentsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await draftAttachmentsMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toBeUndefined();
@@ -438,17 +449,14 @@ describe('DraftAttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue([attachment]);
 
-    const result = await draftAttachmentsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-            attachments: [],
-          },
+    const result = await draftAttachmentsMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          text: '',
+          attachments: [],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toHaveLength(1);
@@ -481,17 +489,14 @@ describe('DraftAttachmentsMiddleware', () => {
       'get',
     ).mockReturnValue([newAttachment]);
 
-    const result = await draftAttachmentsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-            attachments: [existingAttachment],
-          },
+    const result = await draftAttachmentsMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          text: '',
+          attachments: [existingAttachment],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toHaveLength(2);
@@ -505,16 +510,13 @@ describe('DraftAttachmentsMiddleware', () => {
     draftAttachmentsMiddleware =
       createDraftAttachmentsCompositionMiddleware(messageComposer);
 
-    const result = await draftAttachmentsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await draftAttachmentsMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toBeUndefined();

--- a/test/unit/MessageComposer/middleware/messageComposer/linkPreviews.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/linkPreviews.test.ts
@@ -14,6 +14,9 @@ import {
   DraftResponse,
   LinkPreviewsManagerConfig,
   LocalMessage,
+  MessageComposerMiddlewareState,
+  MessageDraftComposerMiddlewareValueState,
+  MiddlewareStatus,
 } from '../../../../../src';
 
 const enrichURLReturnValue = {
@@ -28,6 +31,34 @@ const enrichURLReturnValue = {
   title_link: 'https://example.com',
   type: 'article',
   duration: '100',
+};
+
+const setupHandlerParams = (initialState: MessageComposerMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageComposerMiddlewareState) => ({ state }),
+    complete: async (state: MessageComposerMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setupHandlerParamsDraft = (
+  initialState: MessageDraftComposerMiddlewareValueState,
+) => {
+  return {
+    state: initialState,
+    next: async (state: MessageDraftComposerMiddlewareValueState) => ({ state }),
+    complete: async (state: MessageDraftComposerMiddlewareValueState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
 };
 
 const setup = ({
@@ -62,34 +93,31 @@ const setup = ({
 describe('LinkPreviewsMiddleware', () => {
   it('should keep message attachments empty if not link previews are available', async () => {
     const { linkPreviewsMiddleware } = setup();
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -119,34 +147,31 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(1);
@@ -179,34 +204,31 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -237,34 +259,31 @@ describe('LinkPreviewsMiddleware', () => {
     });
 
     // Set up the previews in the manager
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -294,34 +313,31 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0);
@@ -383,34 +399,31 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example1.com https://example2.com https://example3.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example1.com https://example2.com https://example3.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(2);
@@ -459,34 +472,31 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example1.com https://example2.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example1.com https://example2.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(0); // will be added server-side
@@ -517,45 +527,42 @@ describe('LinkPreviewsMiddleware', () => {
       ]),
     });
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            attachments: [
-              {
-                type: 'image',
-                image_url: 'https://example.com/image.jpg',
-              },
-            ],
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [
-              {
-                type: 'image',
-                image_url: 'https://example.com/image.jpg',
-              },
-            ],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'https://example.com',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          attachments: [
+            {
+              type: 'image',
+              image_url: 'https://example.com/image.jpg',
+            },
+          ],
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [
+            {
+              type: 'image',
+              image_url: 'https://example.com/image.jpg',
+            },
+          ],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'https://example.com',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.attachments ?? []).toHaveLength(2);
@@ -599,16 +606,13 @@ const setupForDraft = ({
 describe('DraftLinkPreviewsMiddleware', () => {
   it('should handle draft without link previews', async () => {
     const { linkPreviewsMiddleware } = setupForDraft();
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toBeUndefined();
@@ -636,16 +640,13 @@ describe('DraftLinkPreviewsMiddleware', () => {
       'get',
     ).mockReturnValue([linkPreview]);
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toHaveLength(1);
@@ -681,17 +682,14 @@ describe('DraftLinkPreviewsMiddleware', () => {
       'get',
     ).mockReturnValue([linkPreview]);
 
-    const result = await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-            attachments: [existingAttachment],
-          },
+    const result = await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
+          attachments: [existingAttachment],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toHaveLength(2);
@@ -706,16 +704,13 @@ describe('DraftLinkPreviewsMiddleware', () => {
     const linkPreviewsMiddlewareWithUndefinedManager =
       createDraftLinkPreviewsCompositionMiddleware(messageComposer);
 
-    const result = await linkPreviewsMiddlewareWithUndefinedManager.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await linkPreviewsMiddlewareWithUndefinedManager.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toBeUndefined();
@@ -726,16 +721,13 @@ describe('DraftLinkPreviewsMiddleware', () => {
     const cancelURLEnrichment = vi.fn();
     messageComposer.linkPreviewsManager.cancelURLEnrichment = cancelURLEnrichment;
 
-    await linkPreviewsMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    await linkPreviewsMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(cancelURLEnrichment).toHaveBeenCalled();
   });

--- a/test/unit/MessageComposer/middleware/messageComposer/messageComposerState.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/messageComposerState.test.ts
@@ -5,6 +5,37 @@ import { Channel } from '../../../../../src/channel';
 import { StreamChat } from '../../../../../src/client';
 import { LocalMessage } from '../../../../../src/types';
 import { createDraftMessageComposerStateCompositionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/messageComposerState';
+import { MessageComposerMiddlewareState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
+import { MiddlewareStatus } from '../../../../../src/middleware';
+import { MessageDraftComposerMiddlewareValueState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
+
+const setupHandlerParams = (initialState: MessageComposerMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageComposerMiddlewareState) => ({ state }),
+    complete: async (state: MessageComposerMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setupHandlerParamsDraft = (
+  initialState: MessageDraftComposerMiddlewareValueState,
+) => {
+  return {
+    state: initialState,
+    next: async (state: MessageDraftComposerMiddlewareValueState) => ({ state }),
+    complete: async (state: MessageDraftComposerMiddlewareValueState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
 
 describe('MessageComposerStateMiddleware', () => {
   let channel: Channel;
@@ -38,34 +69,31 @@ describe('MessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(null);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue(null);
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.state.message.quoted_message_id).toBeUndefined();
     expect(result.state.message.poll_id).toBeUndefined();
@@ -96,34 +124,31 @@ describe('MessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue(null);
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.state.message.quoted_message_id).toBe('quoted-message-id');
     expect(result.state.localMessage.quoted_message_id).toBe('quoted-message-id');
@@ -135,34 +160,31 @@ describe('MessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(null);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.state.message.poll_id).toBe('poll-id-123');
     expect(result.state.localMessage.poll_id).toBe('poll-id-123');
@@ -190,34 +212,31 @@ describe('MessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.state.message.quoted_message_id).toBe('quoted-message-id');
     expect(result.state.message.poll_id).toBe('poll-id-123');
@@ -248,35 +267,32 @@ describe('MessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-            text: 'Original message text',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: 'Original local message text',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParams({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
+          text: 'Original message text',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: 'Original local message text',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     // Verify that the original properties are preserved
     expect(result.state.message.text).toBe('Original message text');
@@ -326,16 +342,13 @@ describe('DraftMessageComposerStateMiddleware', () => {
   });
 
   it('should handle draft without quoted message or poll', async () => {
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.quoted_message_id).toBeUndefined();
@@ -355,16 +368,13 @@ describe('DraftMessageComposerStateMiddleware', () => {
 
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.quoted_message_id).toBe('quoted-message-id');
@@ -374,16 +384,13 @@ describe('DraftMessageComposerStateMiddleware', () => {
   it('should handle draft with poll', async () => {
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.quoted_message_id).toBeUndefined();
@@ -404,16 +411,13 @@ describe('DraftMessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: '',
-          },
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.quoted_message_id).toBe('quoted-message-id');
@@ -434,22 +438,19 @@ describe('DraftMessageComposerStateMiddleware', () => {
     vi.spyOn(messageComposer, 'quotedMessage', 'get').mockReturnValue(quotedMessage);
     vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id-123');
 
-    const result = await messageComposerStateMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            text: 'Original draft text',
-            attachments: [
-              {
-                type: 'image',
-                image_url: 'https://example.com/image.jpg',
-              },
-            ],
-          },
+    const result = await messageComposerStateMiddleware.handlers.compose(
+      setupHandlerParamsDraft({
+        draft: {
+          text: 'Original draft text',
+          attachments: [
+            {
+              type: 'image',
+              image_url: 'https://example.com/image.jpg',
+            },
+          ],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('Original draft text');

--- a/test/unit/MessageComposer/middleware/messageComposer/textComposer.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/textComposer.test.ts
@@ -4,6 +4,37 @@ import { StreamChat } from '../../../../../src/client';
 import { MessageComposer } from '../../../../../src/messageComposer/messageComposer';
 import { createTextComposerCompositionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/textComposer';
 import { createDraftTextComposerCompositionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/textComposer';
+import {
+  MessageComposerMiddlewareState,
+  MessageDraftComposerMiddlewareValueState,
+  MiddlewareStatus,
+} from '../../../../../src';
+
+const setup = (initialState: MessageComposerMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageComposerMiddlewareState) => ({ state }),
+    complete: async (state: MessageComposerMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setupDraft = (initialState: MessageDraftComposerMiddlewareValueState) => {
+  return {
+    state: initialState,
+    next: async (state: MessageDraftComposerMiddlewareValueState) => ({ state }),
+    complete: async (state: MessageDraftComposerMiddlewareValueState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
 
 describe('TextComposerMiddleware', () => {
   let channel: Channel;
@@ -97,34 +128,31 @@ describe('TextComposerMiddleware', () => {
   });
 
   it('should handle empty message', async () => {
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBeUndefined;
@@ -133,35 +161,31 @@ describe('TextComposerMiddleware', () => {
 
   it('should handle message with text', async () => {
     vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('Hello world');
-
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBe('Hello world');
@@ -177,35 +201,32 @@ describe('TextComposerMiddleware', () => {
       { id: 'user2', name: 'User 2' },
     ]);
 
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-            mentioned_users: [] as string[],
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [] as Array<{ id: string; name: string }>,
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
+          mentioned_users: [] as string[],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [] as Array<{ id: string; name: string }>,
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBe('@user1 @user2');
@@ -224,35 +245,32 @@ describe('TextComposerMiddleware', () => {
       { id: 'user2', name: 'User 2' },
     ]);
 
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-            mentioned_users: [] as string[],
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [] as Array<{ id: string; name: string }>,
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
+          mentioned_users: [] as string[],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [] as Array<{ id: string; name: string }>,
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBe('@user1');
@@ -266,34 +284,31 @@ describe('TextComposerMiddleware', () => {
   it('should handle message with commands', async () => {
     vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('/giphy hello');
 
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBe('/giphy hello');
@@ -303,34 +318,31 @@ describe('TextComposerMiddleware', () => {
   it('should handle message with emoji', async () => {
     vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('Hello 👋');
 
-    const result = await textComposerMiddleware.compose({
-      input: {
-        state: {
-          message: {
-            id: 'test-id',
-            parent_id: undefined,
-            type: 'regular',
-          },
-          localMessage: {
-            attachments: [],
-            created_at: new Date(),
-            deleted_at: null,
-            error: undefined,
-            id: 'test-id',
-            mentioned_users: [],
-            parent_id: undefined,
-            pinned_at: null,
-            reaction_groups: null,
-            status: 'sending',
-            text: '',
-            type: 'regular',
-            updated_at: new Date(),
-          },
-          sendOptions: {},
+    const result = await textComposerMiddleware.handlers.compose(
+      setup({
+        message: {
+          id: 'test-id',
+          parent_id: undefined,
+          type: 'regular',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+        localMessage: {
+          attachments: [],
+          created_at: new Date(),
+          deleted_at: null,
+          error: undefined,
+          id: 'test-id',
+          mentioned_users: [],
+          parent_id: undefined,
+          pinned_at: null,
+          reaction_groups: null,
+          status: 'sending',
+          text: '',
+          type: 'regular',
+          updated_at: new Date(),
+        },
+        sendOptions: {},
+      }),
+    );
 
     expect(result.status).toBeUndefined;
     expect(result.state.message.text).toBe('Hello 👋');
@@ -433,18 +445,15 @@ describe('DraftTextComposerMiddleware', () => {
   });
 
   it('should handle empty draft', async () => {
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('');
@@ -454,18 +463,15 @@ describe('DraftTextComposerMiddleware', () => {
   it('should handle draft with text', async () => {
     vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('Hello world');
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('Hello world');
@@ -481,18 +487,15 @@ describe('DraftTextComposerMiddleware', () => {
       { id: 'user2', name: 'User 2' },
     ]);
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('@user1 @user2');
@@ -506,18 +509,15 @@ describe('DraftTextComposerMiddleware', () => {
       { id: 'user2', name: 'User 2' },
     ]);
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('@user1');
@@ -528,18 +528,15 @@ describe('DraftTextComposerMiddleware', () => {
     vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('Hello world');
     vi.spyOn(messageComposer.textComposer, 'mentionedUsers', 'get').mockReturnValue([]);
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('Hello world');
@@ -552,24 +549,21 @@ describe('DraftTextComposerMiddleware', () => {
       { id: 'user1', name: 'User 1' },
     ]);
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-            attachments: [
-              {
-                type: 'image',
-                image_url: 'https://example.com/image.jpg',
-              },
-            ],
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
+          attachments: [
+            {
+              type: 'image',
+              image_url: 'https://example.com/image.jpg',
+            },
+          ],
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('Hello world');
@@ -581,18 +575,15 @@ describe('DraftTextComposerMiddleware', () => {
   it('should handle when textComposer is not available', async () => {
     messageComposer.textComposer = undefined as any;
 
-    const result = await draftTextComposerMiddleware.compose({
-      input: {
-        state: {
-          draft: {
-            id: 'test-id',
-            parent_id: undefined,
-            text: '',
-          },
+    const result = await draftTextComposerMiddleware.handlers.compose(
+      setupDraft({
+        draft: {
+          id: 'test-id',
+          parent_id: undefined,
+          text: '',
         },
-      },
-      nextHandler: async (input) => input,
-    });
+      }),
+    );
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.text).toBe('');

--- a/test/unit/MessageComposer/middleware/textComposer/TextComposerMiddlewareExecutor.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/TextComposerMiddlewareExecutor.test.ts
@@ -6,8 +6,7 @@ import {
   MessageComposer,
 } from '../../../../../src/messageComposer/messageComposer';
 import { createMentionsMiddleware } from '../../../../../src/messageComposer/middleware/textComposer/mentions';
-import { TextComposer } from '../../../../../src/messageComposer/textComposer';
-import type { TextComposerSuggestion } from '../../../../../src/messageComposer/types';
+import type { TextComposerSuggestion } from '../../../../../src/messageComposer/';
 import type {
   CommandResponse,
   DraftResponse,
@@ -63,6 +62,12 @@ const setup = ({
   return { client, channel, messageComposer };
 };
 
+const initialValue = {
+  text: '',
+  selection: { start: 0, end: 0 },
+  mentionedUsers: [],
+};
+
 describe('TextComposerMiddlewareExecutor', () => {
   it('should initialize with default middleware', () => {
     const {
@@ -79,11 +84,12 @@ describe('TextComposerMiddlewareExecutor', () => {
     const {
       messageComposer: { textComposer },
     } = setup();
-    let result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    let result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '@jo',
         selection: { start: 3, end: 3 },
-        mentionedUsers: [],
       },
     });
 
@@ -91,11 +97,12 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(result.state.suggestions?.trigger).toBe('@');
     expect(result.state.suggestions?.query).toBe('jo');
 
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: 'abcde@ho',
         selection: { start: 8, end: 8 },
-        mentionedUsers: [],
       },
     });
 
@@ -103,21 +110,23 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(result.state.suggestions?.trigger).toBe('@');
     expect(result.state.suggestions?.query).toBe('ho');
 
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: 'abcde@ho',
         selection: { start: 5, end: 5 }, // selection is not where the trigger is
-        mentionedUsers: [],
       },
     });
 
     expect(result.state.suggestions).toBeUndefined();
 
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: 'abcde@ho',
         selection: { start: 6, end: 6 }, // selection is where the trigger is but not at the end
-        mentionedUsers: [],
       },
     });
 
@@ -130,11 +139,12 @@ describe('TextComposerMiddlewareExecutor', () => {
     const {
       messageComposer: { textComposer },
     } = setup();
-    let result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    let result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '/ban',
         selection: { start: 4, end: 4 },
-        mentionedUsers: [],
       },
     });
 
@@ -142,11 +152,14 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(result.state.suggestions?.trigger).toBe('/');
     expect(result.state.suggestions?.query).toBe('ban');
 
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
-        text: '/ban /ban',
-        selection: { start: 9, end: 9 },
-        mentionedUsers: [],
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
+        change: {
+          text: '/ban /ban',
+          selection: { start: 9, end: 9 },
+        },
       },
     });
 
@@ -205,6 +218,7 @@ describe('TextComposerMiddlewareExecutor', () => {
         throw new Error('Search failed');
       }),
       activate: vi.fn(),
+      resetinitialValue: vi.fn(),
       resetState: vi.fn(),
       resetStateAndActivate: vi.fn(),
       config: {},
@@ -216,11 +230,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       }),
     ] as TextComposerMiddleware[]);
 
-    const result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    const result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '@jo',
         selection: { start: 3, end: 3 },
-        mentionedUsers: [],
       },
     });
 
@@ -233,11 +248,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '/test',
           selection: { start: 0, end: 0 },
-          mentionedUsers: [],
         },
       });
 
@@ -252,11 +268,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'test',
           selection: { start: 0, end: 4 },
-          mentionedUsers: [],
         },
       });
 
@@ -271,11 +288,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '/test',
           selection: { start: 0, end: 5 },
-          mentionedUsers: [],
         },
       });
 
@@ -288,11 +306,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '/',
           selection: { start: 0, end: 1 },
-          mentionedUsers: [],
         },
       });
 
@@ -305,11 +324,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'test',
           selection: { start: 0, end: 4 },
-          mentionedUsers: [],
           suggestions: {
             trigger: '/',
             query: 'test',
@@ -327,11 +347,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '@test',
           selection: { start: 0, end: 0 },
-          mentionedUsers: [],
         },
       });
 
@@ -346,11 +367,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '@test',
           selection: { start: 0, end: 5 },
-          mentionedUsers: [],
         },
       });
 
@@ -363,11 +385,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: '@',
           selection: { start: 0, end: 1 },
-          mentionedUsers: [],
         },
       });
 
@@ -380,11 +403,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       const {
         messageComposer: { textComposer },
       } = setup();
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'test',
           selection: { start: 0, end: 4 },
-          mentionedUsers: [],
           suggestions: {
             trigger: '@',
             query: 'test',
@@ -402,11 +426,12 @@ describe('TextComposerMiddlewareExecutor', () => {
     const {
       messageComposer: { textComposer },
     } = setup();
-    let result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    let result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '/ban',
         selection: { start: 4, end: 4 },
-        mentionedUsers: [],
       },
     });
 
@@ -415,11 +440,12 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(result.state.suggestions?.query).toBe('ban');
 
     // Then test a mention after the command
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '/ban @jo',
         selection: { start: 9, end: 9 },
-        mentionedUsers: [],
       },
     });
 
@@ -428,22 +454,24 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(result.state.suggestions?.query).toBe('jo');
 
     // Test a command in the middle of text - should not trigger command suggestions
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: 'hello /ban',
         selection: { start: 11, end: 11 },
-        mentionedUsers: [],
       },
     });
 
     expect(result.state.suggestions).toBeUndefined();
 
     // Test a mention followed by a command
-    result = await textComposer.middlewareExecutor.execute('onChange', {
-      state: {
+    result = await textComposer.middlewareExecutor.execute({
+      eventName: 'onChange',
+      initialValue: {
+        ...initialValue,
         text: '@jo /ban',
         selection: { start: 8, end: 8 },
-        mentionedUsers: [],
       },
     });
 
@@ -462,11 +490,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       textComposer.maxLengthOnEdit = 10;
 
       // Test with text exceeding max length
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'Hello World This Is Too Long',
           selection: { start: 30, end: 30 },
-          mentionedUsers: [],
         },
       });
 
@@ -482,11 +511,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       textComposer.maxLengthOnEdit = 20;
 
       // Test with text under max length
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'Hello World',
           selection: { start: 11, end: 11 },
-          mentionedUsers: [],
         },
       });
 
@@ -502,11 +532,12 @@ describe('TextComposerMiddlewareExecutor', () => {
       textComposer.maxLengthOnEdit = 0;
 
       // Test with any text
-      const result = await textComposer.middlewareExecutor.execute('onChange', {
-        state: {
+      const result = await textComposer.middlewareExecutor.execute({
+        eventName: 'onChange',
+        initialValue: {
+          ...initialValue,
           text: 'Hello World',
           selection: { start: 11, end: 11 },
-          mentionedUsers: [],
         },
       });
 

--- a/test/unit/MessageComposer/pollComposer.test.ts
+++ b/test/unit/MessageComposer/pollComposer.test.ts
@@ -269,7 +269,10 @@ describe('PollComposer', () => {
 
       await pollComposer.updateFields(updateData);
 
-      expect(spy).toHaveBeenCalledWith('handleFieldChange', expect.any(Object));
+      expect(spy).toHaveBeenCalledWith({
+        eventName: 'handleFieldChange',
+        initialValue: expect.any(Object),
+      });
     });
 
     it('should not update state if middleware returns discard status', async () => {
@@ -298,7 +301,10 @@ describe('PollComposer', () => {
 
       await pollComposer.handleFieldBlur('name');
 
-      expect(spy).toHaveBeenCalledWith('handleFieldBlur', expect.any(Object));
+      expect(spy).toHaveBeenCalledWith({
+        eventName: 'handleFieldBlur',
+        initialValue: expect.any(Object),
+      });
     });
 
     it('should not update state if middleware returns discard status', async () => {
@@ -326,7 +332,10 @@ describe('PollComposer', () => {
 
       const result = await pollComposer.compose();
 
-      expect(spy).toHaveBeenCalledWith('compose', expect.any(Object));
+      expect(spy).toHaveBeenCalledWith({
+        eventName: 'compose',
+        initialValue: expect.any(Object),
+      });
       expect(result).toBeDefined();
       if (result) {
         expect(result.data.name).toBe('Test Poll');

--- a/test/unit/middleware.test.ts
+++ b/test/unit/middleware.test.ts
@@ -7,18 +7,20 @@ import {
 } from '../../src/middleware';
 
 describe('MiddlewareExecutor', () => {
-  let executor: MiddlewareExecutor<{ value: number }>;
+  let executor: MiddlewareExecutor<{ value: number }, 'test'>;
 
   beforeEach(() => {
-    executor = new MiddlewareExecutor<{ value: number }>();
+    executor = new MiddlewareExecutor<{ value: number }, 'test'>();
   });
 
   describe('use', () => {
     it('should add middleware to the executor', () => {
-      const middleware: Middleware<{ value: number }> = {
+      const middleware: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -31,17 +33,21 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should add multiple middleware when array is provided', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -55,10 +61,12 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should return the executor for chaining', () => {
-      const middleware: Middleware<{ value: number }> = {
+      const middleware: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -69,17 +77,21 @@ describe('MiddlewareExecutor', () => {
 
   describe('replace', () => {
     it('should replace existing middleware with the same id', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       };
 
@@ -93,17 +105,21 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should add new middleware if id does not exist', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -118,10 +134,12 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should return the executor for chaining', () => {
-      const middleware: Middleware<{ value: number }> = {
+      const middleware: Middleware<{ value: number }, 'test'> = {
         id: 'test-middleware',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -132,24 +150,30 @@ describe('MiddlewareExecutor', () => {
 
   describe('insert', () => {
     it('should insert middleware after specified middleware', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware3: Middleware<{ value: number }> = {
+      const middleware3: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-3',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -167,24 +191,30 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should insert middleware before specified middleware', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware3: Middleware<{ value: number }> = {
+      const middleware3: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-3',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -202,24 +232,30 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should remove existing middleware with the same id if unique is true', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2Updated: Middleware<{ value: number }> = {
+      const middleware2Updated: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       };
 
@@ -236,17 +272,21 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should return the executor for chaining', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -261,24 +301,30 @@ describe('MiddlewareExecutor', () => {
 
   describe('setOrder', () => {
     it('should reorder middleware based on provided order', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware3: Middleware<{ value: number }> = {
+      const middleware3: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-3',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -295,17 +341,21 @@ describe('MiddlewareExecutor', () => {
     });
 
     it('should filter out middleware that does not exist in the order', () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler(input);
+        handlers: {
+          test: async ({ state, next }) => {
+            return next(state);
+          },
         },
       };
 
@@ -323,131 +373,164 @@ describe('MiddlewareExecutor', () => {
 
   describe('execute', () => {
     it('should execute middleware chain in order', async () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       };
 
       executor.use([middleware1, middleware2]);
 
-      const result = await executor.execute('test', { state: { value: 5 } });
+      const result = await executor.execute({
+        eventName: 'test',
+        initialValue: { value: 5 },
+      });
 
       expect(result.state.value).toBe(12); // (5 + 1) * 2
     });
 
     it('should skip middleware that does not have the specified event handler', async () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        testX: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value - 2 } });
+        handlers: {
+          testX: async ({ state, next }) => {
+            return next({ ...state, value: state.value - 2 });
+          },
         },
       };
 
-      const middleware3: Middleware<{ value: number }> = {
+      const middleware3: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-3',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       };
 
       executor.use([middleware1, middleware2, middleware3]);
 
-      const result = await executor.execute('test', { state: { value: 5 } });
+      const result = await executor.execute({
+        eventName: 'test',
+        initialValue: { value: 5 },
+      });
 
       expect(result.state.value).toBe(12); // (5 + 1) * 2
     });
 
     it('should handle middleware that returns complete status', async () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({
-            ...input,
-            state: { value: input.state.value + 1 },
-            status: 'complete' as MiddlewareStatus,
-          });
+        handlers: {
+          test: async ({ state, complete }) => {
+            return complete({
+              ...state,
+              value: state.value + 1,
+            });
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       };
 
       executor.use([middleware1, middleware2]);
 
-      const result = await executor.execute('test', { state: { value: 5 } });
+      const result = await executor.execute({
+        eventName: 'test',
+        initialValue: { value: 5 },
+      });
 
       expect(result.state.value).toBe(6); // 5 + 1, middleware2 is not executed
       expect(result.status).toBe('complete');
     });
 
     it('should handle middleware that returns discard status', async () => {
-      const middleware1: Middleware<{ value: number }> = {
+      const middleware1: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({
-            ...input,
-            state: { value: input.state.value + 1 },
-            status: 'discard' as MiddlewareStatus,
-          });
+        handlers: {
+          test: async ({ discard }) => {
+            return discard();
+          },
         },
       };
 
-      const middleware2: Middleware<{ value: number }> = {
+      const middleware2: Middleware<{ value: number }, 'test'> = {
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       };
 
       executor.use([middleware1, middleware2]);
 
-      const result = await executor.execute('test', { state: { value: 5 } });
+      const result = await executor.execute({
+        eventName: 'test',
+        initialValue: { value: 5 },
+      });
 
-      expect(result.state.value).toBe(6); // 5 + 1, middleware2 is not executed
+      expect(result.state.value).toBe(5); // 5 - middleware discards with the current state and middleware2 is not executed
       expect(result.status).toBe('discard');
     });
 
     it('should handle concurrent execute calls by discarding the first one', async () => {
       // Create a middleware that delays execution
-      const middleware: Middleware<{ value: number }> = {
+      const middleware: Middleware<{ value: number }, 'test'> = {
         id: 'delayed-middleware',
-        test: async ({ input, nextHandler }) => {
-          // Simulate a longer delay to ensure the first execution is still in progress
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            // Simulate a longer delay to ensure the first execution is still in progress
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       };
 
       executor.use(middleware);
 
       // Start the first execution
-      const firstExecution = executor.execute('test', { state: { value: 5 } });
+      const firstExecution = executor.execute({
+        eventName: 'test',
+        initialValue: { value: 5 },
+      });
 
       // Wait a short time to ensure the first execution has started but not completed
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Start the second execution before the first one completes
-      const secondExecution = executor.execute('test', { state: { value: 10 } });
+      const secondExecution = executor.execute({
+        eventName: 'test',
+        initialValue: { value: 10 },
+      });
 
       // Wait for both executions to complete
       const [firstResult, secondResult] = await Promise.all([
@@ -463,45 +546,33 @@ describe('MiddlewareExecutor', () => {
       expect(secondResult.state.value).toBe(11); // 10 + 1
     });
 
-    it('should handle middleware that calls nextHandler multiple times', async () => {
-      const middleware1: Middleware<{ value: number }> = {
-        id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          const result1 = await nextHandler({
-            ...input,
-            state: { value: input.state.value + 1 },
-          });
-          // This should throw an error
-          return nextHandler(result1);
-        },
-      };
-
-      executor.use([middleware1]);
-
-      await expect(executor.execute('test', { state: { value: 5 } })).rejects.toThrow(
-        'next() called multiple times',
-      );
-    });
-
     it('should handle concurrent execute calls with different event names', async () => {
       // Create middleware that handles different event names
-      const middleware: Middleware<{ value: number }> = {
+      const middleware: Middleware<{ value: number }, 'test1' | 'test2'> = {
         id: 'multi-event-middleware',
-        test1: async ({ input, nextHandler }) => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
-        },
-        test2: async ({ input, nextHandler }) => {
-          await new Promise((resolve) => setTimeout(resolve, 100));
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test1: async ({ state, next }) => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            return next({ ...state, value: state.value + 1 });
+          },
+          test2: async ({ state, next }) => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       };
 
       executor.use(middleware);
 
       // Start executions with different event names
-      const firstExecution = executor.execute('test1', { state: { value: 5 } });
-      const secondExecution = executor.execute('test2', { state: { value: 10 } });
+      const firstExecution = executor.execute({
+        eventName: 'test1',
+        initialValue: { value: 5 },
+      });
+      const secondExecution = executor.execute({
+        eventName: 'test2',
+        initialValue: { value: 10 },
+      });
 
       // Wait for both executions to complete
       const [firstResult, secondResult] = await Promise.all([
@@ -521,31 +592,35 @@ describe('MiddlewareExecutor', () => {
       const results: number[] = [];
 
       // Create two different middleware executors
-      const executor1 = new MiddlewareExecutor<{ value: number }>();
-      const executor2 = new MiddlewareExecutor<{ value: number }>();
+      const executor1 = new MiddlewareExecutor<{ value: number }, 'test'>();
+      const executor2 = new MiddlewareExecutor<{ value: number }, 'test'>();
 
       // Add middleware to each executor
       executor1.use({
         id: 'middleware-1',
-        test: async ({ input, nextHandler }) => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          results.push(1);
-          return nextHandler({ ...input, state: { value: input.state.value + 1 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            results.push(1);
+            return next({ ...state, value: state.value + 1 });
+          },
         },
       });
 
       executor2.use({
         id: 'middleware-2',
-        test: async ({ input, nextHandler }) => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          results.push(2);
-          return nextHandler({ ...input, state: { value: input.state.value * 2 } });
+        handlers: {
+          test: async ({ state, next }) => {
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            results.push(2);
+            return next({ ...state, value: state.value * 2 });
+          },
         },
       });
 
       // Execute the same event name on different executors concurrently
-      const p1 = executor1.execute('test', { state: { value: 5 } });
-      const p2 = executor2.execute('test', { state: { value: 10 } });
+      const p1 = executor1.execute({ eventName: 'test', initialValue: { value: 5 } });
+      const p2 = executor2.execute({ eventName: 'test', initialValue: { value: 10 } });
 
       // Wait for both executions to complete
       const [r1, r2] = await Promise.all([p1, p2]);


### PR DESCRIPTION
## Goal

1. Prevent disclosing implementation details in middleware handler params and instead provide a nice API:

- next()
- forward()
- discard()
- complete

2. Fix TextComposerMiddleware type bugs by forcing to declare middleware executor handlers and thus prevent casting when calling `MiddlewareExecutor.use()` (when registering middleware).
