### PR TITLE
fix: allow to compose non-empty message from draft without local edits

### DIFF
--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -28,7 +28,7 @@ export const createCompositionValidationMiddleware = (
       const hasExceededMaxLength =
         typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend;
 
-      if (isEmptyMessage || !composer.lastChangeOriginIsLocal || hasExceededMaxLength) {
+      if (isEmptyMessage || hasExceededMaxLength) {
         return await discard();
       }
 

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -28,7 +28,10 @@ export const createCompositionValidationMiddleware = (
       const hasExceededMaxLength =
         typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend;
 
-      if (isEmptyMessage || hasExceededMaxLength) {
+      const editedMessageIsUnchanged =
+        composer.editedMessage && !composer.lastChangeOriginIsLocal;
+
+      if (isEmptyMessage || editedMessageIsUnchanged || hasExceededMaxLength) {
         return await discard();
       }
 

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -313,39 +313,6 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
 
     expect(result.status).toBeUndefined;
   });
-
-  it('should validate message with last origin change', async () => {
-    vi.spyOn(messageComposer, 'lastChangeOriginIsLocal', 'get').mockReturnValue(false);
-
-    const result = await validationMiddleware.handlers.compose(
-      setup({
-        message: {
-          id: 'test-id',
-          parent_id: undefined,
-          text: 'Hello world',
-          type: 'regular',
-        },
-        localMessage: {
-          attachments: [],
-          created_at: new Date(),
-          deleted_at: null,
-          error: undefined,
-          id: 'test-id',
-          mentioned_users: [],
-          parent_id: undefined,
-          pinned_at: null,
-          reaction_groups: null,
-          status: 'sending',
-          text: 'Hello world',
-          type: 'regular',
-          updated_at: new Date(),
-        },
-        sendOptions: {},
-      }),
-    );
-
-    expect(result.status).toBe('discard');
-  });
 });
 
 describe('stream-io/message-composer-middleware/draft-data-validation', () => {


### PR DESCRIPTION
## Explanation

Loading UI with empty message composition, then creating draft (type text, leave to another channel and get back) and trying to send the message would prevent message from being sent. The reason was that the composition workflow validation required at least one local edit.

Closes REACT-383
