### PR TITLE
fix: upsert attachmemts only when attachment exist and handle FileList for react native

### DIFF
--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -182,32 +182,53 @@ export class AttachmentManager {
         attachment.localMetadata.id && localId === attachment.localMetadata?.id,
     );
 
-  upsertAttachments = (attachmentsToUpsert: LocalAttachment[]) => {
-    if (!attachmentsToUpsert.length) return;
+  private prepareAttachmentUpdate = (attachmentToUpdate: LocalAttachment) => {
     const stateAttachments = this.attachments;
     const attachments = [...this.attachments];
-    attachmentsToUpsert.forEach((upsertedAttachment) => {
-      const attachmentIndex = this.getAttachmentIndex(
-        upsertedAttachment.localMetadata.id,
-      );
+    const attachmentIndex = this.getAttachmentIndex(attachmentToUpdate.localMetadata.id);
+    if (attachmentIndex === -1) return null;
+    const merged = mergeWithDiff<LocalAttachment>(
+      stateAttachments[attachmentIndex] ?? {},
+      attachmentToUpdate,
+    );
+    const updatesOnMerge = merged.diff && Object.keys(merged.diff.children).length;
+    if (updatesOnMerge) {
+      const localAttachment = ensureIsLocalAttachment(merged.result);
+      if (localAttachment) {
+        attachments.splice(attachmentIndex, 1, localAttachment);
+        return attachments;
+      }
+    }
+    return null;
+  };
 
-      if (attachmentIndex === -1) {
-        const localAttachment = ensureIsLocalAttachment(upsertedAttachment);
-        if (localAttachment) attachments.push(localAttachment);
+  updateAttachment = (attachmentToUpdate: LocalAttachment) => {
+    const updatedAttachments = this.prepareAttachmentUpdate(attachmentToUpdate);
+    if (updatedAttachments) {
+      this.state.partialNext({ attachments: updatedAttachments });
+    }
+  };
+
+  upsertAttachments = (attachmentsToUpsert: LocalAttachment[]) => {
+    if (!attachmentsToUpsert.length) return;
+    let attachments = [...this.attachments];
+    let hasUpdates = false;
+    attachmentsToUpsert.forEach((attachment) => {
+      const updatedAttachments = this.prepareAttachmentUpdate(attachment);
+      if (updatedAttachments) {
+        attachments = updatedAttachments;
+        hasUpdates = true;
       } else {
-        const merged = mergeWithDiff<LocalAttachment>(
-          stateAttachments[attachmentIndex] ?? {},
-          upsertedAttachment,
-        );
-        const updatesOnMerge = merged.diff && Object.keys(merged.diff.children).length;
-        if (updatesOnMerge) {
-          const localAttachment = ensureIsLocalAttachment(merged.result);
-          if (localAttachment) attachments.splice(attachmentIndex, 1, localAttachment);
+        const localAttachment = ensureIsLocalAttachment(attachment);
+        if (localAttachment) {
+          attachments.push(localAttachment);
+          hasUpdates = true;
         }
       }
     });
-
-    this.state.partialNext({ attachments });
+    if (hasUpdates) {
+      this.state.partialNext({ attachments });
+    }
   };
 
   removeAttachments = (localAttachmentIds: string[]) => {
@@ -448,11 +469,7 @@ export class AttachmentManager {
         },
       };
 
-      const isAttachmentPresent =
-        this.getAttachmentIndex(failedAttachment.localMetadata.id) !== -1;
-      if (isAttachmentPresent) {
-        this.upsertAttachments([failedAttachment]);
-      }
+      this.updateAttachment(failedAttachment);
       return failedAttachment;
     }
 
@@ -486,12 +503,7 @@ export class AttachmentManager {
       (uploadedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
     }
 
-    const isAttachmentPresent =
-      this.getAttachmentIndex(uploadedAttachment.localMetadata.id) !== -1;
-
-    if (isAttachmentPresent) {
-      this.upsertAttachments([uploadedAttachment]);
-    }
+    this.updateAttachment(uploadedAttachment);
 
     return uploadedAttachment;
   };

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -448,7 +448,12 @@ export class AttachmentManager {
         },
       };
 
-      this.upsertAttachments([failedAttachment]);
+      const isAttachmentPresent = this.getAttachmentIndex(
+        failedAttachment.localMetadata.id,
+      );
+      if (isAttachmentPresent !== -1) {
+        this.upsertAttachments([failedAttachment]);
+      }
       return failedAttachment;
     }
 
@@ -482,11 +487,11 @@ export class AttachmentManager {
       (uploadedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
     }
 
-    if (
-      this.attachments.some(
-        (att) => att.localMetadata.id === uploadedAttachment.localMetadata.id,
-      )
-    ) {
+    const isAttachmentPresent = this.getAttachmentIndex(
+      uploadedAttachment.localMetadata.id,
+    );
+
+    if (isAttachmentPresent !== -1) {
       this.upsertAttachments([uploadedAttachment]);
     }
 

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -482,7 +482,13 @@ export class AttachmentManager {
       (uploadedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
     }
 
-    this.upsertAttachments([uploadedAttachment]);
+    if (
+      this.attachments.some(
+        (att) => att.localMetadata.id === uploadedAttachment.localMetadata.id,
+      )
+    ) {
+      this.upsertAttachments([uploadedAttachment]);
+    }
 
     return uploadedAttachment;
   };

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -448,10 +448,9 @@ export class AttachmentManager {
         },
       };
 
-      const isAttachmentPresent = this.getAttachmentIndex(
-        failedAttachment.localMetadata.id,
-      );
-      if (isAttachmentPresent !== -1) {
+      const isAttachmentPresent =
+        this.getAttachmentIndex(failedAttachment.localMetadata.id) !== -1;
+      if (isAttachmentPresent) {
         this.upsertAttachments([failedAttachment]);
       }
       return failedAttachment;
@@ -487,11 +486,10 @@ export class AttachmentManager {
       (uploadedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
     }
 
-    const isAttachmentPresent = this.getAttachmentIndex(
-      uploadedAttachment.localMetadata.id,
-    );
+    const isAttachmentPresent =
+      this.getAttachmentIndex(uploadedAttachment.localMetadata.id) !== -1;
 
-    if (isAttachmentPresent !== -1) {
+    if (isAttachmentPresent) {
       this.upsertAttachments([uploadedAttachment]);
     }
 

--- a/src/messageComposer/fileUtils.ts
+++ b/src/messageComposer/fileUtils.ts
@@ -16,7 +16,7 @@ export const isFileList = (obj: unknown): obj is FileList => {
   if (typeof obj !== 'object') return false;
 
   return (
-    (obj as object) instanceof FileList ||
+    (typeof FileList !== 'undefined' && (obj as object) instanceof FileList) ||
     ('item' in obj && 'length' in obj && !Array.isArray(obj))
   );
 };

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -503,6 +503,57 @@ describe('AttachmentManager', () => {
     });
   });
 
+  describe('updateAttachment', () => {
+    it('should update an attachment by id', () => {
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+
+      const newAttachments = [
+        { localMetadata: { id: 'test-id-1' }, type: 'image' },
+        { localMetadata: { id: 'test-id-2' }, type: 'video' },
+      ];
+
+      attachmentManager.upsertAttachments(newAttachments);
+
+      const updatedAttachment = {
+        id: 'test-id-1',
+        localMetadata: { id: 'test-id-1' },
+        type: 'audio',
+      };
+
+      attachmentManager.updateAttachment(updatedAttachment);
+
+      expect(attachmentManager.attachments).toEqual([
+        updatedAttachment,
+        newAttachments[1],
+      ]);
+    });
+
+    it('should not update an attachment if id is not found', () => {
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+
+      const newAttachments = [
+        { localMetadata: { id: 'test-id-1' }, type: 'image' },
+        { localMetadata: { id: 'test-id-2' }, type: 'video' },
+      ];
+
+      attachmentManager.upsertAttachments(newAttachments);
+
+      const updatedAttachment = {
+        id: 'non-existent-id',
+        localMetadata: { id: 'non-existent-id' },
+        type: 'audio',
+      };
+
+      attachmentManager.updateAttachment(updatedAttachment);
+
+      expect(attachmentManager.attachments).toEqual(newAttachments);
+    });
+  });
+
   describe('removeAttachments', () => {
     it('should remove attachments by id', () => {
       const {


### PR DESCRIPTION
The goal of the PR is to upsert attachments only when they exist. This is especially important because on React Native, we allow cancelling uploading by calling removeAttachments, but when the upload still happens, the upsert proceeds. We will only update you if the attachment is present.

The other fix is that the `FileList` is not supported on RN. Thanks to @MartinCupela for a prompt suggestion on this issue.