### PR TITLE
fix: attach original token provider error as cause to loadToken rejection

### DIFF
--- a/src/token_manager.ts
+++ b/src/token_manager.ts
@@ -126,7 +126,9 @@ export class TokenManager {
         try {
           this.token = await this.tokenProvider();
         } catch (e) {
-          return reject(new Error(`Call to tokenProvider failed with message: ${e}`));
+          return reject(
+            new Error(`Call to tokenProvider failed with message: ${e}`, { cause: e }),
+          );
         }
         resolve(this.token);
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     "emitDeclarationOnly": true,
     "outDir": "./dist/types",
 
-    "lib": ["ES2020", "DOM"],
+    "lib": ["ES2020", "DOM", "ES2022.Error"],
     "moduleResolution": "bundler",
     "module": "Preserve",
     "target": "ES2020"


### PR DESCRIPTION
## Description of the changes, What, Why and How?

This is a backport of https://github.com/GetStream/stream-video-js/pull/1812 - see there for details.

## Changelog

- Errors (rejections) thrown from `client.connectUser()` will have `cause` attached in some cases with an original error that caused token to fail to load.
