### PR TITLE
fix: add user to RESERVED_UPDATED_MESSAGE_FIELDS

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -2874,10 +2874,10 @@ export class StreamChat {
       throw Error('Please specify the message.id when calling updateMessage');
     }
 
-    // should be without user object
+    // should not include user object
     const payload = toUpdatedMessagePayload(message);
 
-    // override user_id
+    // add user_id (if exists)
     if (typeof partialUserOrUserId === 'string') {
       payload.user_id = partialUserOrUserId;
     } else if (typeof partialUserOrUserId?.id === 'string') {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,31 +1,30 @@
-import type { ReservedUpdatedMessageFields } from './types';
-
 export const DEFAULT_QUERY_CHANNELS_MESSAGE_LIST_PAGE_SIZE = 25;
 export const DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE = 100;
 export const DEFAULT_MESSAGE_SET_PAGINATION = { hasNext: false, hasPrev: false };
 export const DEFAULT_UPLOAD_SIZE_LIMIT_BYTES = 100 * 1024 * 1024; // 100 MB
 export const API_MAX_FILES_ALLOWED_PER_MESSAGE = 10;
 export const MAX_CHANNEL_MEMBER_COUNT_IN_CHANNEL_QUERY = 100;
-export const RESERVED_UPDATED_MESSAGE_FIELDS: Array<ReservedUpdatedMessageFields> = [
+export const RESERVED_UPDATED_MESSAGE_FIELDS = {
   // Dates should not be converted back to ISO strings as JS looses precision on them (milliseconds)
-  'created_at',
-  'deleted_at',
-  'pinned_at',
-  'updated_at',
-  'command',
+  created_at: true,
+  deleted_at: true,
+  pinned_at: true,
+  updated_at: true,
+  command: true,
   // Back-end enriches these fields
-  'mentioned_users',
-  'quoted_message',
+  mentioned_users: true,
+  quoted_message: true,
   // Client-specific fields
-  'latest_reactions',
-  'own_reactions',
-  'reaction_counts',
-  'reply_count',
+  latest_reactions: true,
+  own_reactions: true,
+  reaction_counts: true,
+  reply_count: true,
   // Message text related fields that shouldn't be in update
-  'i18n',
-  'type',
-  'html',
-  '__html',
-] as const;
+  i18n: true,
+  type: true,
+  html: true,
+  __html: true,
+  user: true,
+} as const;
 
-export const LOCAL_MESSAGE_FIELDS = ['error'] as const;
+export const LOCAL_MESSAGE_FIELDS = { error: true } as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ import type {
   CustomUserData,
 } from './custom_types';
 import type { NotificationManager } from './notifications';
+import type { RESERVED_UPDATED_MESSAGE_FIELDS } from './constants';
 
 /**
  * Utility Types
@@ -2945,23 +2946,7 @@ export type TranslationLanguages =
 
 export type TypingStartEvent = Event;
 
-export type ReservedUpdatedMessageFields =
-  | 'command'
-  | 'created_at'
-  | 'deleted_at'
-  | 'html'
-  | 'i18n'
-  | 'latest_reactions'
-  // the the original array of UserResponse object is converted to array of user ids and re-inserted before sending the update request
-  | 'mentioned_users'
-  | 'own_reactions'
-  | 'pinned_at'
-  | 'quoted_message'
-  | 'reaction_counts'
-  | 'reply_count'
-  | 'type'
-  | 'updated_at'
-  | '__html';
+export type ReservedUpdatedMessageFields = keyof typeof RESERVED_UPDATED_MESSAGE_FIELDS;
 
 export type UpdatedMessage = Omit<MessageResponse, ReservedUpdatedMessageFields> & {
   mentioned_users?: string[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -367,14 +367,14 @@ export const localMessageToNewMessagePayload = (localMessage: LocalMessage): Mes
 export const toUpdatedMessagePayload = (
   message: LocalMessage | Partial<MessageResponse>,
 ): UpdatedMessage => {
+  const reservedKeys = {
+    ...RESERVED_UPDATED_MESSAGE_FIELDS,
+    ...LOCAL_MESSAGE_FIELDS,
+  } as const;
+
   const messageFields = Object.fromEntries(
     Object.entries(message).filter(
-      ([key]) =>
-        ![...RESERVED_UPDATED_MESSAGE_FIELDS, ...LOCAL_MESSAGE_FIELDS].includes(
-          key as
-            | (typeof RESERVED_UPDATED_MESSAGE_FIELDS)[number]
-            | (typeof LOCAL_MESSAGE_FIELDS)[number],
-        ),
+      ([key]) => !reservedKeys[key as keyof typeof reservedKeys],
     ),
   ) as UpdatedMessage;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,7 +384,6 @@ export const toUpdatedMessagePayload = (
     mentioned_users: message.mentioned_users?.map((user) =>
       typeof user === 'string' ? user : user.id,
     ),
-    user_id: message.user?.id ?? message.user_id,
   };
 };
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Update fails if the payload contains both `user` object and `user_id`property.

```
StreamChat error code 4: UpdateMessage failed with error: "cannot set both message.user and message.user_id."
```