### PR TITLE
fix: override target scalar, null and undefined values with mergeWith

### DIFF
--- a/src/utils/mergeWith/mergeWithCore.ts
+++ b/src/utils/mergeWith/mergeWithCore.ts
@@ -438,7 +438,13 @@ export function createMergeCore<T extends object>(options: { trackDiff?: boolean
       return false;
     }
 
-    function createNewTarget(targetValue: unknown, srcValue: unknown): object {
+    function createNewTarget(targetValue: unknown, srcValue: object): object {
+      if (targetValue === null || typeof targetValue === 'undefined') {
+        return srcValue;
+      }
+      if (!Array.isArray(targetValue) && typeof targetValue !== 'object') {
+        return srcValue;
+      }
       if (targetValue && typeof targetValue === 'object') {
         // Check if it's a class instance (not a plain object)
         const isTargetClassInstance = isClassInstance(targetValue);

--- a/test/unit/utils/mergeWith.test.ts
+++ b/test/unit/utils/mergeWith.test.ts
@@ -318,6 +318,20 @@ describe('mergeWith', () => {
     expect(result.file.type).toBe('text/plain');
   });
 
+  it('should override the target scalar with source object', () => {
+    const source = { name: 'source.txt', content: 'source content' };
+    expect(mergeWith({ a: 1 }, { a: source }).a).toEqual(source);
+    expect(mergeWith({ a: '1' }, { a: source }).a).toEqual(source);
+    expect(mergeWith({ a: true }, { a: source }).a).toEqual(source);
+    expect(mergeWith({ a: false }, { a: source }).a).toEqual(source);
+  });
+
+  it('should override the target null or undefined with source object', () => {
+    const source = { name: 'source.txt', content: 'source content' };
+    expect(mergeWith({ a: null }, { a: source }).a).toEqual(source);
+    expect(mergeWith({ a: undefined }, { a: source }).a).toEqual(source);
+  });
+
   it('should use source class instance when target is a plain object', () => {
     // Create File instance and plain object
     const sourceFile = new File(['source content'], 'source.txt', { type: 'text/html' });


### PR DESCRIPTION
## Goal

Closes REACT-402

Trying to merge objects from source to undefined, null or scalar target lead to infinite loop in mergeWith util. Breaks initiation of middleware that allows for custom searchSource 
