### PR TITLE
fix: broken api return values and types

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -207,7 +207,7 @@ export class Channel {
       if (offlineDb) {
         const messageId = message.id;
         if (messageId) {
-          return (await offlineDb.queueTask({
+          return await offlineDb.queueTask<SendMessageAPIResponse>({
             task: {
               channelId: this.id as string,
               channelType: this.type,
@@ -215,7 +215,7 @@ export class Channel {
               payload: [message, options],
               type: 'send-message',
             },
-          })) as SendMessageAPIResponse;
+          });
         }
       }
     } catch (error) {
@@ -410,7 +410,7 @@ export class Channel {
     messageID: string,
     reaction: Reaction,
     options?: { enforce_unique?: boolean; skip_push?: boolean },
-  ): Promise<ReactionAPIResponse | undefined> {
+  ) {
     if (!messageID) {
       throw Error(`Message id is missing`);
     }
@@ -454,7 +454,7 @@ export class Channel {
     messageID: string,
     reaction: Reaction,
     options?: { enforce_unique?: boolean; skip_push?: boolean },
-  ): Promise<ReactionAPIResponse | undefined> {
+  ) {
     if (!messageID) {
       throw Error(`Message id is missing`);
     }
@@ -498,7 +498,7 @@ export class Channel {
           });
         }
 
-        return await offlineDb.queueTask({
+        return await offlineDb.queueTask<ReactionAPIResponse>({
           task: {
             channelId: this.id as string,
             channelType: this.type,

--- a/src/client.ts
+++ b/src/client.ts
@@ -3036,13 +3036,15 @@ export class StreamChat {
         } else {
           await this.offlineDb.softDeleteMessage({ id: messageID });
         }
-        return await this.offlineDb.queueTask({
-          task: {
-            messageId: messageID,
-            payload: [messageID, hardDelete],
-            type: 'delete-message',
+        return await this.offlineDb.queueTask<APIResponse & { message: MessageResponse }>(
+          {
+            task: {
+              messageId: messageID,
+              payload: [messageID, hardDelete],
+              type: 'delete-message',
+            },
           },
-        });
+        );
       }
     } catch (error) {
       this.logger('error', `offlineDb:deleteMessage`, {

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -6,7 +6,6 @@ import type {
   ChannelResponse,
   ChannelSort,
   LocalMessage,
-  Message,
   MessageResponse,
   PollResponse,
   ReactionFilters,
@@ -398,6 +397,31 @@ export type PendingTask = {
     }
 );
 
-export type PendingTaskExtraData = {
-  message?: Message;
-};
+export type OfflineErrorType = 'connection:lost';
+
+export class OfflineError extends Error {
+  public type: OfflineErrorType;
+  public name = 'OfflineError';
+
+  constructor(
+    message: string,
+    {
+      type,
+    }: {
+      type: OfflineError['type'];
+    },
+  ) {
+    super(message);
+    this.type = type;
+  }
+
+  // Vitest helper (serialized errors are too large to read)
+  // https://github.com/vitest-dev/vitest/blob/v3.1.3/packages/utils/src/error.ts#L60-L62
+  toJSON() {
+    return {
+      message: `${this.type} - ${this.message}`,
+      stack: this.stack,
+      name: this.name,
+    };
+  }
+}


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Unfortunately, with the latest offline support rework the types of all queueable actions were broken to be `T | undefined` instead of `T`. 

This PR addresses that, by forcing `queueTask` to throw if execution fails just like any of our HTTP apis would.

## Changelog

-
