### PR TITLE
fix: add status and code to object returned from ErrorFromResponse.toJSON

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3261,7 +3261,9 @@ export class ErrorFromResponse<T> extends Error {
       message: `(${joinable.join(', ')}) - ${this.message}`,
       stack: this.stack,
       name: this.name,
-    };
+      code: this.code,
+      status: this.status,
+    } as const;
   }
 }
 


### PR DESCRIPTION
React SDK is missing `code` property which it tries to access from serialized `ErrorFromResponse` object:

![image](https://github.com/user-attachments/assets/ed2d1c30-b313-4a26-bb14-ce3d5660ceb3)

`JSON.stringify` internally calls `toJSON` on objects which provide such method.
