### PR TITLE
feat: add taking state snapshots to MessageComposer

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -33,6 +33,10 @@ export type EditingAuditState = {
   lastChange: LastComposerChange;
 };
 
+export type MessageComposerStateSnapshot = {
+  restore(): void;
+};
+
 export type LocalMessageWithLegacyThreadId = LocalMessage & { legacyThreadId?: string };
 export type CompositionContext = Channel | Thread | LocalMessageWithLegacyThreadId;
 
@@ -336,6 +340,26 @@ export class MessageComposer {
   initEditingAuditState = (
     composition?: DraftResponse | MessageResponse | LocalMessage,
   ) => initEditingAuditState(composition);
+
+  takeStateSnapshot = (): MessageComposerStateSnapshot => {
+    const textComposerState = this.textComposer.state.getLatestValue();
+    const attachmentManagerState = this.attachmentManager.state.getLatestValue();
+    const linkPreviewsManagerState = this.linkPreviewsManager.state.getLatestValue();
+    const pollComposerState = this.pollComposer.state.getLatestValue();
+    const customDataManagerState = this.customDataManager.state.getLatestValue();
+    const state = this.state.getLatestValue();
+
+    return {
+      restore: () => {
+        this.state.next(state);
+        this.textComposer.state.next(textComposerState);
+        this.attachmentManager.state.next(attachmentManagerState);
+        this.linkPreviewsManager.state.next(linkPreviewsManagerState);
+        this.pollComposer.state.next(pollComposerState);
+        this.customDataManager.state.next(customDataManagerState);
+      },
+    };
+  };
 
   private logStateUpdateTimestamp() {
     this.editingAuditState.partialNext({

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -29,14 +29,14 @@ vi.mock('../../../src/utils', () => ({
   throttle: vi.fn().mockImplementation((fn) => fn),
 }));
 
-vi.mock('../../../src/messageComposer/attachmentManager', () => ({
-  AttachmentManager: vi.fn().mockImplementation(() => ({
-    state: new StateStore({ attachments: [] }),
-    initState: vi.fn(),
-    clear: vi.fn(),
-    attachments: [],
-  })),
-}));
+// vi.mock('../../../src/messageComposer/attachmentManager', () => ({
+//   AttachmentManager: vi.fn().mockImplementation(() => ({
+//     state: new StateStore({ attachments: [] }),
+//     initState: vi.fn(),
+//     clear: vi.fn(),
+//     attachments: [],
+//   })),
+// }));
 
 vi.mock('../../../src/messageComposer/pollComposer', () => ({
   PollComposer: vi.fn().mockImplementation(() => ({
@@ -404,6 +404,39 @@ describe('MessageComposer', () => {
         quotedMessage: null,
         draftId: null,
       });
+    });
+
+    it('should take state snapshot and restore it', () => {
+      const composition = {
+        id: 'test-message-id',
+        text: 'Hello world @xx',
+        attachments: [{ id: 'x' }],
+        mentioned_users: [{ id: 'xx', name: 'xx' }],
+      };
+
+      const { messageComposer } = setup({ composition });
+      const snapshot = messageComposer.takeStateSnapshot();
+      expect(messageComposer.textComposer.text).toBe(composition.text);
+      expect(messageComposer.textComposer.mentionedUsers).toEqual(
+        composition.mentioned_users,
+      );
+      expect(messageComposer.attachmentManager.attachments[0].id).toBe(
+        composition.attachments[0].id,
+      );
+      expect(messageComposer.attachmentManager.attachments).toHaveLength(1);
+      messageComposer.clear();
+      expect(messageComposer.textComposer.text).toBe('');
+      expect(messageComposer.textComposer.mentionedUsers).toEqual([]);
+      expect(messageComposer.attachmentManager.attachments).toEqual([]);
+      snapshot.restore();
+      expect(messageComposer.textComposer.text).toBe(composition.text);
+      expect(messageComposer.textComposer.mentionedUsers).toEqual(
+        composition.mentioned_users,
+      );
+      expect(messageComposer.attachmentManager.attachments[0].id).toBe(
+        composition.attachments[0].id,
+      );
+      expect(messageComposer.attachmentManager.attachments).toHaveLength(1);
     });
 
     it('should initialize editing audit state', () => {


### PR DESCRIPTION
## Goal

Allow to take state snapshots in order to be able to restore the state in the future. The logic of taking snapshot is encapsulated as we may want to change it in the future. The only important part of the contract is that the method returns an object with property `restore` that allows us to restore the state to the given snapshot. We do not care how the snapshot looks like.
