### PR TITLE
fix: add optional raw queryChannels api response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1743,8 +1743,9 @@ export class StreamChat {
    * @param {ChannelOptions} [options] Options object
    * @param {ChannelStateOptions} [stateOptions] State options object. These options will only be used for state management and won't be sent in the request.
    * - stateOptions.skipInitialization - Skips the initialization of the state for the channels matching the ids in the list.
+   * - stateOptions.skipHydration - Skips returning the channels as instances of the Channel class and rather returns the raw query response.
    *
-   * @return {Promise<{ channels: Array<ChannelAPIResponse>}> } search channels response
+   * @return {Promise<Array<ChannelAPIResponse> | Array<Channel>> } search channels response
    */
   async queryChannels(
     filterConditions: ChannelFilters,
@@ -1784,6 +1785,10 @@ export class StreamChat {
         isLatestMessageSet: true,
       },
     });
+
+    if (stateOptions?.skipHydration) {
+      return data.channels;
+    }
 
     return this.hydrateActiveChannels(data.channels, stateOptions, options);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -968,6 +968,7 @@ export type ChannelQueryOptions = {
 export type ChannelStateOptions = {
   offlineMode?: boolean;
   skipInitialization?: string[];
+  skipHydration?: boolean;
 };
 
 export type CreateChannelOptions = {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -667,7 +667,7 @@ describe('StreamChat.queryChannels', async () => {
 		mock.restore();
 	});
 
-	it('should return the channels response as Channel instances when stateOptions.skipHydration is false', async () => {
+	it('should return hydrated channels as Channel instances from queryChannels', async () => {
 		const client = await getClientWithUser();
 		const mockedChannelsQueryResponse = Array.from({ length: 10 }, () => ({
 			...mockChannelQueryResponse,
@@ -687,7 +687,7 @@ describe('StreamChat.queryChannels', async () => {
 		postStub.restore();
 	});
 
-	it('should return the raw response when stateOptions.skipHydration is true', async () => {
+	it('should return the raw channels response from queryChannelsRequest', async () => {
 		const client = await getClientWithUser();
 		const mockedChannelsQueryResponse = Array.from({ length: 10 }, () => ({
 			...mockChannelQueryResponse,
@@ -699,12 +699,7 @@ describe('StreamChat.queryChannels', async () => {
 		const postStub = sinon
 			.stub(client, 'post')
 			.returns(Promise.resolve({ channels: mockedChannelsQueryResponse }));
-		const queryChannelsResponse = await client.queryChannels(
-			{},
-			{},
-			{},
-			{ skipHydration: true },
-		);
+		const queryChannelsResponse = await client.queryChannelsRequest();
 		expect(queryChannelsResponse.length).to.be.equal(mockedChannelsQueryResponse.length);
 		expect(queryChannelsResponse).to.deep.equal(mockedChannelsQueryResponse);
 		postStub.restore();

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -10,6 +10,8 @@ import { mockChannelQueryResponse } from './test-utils/mockChannelQueryResponse'
 import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from '../../src/constants';
 
 import { describe, beforeEach, it, expect, beforeAll, afterAll } from 'vitest';
+import { Channel } from '../../src';
+import { ChannelAPIResponse } from '../../src';
 
 describe('StreamChat getInstance', () => {
 	beforeEach(() => {
@@ -663,6 +665,49 @@ describe('StreamChat.queryChannels', async () => {
 		expect(Object.keys(client.activeChannels).length).to.be.equal(0);
 		expect(Object.keys(client.configs).length).to.be.equal(0);
 		mock.restore();
+	});
+
+	it('should return the channels response as Channel instances when stateOptions.skipHydration is false', async () => {
+		const client = await getClientWithUser();
+		const mockedChannelsQueryResponse = Array.from({ length: 10 }, () => ({
+			...mockChannelQueryResponse,
+			messages: Array.from(
+				{ length: DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE },
+				generateMsg,
+			),
+		}));
+		const postStub = sinon
+			.stub(client, 'post')
+			.returns(Promise.resolve({ channels: mockedChannelsQueryResponse }));
+		const queryChannelsResponse = await client.queryChannels();
+		expect(queryChannelsResponse.length).to.be.equal(mockedChannelsQueryResponse.length);
+		queryChannelsResponse.forEach((item) => {
+			expect(item).to.be.instanceOf(Channel);
+		});
+		postStub.restore();
+	});
+
+	it('should return the raw response when stateOptions.skipHydration is true', async () => {
+		const client = await getClientWithUser();
+		const mockedChannelsQueryResponse = Array.from({ length: 10 }, () => ({
+			...mockChannelQueryResponse,
+			messages: Array.from(
+				{ length: DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE },
+				generateMsg,
+			),
+		}));
+		const postStub = sinon
+			.stub(client, 'post')
+			.returns(Promise.resolve({ channels: mockedChannelsQueryResponse }));
+		const queryChannelsResponse = await client.queryChannels(
+			{},
+			{},
+			{},
+			{ skipHydration: true },
+		);
+		expect(queryChannelsResponse.length).to.be.equal(mockedChannelsQueryResponse.length);
+		expect(queryChannelsResponse).to.deep.equal(mockedChannelsQueryResponse);
+		postStub.restore();
 	});
 
 	it('should not update pagination for queried message set', async () => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR allows `client.queryChannels` to optionally return the raw response and not run hydration at all (and subsequently not provide an array of `Channel` instances).

It is meant to be used generally server-side so that integrators can have access to other fields not available in a `Channel` instance. It should resolve [this Zendesk ticket](https://getstream.zendesk.com/agent/tickets/64585). 

We can probably keep it the same api if we use discriminated unions, but I feel like it'd complicate things further for no good reason. Keeping the apis separate made sense to me.

## Changelog

-
