### PR TITLE
feat: introduce sync search

### DIFF
--- a/src/messageComposer/middleware/textComposer/commands.ts
+++ b/src/messageComposer/middleware/textComposer/commands.ts
@@ -1,14 +1,14 @@
 import type { Channel } from '../../../channel';
 import type { Middleware } from '../../../middleware';
 import type { SearchSourceOptions } from '../../../search';
-import { BaseSearchSource } from '../../../search';
+import { BaseSearchSourceSync } from '../../../search';
 import type { CommandResponse } from '../../../types';
 import { mergeWith } from '../../../utils/mergeWith';
 import type { CommandSuggestion, TextComposerMiddlewareOptions } from './types';
 import { getTriggerCharWithToken, insertItemWithTrigger } from './textMiddlewareUtils';
 import type { TextComposerMiddlewareExecutorState } from './TextComposerMiddlewareExecutor';
 
-export class CommandSearchSource extends BaseSearchSource<CommandSuggestion> {
+export class CommandSearchSource extends BaseSearchSourceSync<CommandSuggestion> {
   readonly type = 'commands';
   private channel: Channel;
 
@@ -70,27 +70,13 @@ export class CommandSearchSource extends BaseSearchSource<CommandSuggestion> {
 
   query(searchQuery: string) {
     const commands = this.searchCommands(searchQuery);
-    return Promise.resolve({
-      items: commands.map((c) => ({ ...c, id: c.name })),
-      next: null,
-    });
-  }
-
-  protected filterQueryResults(
-    items: CommandSuggestion[],
-  ): CommandSuggestion[] | Promise<CommandSuggestion[]> {
-    return items;
-  }
-
-  querySync(searchQuery: string) {
-    const commands = this.searchCommands(searchQuery);
     return {
       items: commands.map((c) => ({ ...c, id: c.name })),
       next: null,
     };
   }
 
-  protected filterQueryResultsSync(items: CommandSuggestion[]) {
+  protected filterQueryResults(items: CommandSuggestion[]) {
     return items;
   }
 }
@@ -143,7 +129,8 @@ export const createCommandsMiddleware = (
         });
 
         const inputText = triggerWithToken?.slice(1).toLowerCase() ?? '';
-        const commands = searchSource.querySync(inputText).items;
+        const commands = searchSource.query(inputText).items;
+
         console.log(commands);
 
         const newSearchTriggerred =

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -3,8 +3,7 @@ import {
   getTriggerCharWithToken,
   insertItemWithTrigger,
 } from './textMiddlewareUtils';
-import type { SearchSourceOptions } from '../../../search';
-import { BaseSearchSource } from '../../../search';
+import { BaseSearchSource, type SearchSourceOptions } from '../../../search';
 import { mergeWith } from '../../../utils/mergeWith';
 import type { TextComposerMiddlewareOptions, UserSuggestion } from './types';
 import type { StreamChat } from '../../../client';

--- a/src/messageComposer/middleware/textComposer/types.ts
+++ b/src/messageComposer/middleware/textComposer/types.ts
@@ -1,7 +1,7 @@
 import type { MessageComposer } from '../../messageComposer';
 import type { CommandResponse, UserResponse } from '../../../types';
 import type { TokenizationPayload } from './textMiddlewareUtils';
-import type { SearchSource } from '../../../search';
+import type { SearchSource, SearchSourceSync } from '../../../search';
 import type { CustomTextComposerSuggestion } from '../../types.custom';
 
 export type TextComposerSuggestion<T = unknown> = T & {
@@ -28,7 +28,7 @@ export type TextComposerMiddlewareExecutorOptions = {
 
 export type Suggestions<T extends Suggestion = Suggestion> = {
   query: string;
-  searchSource: SearchSource<T>;
+  searchSource: SearchSource<T> | SearchSourceSync<T>;
   trigger: string;
 };
 

--- a/src/search/BaseSearchSource.ts
+++ b/src/search/BaseSearchSource.ts
@@ -1,18 +1,20 @@
 import { StateStore } from '../store';
 import { debounce, type DebouncedFunc } from '../utils';
+import type {
+  QueryReturnValue,
+  SearchSourceOptions,
+  SearchSourceState,
+  SearchSourceType,
+} from './types';
 
-export type SearchSourceType = 'channels' | 'users' | 'messages' | (string & {});
-export type QueryReturnValue<T> = { items: T[]; next?: string | null };
 export type DebounceOptions = {
   debounceMs: number;
 };
 type DebouncedExecQueryFunction = DebouncedFunc<(searchString?: string) => Promise<void>>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface SearchSource<T = any> {
+interface ISearchSource<T = any> {
   activate(): void;
-
-  cancelScheduledQuery(): void;
 
   canExecuteQuery(newSearchString?: string): boolean;
 
@@ -30,49 +32,40 @@ export interface SearchSource<T = any> {
 
   resetState(): void;
 
-  search(text?: string): Promise<void> | undefined;
-  searchSync(text?: string): void;
-
   readonly searchQuery: string;
-
-  setDebounceOptions(options: DebounceOptions): void;
 
   readonly state: StateStore<SearchSourceState<T>>;
   readonly type: SearchSourceType;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SearchSourceState<T = any> = {
-  hasNext: boolean;
-  isActive: boolean;
-  isLoading: boolean;
-  items: T[] | undefined;
-  searchQuery: string;
-  lastQueryError?: Error;
-  next?: string | null;
-  offset?: number;
-};
-export type SearchSourceOptions = {
-  /** The number of milliseconds to debounce the search query. The default interval is 300ms. */
-  debounceMs?: number;
-  pageSize?: number;
-};
+export interface SearchSource<T = any> extends ISearchSource<T> {
+  cancelScheduledQuery(): void;
+  setDebounceOptions(options: DebounceOptions): void;
+  search(text?: string): Promise<void> | undefined;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface SearchSourceSync<T = any> extends ISearchSource<T> {
+  cancelScheduledQuery(): void;
+  setDebounceOptions(options: DebounceOptions): void;
+  search(text?: string): void;
+}
+
 const DEFAULT_SEARCH_SOURCE_OPTIONS: Required<SearchSourceOptions> = {
   debounceMs: 300,
   pageSize: 10,
 } as const;
 
-export abstract class BaseSearchSource<T> implements SearchSource<T> {
+abstract class BaseSearchSourceBase<T> implements ISearchSource<T> {
   state: StateStore<SearchSourceState<T>>;
   protected pageSize: number;
   abstract readonly type: SearchSourceType;
-  protected searchDebounced!: DebouncedExecQueryFunction;
 
   protected constructor(options?: SearchSourceOptions) {
-    const { debounceMs, pageSize } = { ...DEFAULT_SEARCH_SOURCE_OPTIONS, ...options };
+    const { pageSize } = { ...DEFAULT_SEARCH_SOURCE_OPTIONS, ...options };
     this.pageSize = pageSize;
     this.state = new StateStore<SearchSourceState<T>>(this.initialState);
-    this.setDebounceOptions({ debounceMs });
   }
 
   get lastQueryError() {
@@ -124,18 +117,6 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
     return this.state.getLatestValue().searchQuery;
   }
 
-  protected abstract query(searchQuery: string): Promise<QueryReturnValue<T>>;
-
-  protected abstract filterQueryResults(items: T[]): T[] | Promise<T[]>;
-
-  protected abstract querySync(searchQuery: string): QueryReturnValue<T>;
-
-  protected abstract filterQueryResultsSync(items: T[]): T[];
-
-  setDebounceOptions = ({ debounceMs }: DebounceOptions) => {
-    this.searchDebounced = debounce(this.executeQuery.bind(this), debounceMs);
-  };
-
   activate = () => {
     if (this.isActive) return;
     this.state.partialNext({ isActive: true });
@@ -182,6 +163,36 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
     };
   }
 
+  resetState() {
+    this.state.next(this.initialState);
+  }
+
+  resetStateAndActivate() {
+    this.resetState();
+    this.activate();
+  }
+}
+
+export abstract class BaseSearchSource<T>
+  extends BaseSearchSourceBase<T>
+  implements SearchSource<T>
+{
+  protected searchDebounced!: DebouncedExecQueryFunction;
+
+  constructor(options?: SearchSourceOptions) {
+    const { debounceMs } = { ...DEFAULT_SEARCH_SOURCE_OPTIONS, ...options };
+    super(options);
+    this.setDebounceOptions({ debounceMs });
+  }
+
+  protected abstract query(searchQuery: string): Promise<QueryReturnValue<T>>;
+
+  protected abstract filterQueryResults(items: T[]): T[] | Promise<T[]>;
+
+  setDebounceOptions = ({ debounceMs }: DebounceOptions) => {
+    this.searchDebounced = debounce(this.executeQuery.bind(this), debounceMs);
+  };
+
   async executeQuery(newSearchString?: string) {
     if (!this.canExecuteQuery(newSearchString)) return;
     const hasNewSearchQuery = typeof newSearchString !== 'undefined';
@@ -215,7 +226,34 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
     }
   }
 
-  executeQuerySync = (newSearchString?: string) => {
+  search = (searchQuery?: string) => this.searchDebounced(searchQuery);
+
+  cancelScheduledQuery() {
+    this.searchDebounced.cancel();
+  }
+}
+
+export abstract class BaseSearchSourceSync<T>
+  extends BaseSearchSourceBase<T>
+  implements SearchSourceSync<T>
+{
+  protected searchDebounced!: DebouncedExecQueryFunction;
+
+  constructor(options?: SearchSourceOptions) {
+    const { debounceMs } = { ...DEFAULT_SEARCH_SOURCE_OPTIONS, ...options };
+    super(options);
+    this.setDebounceOptions({ debounceMs });
+  }
+
+  protected abstract query(searchQuery: string): QueryReturnValue<T>;
+
+  protected abstract filterQueryResults(items: T[]): T[];
+
+  setDebounceOptions = ({ debounceMs }: DebounceOptions) => {
+    this.searchDebounced = debounce(this.executeQuery.bind(this), debounceMs);
+  };
+
+  executeQuery(newSearchString?: string) {
     if (!this.canExecuteQuery(newSearchString)) return;
     const hasNewSearchQuery = typeof newSearchString !== 'undefined';
     const searchString = newSearchString ?? this.searchQuery;
@@ -228,7 +266,7 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
 
     const stateUpdate: Partial<SearchSourceState<T>> = {};
     try {
-      const results = this.querySync(searchString);
+      const results = this.query(searchString);
       if (!results) return;
       const { items, next } = results;
 
@@ -240,28 +278,17 @@ export abstract class BaseSearchSource<T> implements SearchSource<T> {
         stateUpdate.hasNext = items.length === this.pageSize;
       }
 
-      stateUpdate.items = this.filterQueryResultsSync(items);
+      stateUpdate.items = this.filterQueryResults(items);
     } catch (e) {
       stateUpdate.lastQueryError = e as Error;
     } finally {
       this.state.next(this.getStateAfterQuery(stateUpdate, hasNewSearchQuery));
     }
-  };
-
-  searchSync = (searchQuery?: string) => this.executeQuerySync(searchQuery);
+  }
 
   search = (searchQuery?: string) => this.searchDebounced(searchQuery);
 
   cancelScheduledQuery() {
     this.searchDebounced.cancel();
-  }
-
-  resetState() {
-    this.state.next(this.initialState);
-  }
-
-  resetStateAndActivate() {
-    this.resetState();
-    this.activate();
   }
 }

--- a/src/search/ChannelSearchSource.ts
+++ b/src/search/ChannelSearchSource.ts
@@ -1,8 +1,8 @@
 import { BaseSearchSource } from './BaseSearchSource';
-import type { SearchSourceOptions } from './BaseSearchSource';
 import type { Channel } from '../channel';
 import type { StreamChat } from '../client';
 import type { ChannelFilters, ChannelOptions, ChannelSort } from '../types';
+import type { SearchSourceOptions } from './types';
 
 export class ChannelSearchSource extends BaseSearchSource<Channel> {
   readonly type = 'channels';

--- a/src/search/MessageSearchSource.ts
+++ b/src/search/MessageSearchSource.ts
@@ -1,5 +1,4 @@
 import { BaseSearchSource } from './BaseSearchSource';
-import type { SearchSourceOptions } from './BaseSearchSource';
 import type {
   ChannelFilters,
   ChannelOptions,
@@ -10,6 +9,7 @@ import type {
   SearchOptions,
 } from '../types';
 import type { StreamChat } from '../client';
+import type { SearchSourceOptions } from './types';
 
 export class MessageSearchSource extends BaseSearchSource<MessageResponse> {
   readonly type = 'messages';

--- a/src/search/SearchController.ts
+++ b/src/search/SearchController.ts
@@ -122,14 +122,6 @@ export class SearchController {
     await Promise.all(searchedSources.map((source) => source.search(searchQuery)));
   };
 
-  searchSync = (searchQuery?: string) => {
-    const searchedSources = this.activeSources;
-    this.state.partialNext({
-      searchQuery,
-    });
-    searchedSources.map((source) => source.searchSync(searchQuery));
-  };
-
   cancelSearchQueries = () => {
     this.activeSources.forEach((s) => s.cancelScheduledQuery());
   };

--- a/src/search/SearchController.ts
+++ b/src/search/SearchController.ts
@@ -122,6 +122,14 @@ export class SearchController {
     await Promise.all(searchedSources.map((source) => source.search(searchQuery)));
   };
 
+  searchSync = (searchQuery?: string) => {
+    const searchedSources = this.activeSources;
+    this.state.partialNext({
+      searchQuery,
+    });
+    searchedSources.map((source) => source.searchSync(searchQuery));
+  };
+
   cancelSearchQueries = () => {
     this.activeSources.forEach((s) => s.cancelScheduledQuery());
   };

--- a/src/search/UserSearchSource.ts
+++ b/src/search/UserSearchSource.ts
@@ -1,7 +1,7 @@
 import { BaseSearchSource } from './BaseSearchSource';
-import type { SearchSourceOptions } from './BaseSearchSource';
 import type { StreamChat } from '../client';
 import type { UserFilters, UserOptions, UserResponse, UserSort } from '../types';
+import type { SearchSourceOptions } from './types';
 
 export class UserSearchSource extends BaseSearchSource<UserResponse> {
   readonly type = 'users';

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -3,3 +3,4 @@ export * from './SearchController';
 export { UserSearchSource } from './UserSearchSource';
 export { ChannelSearchSource } from './ChannelSearchSource';
 export { MessageSearchSource } from './MessageSearchSource';
+export * from './types';

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SearchSourceState<T = any> = {
+  hasNext: boolean;
+  isActive: boolean;
+  isLoading: boolean;
+  items: T[] | undefined;
+  searchQuery: string;
+  lastQueryError?: Error;
+  next?: string | null;
+  offset?: number;
+};
+
+export type SearchSourceOptions = {
+  /** The number of milliseconds to debounce the search query. The default interval is 300ms. */
+  debounceMs?: number;
+  pageSize?: number;
+};
+
+export type SearchSourceType = 'channels' | 'users' | 'messages' | (string & {});
+export type QueryReturnValue<T> = { items: T[]; next?: string | null };


### PR DESCRIPTION
The goal of the PR is to introduce sync search by extending the current API. The previously `SearchSource` is now changed to `ISearchSource`, and the `SearchSource` is the async variant of `ISearchSource`, and the `SearchSourceSync` is the sync variant of the `ISearchSource`. 

The previously named `BaseSearchSource` is still intact and handles the async search, and the `BaseSearchSourceSync` is introduced to provide sync search capabilities. Both extend the `BaseSearchSourceBase` that handles the common utilities required for search.

This change was made to ensure that the classes that previously extended the `BaseSearchSource` do not complain about the new abstract methods if they were introduced, because you will never have the same search source having async and sync variants in the same class. Moreover, this change is done in a non-breaking way.

NOTE: The names used right now are a bit lame, and I am open to changing them to a suitable convention. Any suggestions would be highly appreciated.