### PR TITLE
fix: check for max votes allowed respecting a value from 2-10

### DIFF
--- a/src/messageComposer/middleware/pollComposer/state.ts
+++ b/src/messageComposer/middleware/pollComposer/state.ts
@@ -31,7 +31,7 @@ export const pollStateChangeValidators: Partial<
   max_votes_allowed: ({ data, value }) => {
     if (data.enforce_unique_vote && value)
       return { max_votes_allowed: 'Enforce unique vote is enabled' };
-    if (value?.length > 1 && !value.match(VALID_MAX_VOTES_VALUE_REGEX))
+    if (!value.match(VALID_MAX_VOTES_VALUE_REGEX))
       return { max_votes_allowed: 'Type a number from 2 to 10' };
     return { max_votes_allowed: undefined };
   },


### PR DESCRIPTION
Respect the value of `max_votes_allowed` to be in the range 2-10. Right now, if you type 1, the `error` didn't complain.