### PR TITLE
chore: fix MessageComposer.registerSubscriptions

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -372,7 +372,7 @@ export class MessageComposer extends WithSubscriptions {
     this.addUnsubscribeFunction(this.subscribeMessageComposerStateChanged());
     this.addUnsubscribeFunction(this.subscribeMessageComposerConfigStateChanged());
 
-    return this.unregisterSubscriptions;
+    return this.unregisterSubscriptions.bind(this);
   };
 
   private subscribeMessageUpdated = () => {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Newly introduced helper `WithSubscriptions` abstract class provides a pre-defined `unregisterSubscriptions` method which needs to be in this form (not arrow function) for devs to be able to use it with `super` keyword. This obviously means that `this` has to be bound to it when used as standalone function as `this` means something else entirely when it's not attached to an object (or attached to a different object). Rookie mistake, my apologies. Thank you @khushal87 for spotting this issue.

Marked as `chore` as to not pollute changelog with unreleased broken stuff.