### PR TITLE
feat: add toJSON to ErrorFromResponse class

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3218,6 +3218,7 @@ export class ErrorFromResponse<T> extends Error {
   public code: number | null;
   public status: number;
   public response: AxiosResponse<T>;
+  public name = 'ErrorFromResponse';
 
   constructor(
     message: string,
@@ -3235,6 +3236,29 @@ export class ErrorFromResponse<T> extends Error {
     this.code = code;
     this.response = response;
     this.status = status;
+  }
+
+  // Vitest helper (serialized errors are too large to read)
+  // https://github.com/vitest-dev/vitest/blob/v3.1.3/packages/utils/src/error.ts#L60-L62
+  toJSON() {
+    const extra = [
+      ['status', this.status],
+      ['code', this.code],
+    ] as const;
+
+    const joinable = [];
+
+    for (const [key, value] of extra) {
+      if (typeof value !== 'undefined' && value !== null) {
+        joinable.push(`${key}: ${value}`);
+      }
+    }
+
+    return {
+      message: `(${joinable.join(', ')}) - ${this.message}`,
+      stack: this.stack,
+      name: this.name,
+    };
   }
 }
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Vitest [serializes errors](https://github.com/vitest-dev/vitest/blob/v3.1.3/packages/utils/src/error.ts#L60-L62) and our error instance keeps a ton of data (from Axios) which - when serialized - pollutes test logs with unreadable messages (before):

![image](https://github.com/user-attachments/assets/254b00dc-cac6-40e6-8511-bcbe201c3db2)
(it's way longer, see scrollbar)

after:
![image](https://github.com/user-attachments/assets/bb8460f2-9b09-416a-8491-590fd8870608)


This needs to be copied over to video SDK as well.
