### PR TITLE
feat: handle offline support for drafts

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1638,6 +1638,8 @@ export class Channel {
         },
       );
     }
+
+    return response;
   }
 
   /**
@@ -1668,6 +1670,8 @@ export class Channel {
         },
       );
     }
+
+    return response;
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1626,19 +1626,7 @@ export class Channel {
         message,
       },
     );
-
-    if (response.draft) {
-      this.getClient().offlineDb?.executeQuerySafely(
-        (db) =>
-          db.upsertDraft?.({
-            draft: response.draft,
-          }),
-        {
-          method: 'upsertDraft',
-        },
-      );
-    }
-
+    console.log(response);
     return response;
   }
 
@@ -1651,27 +1639,9 @@ export class Channel {
    * @return {Promise<APIResponse>} API response
    */
   async deleteDraft({ parent_id }: { parent_id?: string } = {}) {
-    const response = await this.getClient().delete<APIResponse>(
-      this._channelURL() + '/draft',
-      {
-        parent_id,
-      },
-    );
-
-    if (response) {
-      this.getClient().offlineDb?.executeQuerySafely(
-        (db) =>
-          db.deleteDraft?.({
-            cid: this.cid,
-            parent_id,
-          }),
-        {
-          method: 'deleteDraft',
-        },
-      );
-    }
-
-    return response;
+    return await this.getClient().delete<APIResponse>(this._channelURL() + '/draft', {
+      parent_id,
+    });
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1620,12 +1620,24 @@ export class Channel {
    * @return {Promise<CreateDraftResponse>} Response containing the created draft
    */
   async createDraft(message: DraftMessagePayload) {
-    return await this.getClient().post<CreateDraftResponse>(
+    const response = await this.getClient().post<CreateDraftResponse>(
       this._channelURL() + '/draft',
       {
         message,
       },
     );
+
+    if (response.draft) {
+      this.getClient().offlineDb?.executeQuerySafely(
+        (db) =>
+          db.upsertDraft?.({
+            draft: response.draft,
+          }),
+        {
+          method: 'upsertDraft',
+        },
+      );
+    }
   }
 
   /**
@@ -1637,9 +1649,25 @@ export class Channel {
    * @return {Promise<APIResponse>} API response
    */
   async deleteDraft({ parent_id }: { parent_id?: string } = {}) {
-    return await this.getClient().delete<APIResponse>(this._channelURL() + '/draft', {
-      parent_id,
-    });
+    const response = await this.getClient().delete<APIResponse>(
+      this._channelURL() + '/draft',
+      {
+        parent_id,
+      },
+    );
+
+    if (response) {
+      this.getClient().offlineDb?.executeQuerySafely(
+        (db) =>
+          db.deleteDraft?.({
+            cid: this.cid,
+            parent_id,
+          }),
+        {
+          method: 'deleteDraft',
+        },
+      );
+    }
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1620,14 +1620,12 @@ export class Channel {
    * @return {Promise<CreateDraftResponse>} Response containing the created draft
    */
   async createDraft(message: DraftMessagePayload) {
-    const response = await this.getClient().post<CreateDraftResponse>(
+    return await this.getClient().post<CreateDraftResponse>(
       this._channelURL() + '/draft',
       {
         message,
       },
     );
-    console.log(response);
-    return response;
   }
 
   /**

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -275,6 +275,10 @@ export class MessageComposer extends WithSubscriptions {
   }
 
   get hasSendableData() {
+    // If the offline mode is enabled, we allow sending a message if the composition is not empty.
+    if (this.client.offlineDb) {
+      return !this.compositionIsEmpty;
+    }
     return !!(
       (!this.attachmentManager.uploadsInProgressCount &&
         (!this.textComposer.textIsEmpty ||

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -939,7 +939,7 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     event: Event;
     execute?: boolean;
   }) => {
-    const { draft, type } = event;
+    const { cid, draft, type } = event;
 
     if (!draft) return [];
 
@@ -951,10 +951,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     }
 
     if (type === 'draft.deleted') {
-      if (!event.cid) return [];
+      if (!cid) return [];
 
       return await this.deleteDraft({
-        cid: event.cid,
+        cid,
         parent_id: draft.parent_id,
         execute,
       });

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -980,12 +980,16 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     }
 
     if (type === 'draft.deleted') {
-      if (event.parent_id) {
-        return await this.deleteDraft({ cid: event.parent_id, execute });
+      if (!event.cid) return;
+
+      if (event.draft && event.draft.parent_id) {
+        return await this.deleteDraft({
+          cid: event.cid,
+          parent_id: event.draft.parent_id,
+          execute,
+        });
       }
-      if (event.channel_id) {
-        return await this.deleteDraft({ cid: event.channel_id, execute });
-      }
+      return await this.deleteDraft({ cid: event.cid, execute });
     }
 
     // Note: It is a bit counter-intuitive that we do not touch the messages in the

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -36,6 +36,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     });
   }
 
+  abstract upsertDraft: OfflineDBApi['upsertDraft'];
+  abstract getDraft: OfflineDBApi['getDraft'];
+  abstract deleteDraft: OfflineDBApi['deleteDraft'];
+
   /**
    * @abstract
    * Inserts a reaction into the DB.
@@ -942,6 +946,21 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
 
     if (type === 'channel.hidden' || type === 'channel.visible') {
       return await this.handleChannelVisibilityEvent({ event, execute });
+    }
+
+    if (type === 'draft.updated') {
+      if (event.draft) {
+        return await this.upsertDraft({ draft: event.draft, execute });
+      }
+    }
+
+    if (type === 'draft.deleted') {
+      if (event.parent_id) {
+        return await this.deleteDraft({ cid: event.parent_id, execute });
+      }
+      if (event.channel_id) {
+        return await this.deleteDraft({ cid: event.channel_id, execute });
+      }
     }
 
     // Note: It is a bit counter-intuitive that we do not touch the messages in the

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -36,10 +36,6 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     });
   }
 
-  abstract upsertDraft: OfflineDBApi['upsertDraft'];
-  abstract getDraft: OfflineDBApi['getDraft'];
-  abstract deleteDraft: OfflineDBApi['deleteDraft'];
-
   /**
    * @abstract
    * Inserts a reaction into the DB.
@@ -197,6 +193,35 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
    * @returns {Promise<ExecuteBatchDBQueriesType>}
    */
   abstract updateMessage: OfflineDBApi['updateMessage'];
+
+  /**
+   * @abstract
+   * Fetches the provided draft from the DB. Should return as close to
+   * the server side DraftResponse as possible.
+   * @param {DBGetDraftType} options
+   * @returns {Promise<DraftResponse | null>}
+   */
+  abstract getDraft: OfflineDBApi['getDraft'];
+  /**
+   * @abstract
+   * Upserts a draft in the DB.
+   * Will write to the draft table upserting the draft.
+   * Will return the prepared queries for delayed execution (even if they are
+   * already executed).
+   * @param {DBUpsertDraftType} options
+   * @returns {Promise<ExecuteBatchDBQueriesType>}
+   */
+  abstract upsertDraft: OfflineDBApi['upsertDraft'];
+  /**
+   * @abstract
+   * Deletes a draft from the DB.
+   * Will write to the draft table removing the draft.
+   * Will return the prepared queries for delayed execution (even if they are
+   * already executed).
+   * @param {DBDeleteDraftType} options
+   * @returns {Promise<ExecuteBatchDBQueriesType>}
+   */
+  abstract deleteDraft: OfflineDBApi['deleteDraft'];
 
   /**
    * @abstract

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -944,7 +944,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     if (!draft) return [];
 
     if (type === 'draft.updated') {
-      return await this.upsertDraft({ draft, execute });
+      return await this.upsertDraft({
+        draft,
+        execute,
+      });
     }
 
     if (type === 'draft.deleted') {

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -312,7 +312,7 @@ export type DBGetDraftType = {
   /** Channel ID for which to get the draft. */
   cid: string;
   /** ID of the user requesting the draft. */
-  currentUserId: string;
+  userId: string;
   /** Optional parent ID for the parent message in thread, if applicable. */
   parent_id?: string;
 };

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -5,6 +5,7 @@ import type {
   ChannelMemberResponse,
   ChannelResponse,
   ChannelSort,
+  DraftResponse,
   LocalMessage,
   MessageResponse,
   PollResponse,
@@ -300,6 +301,23 @@ export type DBChannelExistsType = {
   cid: string;
 };
 
+export type DBUpsertDraftType = {
+  draft: DraftResponse;
+  execute?: boolean;
+};
+
+export type DBGetDraftType = {
+  cid: string;
+  currentUserId: string;
+  parent_id?: string;
+};
+
+export type DBDeleteDraftType = {
+  cid: string;
+  parent_id?: string;
+  execute?: boolean;
+};
+
 /**
  * Represents a list of batch SQL queries to be executed.
  */
@@ -317,6 +335,7 @@ export interface OfflineDBApi {
   upsertAppSettings: (
     options: DBUpsertAppSettingsType,
   ) => Promise<ExecuteBatchDBQueriesType>;
+  upsertDraft: (options: DBUpsertDraftType) => Promise<ExecuteBatchDBQueriesType>;
   upsertPoll: (options: DBUpsertPollType) => Promise<ExecuteBatchDBQueriesType>;
   upsertChannelData: (
     options: DBUpsertChannelDataType,
@@ -326,6 +345,8 @@ export interface OfflineDBApi {
   upsertMembers: (options: DBUpsertMembersType) => Promise<ExecuteBatchDBQueriesType>;
   updateReaction: (options: DBUpdateReactionType) => Promise<ExecuteBatchDBQueriesType>;
   updateMessage: (options: DBUpdateMessageType) => Promise<ExecuteBatchDBQueriesType>;
+  getDraft: (options: DBGetDraftType) => Promise<DraftResponse | null>;
+  deleteDraft: (options: DBDeleteDraftType) => Promise<ExecuteBatchDBQueriesType>;
   getChannels: (
     options: DBGetChannelsType,
   ) => Promise<Omit<ChannelAPIResponse, 'duration'>[] | null>;

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -302,19 +302,27 @@ export type DBChannelExistsType = {
 };
 
 export type DBUpsertDraftType = {
+  /** Draft message to upsert. */
   draft: DraftResponse;
+  /** Whether to immediately execute the operation. */
   execute?: boolean;
 };
 
 export type DBGetDraftType = {
+  /** Channel ID for which to get the draft. */
   cid: string;
+  /** ID of the user requesting the draft. */
   currentUserId: string;
+  /** Optional parent ID for the parent message in thread, if applicable. */
   parent_id?: string;
 };
 
 export type DBDeleteDraftType = {
+  /** Channel ID for which to delete the draft. */
   cid: string;
+  /** Optional parent ID for the parent message in thread, if applicable. */
   parent_id?: string;
+  /** Whether to immediately execute the operation. */
   execute?: boolean;
 };
 
@@ -346,7 +354,6 @@ export interface OfflineDBApi {
   updateReaction: (options: DBUpdateReactionType) => Promise<ExecuteBatchDBQueriesType>;
   updateMessage: (options: DBUpdateMessageType) => Promise<ExecuteBatchDBQueriesType>;
   getDraft: (options: DBGetDraftType) => Promise<DraftResponse | null>;
-  deleteDraft: (options: DBDeleteDraftType) => Promise<ExecuteBatchDBQueriesType>;
   getChannels: (
     options: DBGetChannelsType,
   ) => Promise<Omit<ChannelAPIResponse, 'duration'>[] | null>;
@@ -362,6 +369,7 @@ export interface OfflineDBApi {
   executeSqlBatch: (queries: ExecuteBatchDBQueriesType) => Promise<unknown>;
   addPendingTask: (task: PendingTask) => Promise<() => Promise<void>>;
   getPendingTasks: (conditions?: DBGetPendingTasksType) => Promise<PendingTask[]>;
+  deleteDraft: (options: DBDeleteDraftType) => Promise<ExecuteBatchDBQueriesType>;
   deletePendingTask: (
     options: DBDeletePendingTaskType,
   ) => Promise<ExecuteBatchDBQueriesType>;

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   Channel,
   LocalMessage,
@@ -419,7 +419,6 @@ describe('MessageComposer', () => {
         .spyOn(messageComposer, 'compositionIsEmpty', 'get')
         .mockReturnValue(true);
 
-      expect(messageComposer.client.offlineDb).toBeDefined();
       expect(messageComposer.hasSendableData).toBe(false);
       spyCompositionIsEmpty.mockRestore();
     });
@@ -431,7 +430,6 @@ describe('MessageComposer', () => {
         .spyOn(messageComposer, 'compositionIsEmpty', 'get')
         .mockReturnValue(false);
 
-      expect(messageComposer.client.offlineDb).toBeDefined();
       expect(messageComposer.hasSendableData).toBe(true);
       spyCompositionIsEmpty.mockRestore();
     });

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -133,6 +133,40 @@ const setup = ({
   return { mockClient, mockChannel, messageComposer };
 };
 
+const offlineModeMessageComposerSetup = ({
+  composition,
+  compositionContext,
+  config,
+}: {
+  composition?: LocalMessage | DraftResponse | MessageResponse | undefined;
+  compositionContext?: Channel | Thread | LocalMessage | undefined;
+  config?: DeepPartial<MessageComposerConfig>;
+} = {}) => {
+  const mockClient = new StreamChat('test-api-key');
+  mockClient.user = user;
+  mockClient.userID = user.id;
+  mockClient.setOfflineDBApi(new MockOfflineDB({ client: mockClient }));
+  vi.spyOn(mockClient.offlineDb!, 'initializeDB').mockResolvedValue(false);
+  // Create a proper Channel instance with only the necessary attributes mocked
+  const mockChannel = new Channel(mockClient, 'messaging', 'test-channel-id', {
+    id: 'test-channel-id',
+    type: 'messaging',
+    cid: 'messaging:test-channel-id',
+  });
+
+  // Mock the getClient method
+  vi.spyOn(mockChannel, 'getClient').mockReturnValue(mockClient);
+
+  const messageComposer = new MessageComposer({
+    client: mockClient,
+    compositionContext: compositionContext || mockChannel,
+    composition,
+    config,
+  });
+
+  return { mockClient, mockChannel, messageComposer };
+};
+
 describe('MessageComposer', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -378,40 +412,6 @@ describe('MessageComposer', () => {
   });
 
   describe('offlineDB enabled', () => {
-    const offlineModeMessageComposerSetup = ({
-      composition,
-      compositionContext,
-      config,
-    }: {
-      composition?: LocalMessage | DraftResponse | MessageResponse | undefined;
-      compositionContext?: Channel | Thread | LocalMessage | undefined;
-      config?: DeepPartial<MessageComposerConfig>;
-    } = {}) => {
-      const mockClient = new StreamChat('test-api-key');
-      mockClient.user = user;
-      mockClient.userID = user.id;
-      mockClient.setOfflineDBApi(new MockOfflineDB({ client: mockClient }));
-      vi.spyOn(mockClient.offlineDb!, 'initializeDB').mockResolvedValue(false);
-      // Create a proper Channel instance with only the necessary attributes mocked
-      const mockChannel = new Channel(mockClient, 'messaging', 'test-channel-id', {
-        id: 'test-channel-id',
-        type: 'messaging',
-        cid: 'messaging:test-channel-id',
-      });
-
-      // Mock the getClient method
-      vi.spyOn(mockChannel, 'getClient').mockReturnValue(mockClient);
-
-      const messageComposer = new MessageComposer({
-        client: mockClient,
-        compositionContext: compositionContext || mockChannel,
-        composition,
-        config,
-      });
-
-      return { mockClient, mockChannel, messageComposer };
-    };
-
     it('hasSendableData should return false if the composition is empty', () => {
       const { messageComposer } = offlineModeMessageComposerSetup();
 
@@ -814,6 +814,145 @@ describe('MessageComposer', () => {
       await expect(messageComposer.createPoll()).rejects.toThrow('Failed to create poll');
       expect(spyAddNotification).toHaveBeenCalledWith({
         message: 'Failed to create the poll',
+        origin: {
+          emitter: 'MessageComposer',
+          context: { composer: messageComposer },
+        },
+      });
+    });
+  });
+
+  describe('getDraft', () => {
+    const draftResponse: DraftResponse = {
+      channel_cid: 'messaging:test-channel-id',
+      message: {
+        id: 'test-message-id',
+        text: 'Test message',
+        attachments: [],
+        mentioned_users: [],
+      },
+      created_at: new Date().toISOString(),
+    };
+    it('should not create draft if edited message exists', async () => {
+      const editedMessage = {
+        id: 'edited-message-id',
+        type: 'regular',
+        text: 'Edited message',
+        attachments: [],
+        mentioned_users: [],
+      };
+
+      const { messageComposer } = offlineModeMessageComposerSetup({
+        composition: editedMessage,
+      });
+
+      const spyGetDraft = vi.spyOn(messageComposer.channel, 'getDraft');
+      await messageComposer.getDraft();
+
+      expect(messageComposer.client.offlineDb!.getDraft).not.toHaveBeenCalled();
+      expect(spyGetDraft).not.toHaveBeenCalled();
+    });
+
+    it("should return if draft config isn't enabled", async () => {
+      const { messageComposer } = offlineModeMessageComposerSetup({
+        config: { drafts: { enabled: false } },
+      });
+
+      const spyGetDraft = vi.spyOn(messageComposer.channel, 'getDraft');
+
+      await messageComposer.getDraft();
+
+      expect(messageComposer.client.offlineDb!.getDraft).not.toHaveBeenCalled();
+      expect(spyGetDraft).not.toHaveBeenCalled();
+    });
+
+    it('should rely on offline db if draft exists in offline DB', async () => {
+      const { messageComposer, mockChannel } = offlineModeMessageComposerSetup({
+        config: { drafts: { enabled: true } },
+      });
+
+      const initStateSpy = vi.spyOn(messageComposer, 'initState');
+      const spyGetDraftFromOfflineDB = vi.spyOn(
+        messageComposer.client.offlineDb!,
+        'getDraft',
+      );
+      spyGetDraftFromOfflineDB.mockResolvedValue(draftResponse);
+
+      const spyChannelGetDraft = vi.spyOn(mockChannel, 'getDraft');
+      spyChannelGetDraft.mockResolvedValue({
+        draft: draftResponse,
+        duration: '10',
+      });
+
+      await messageComposer.getDraft();
+
+      expect(spyGetDraftFromOfflineDB).toHaveBeenCalled();
+      expect(initStateSpy).toHaveBeenCalledWith({
+        composition: draftResponse,
+      });
+      expect(initStateSpy).toHaveBeenCalledTimes(2);
+      expect(spyChannelGetDraft).toHaveBeenCalled();
+      expect(messageComposer.state.getLatestValue().draftId).toBe('test-message-id');
+    });
+
+    it('should rely on http API if draft not found in offline DB', async () => {
+      const { messageComposer, mockChannel } = offlineModeMessageComposerSetup({
+        config: { drafts: { enabled: true } },
+      });
+
+      const initStateSpy = vi.spyOn(messageComposer, 'initState');
+      const spyGetDraftFromOfflineDB = vi.spyOn(
+        messageComposer.client.offlineDb!,
+        'getDraft',
+      );
+      spyGetDraftFromOfflineDB.mockResolvedValue(null);
+
+      const spyChannelGetDraft = vi.spyOn(mockChannel, 'getDraft');
+      spyChannelGetDraft.mockResolvedValue({
+        draft: draftResponse,
+        duration: '10',
+      });
+
+      await messageComposer.getDraft();
+
+      expect(spyGetDraftFromOfflineDB).toHaveBeenCalled();
+      expect(initStateSpy).toHaveBeenCalledWith({
+        composition: draftResponse,
+      });
+      expect(initStateSpy).toHaveBeenCalledTimes(1);
+      expect(spyChannelGetDraft).toHaveBeenCalled();
+      expect(messageComposer.state.getLatestValue().draftId).toBe('test-message-id');
+    });
+
+    it('should reach catch block if getDraft fails', async () => {
+      const { mockClient, messageComposer, mockChannel } =
+        offlineModeMessageComposerSetup({
+          config: { drafts: { enabled: true } },
+        });
+
+      const initStateSpy = vi.spyOn(messageComposer, 'initState');
+      const spyGetDraftFromOfflineDB = vi.spyOn(
+        messageComposer.client.offlineDb!,
+        'getDraft',
+      );
+      spyGetDraftFromOfflineDB.mockResolvedValue(draftResponse);
+
+      const spyChannelGetDraft = vi.spyOn(mockChannel, 'getDraft');
+      spyChannelGetDraft.mockRejectedValue(new Error('Failed to get draft'));
+
+      const spyAddNotification = vi.spyOn(mockClient.notifications, 'add');
+
+      await messageComposer.getDraft();
+
+      expect(spyGetDraftFromOfflineDB).toHaveBeenCalled();
+      expect(initStateSpy).toHaveBeenCalledWith({
+        composition: draftResponse,
+      });
+      expect(initStateSpy).toHaveBeenCalledTimes(1);
+      expect(spyChannelGetDraft).toHaveBeenCalled();
+      expect(messageComposer.state.getLatestValue().draftId).toBe('test-message-id');
+      expect(spyAddNotification).toHaveBeenCalledWith({
+        message: 'Failed to get the draft',
         origin: {
           emitter: 'MessageComposer',
           context: { composer: messageComposer },

--- a/test/unit/offline-support/MockOfflineDB.ts
+++ b/test/unit/offline-support/MockOfflineDB.ts
@@ -13,6 +13,9 @@ export class MockOfflineDB extends AbstractOfflineDB {
   upsertPoll = vi.fn();
   upsertChannelData = vi.fn();
   upsertReads = vi.fn();
+  getDraft = vi.fn();
+  upsertDraft = vi.fn();
+  deleteDraft = vi.fn();
   upsertMessages = vi.fn();
   upsertMembers = vi.fn();
   updateMessage = vi.fn();

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1353,6 +1353,74 @@ describe('OfflineSupportApi', () => {
         });
       });
 
+      describe('handleDraftEvent', () => {
+        const draft = {
+          message: { id: 'message-123', text: 'Draft message', parent_id: 'parent-123' },
+          parent_id: 'parent-123',
+        };
+
+        const baseDraftEvent: Event = {
+          ...baseEvent,
+          draft,
+        } as Event;
+
+        beforeEach(() => {
+          offlineDb.deleteDraft.mockResolvedValue(['DELETE FROM drafts']);
+          offlineDb.upsertDraft.mockResolvedValue(['INSERT INTO drafts']);
+        });
+
+        it("should return empty array if event's draft is missing", async () => {
+          const noDraftEvent = { ...baseDraftEvent, draft: undefined };
+          const result = await offlineDb.handleDraftEvent({ event: noDraftEvent });
+          expect(result).toEqual([]);
+          expect(offlineDb.queriesWithChannelGuard).not.toHaveBeenCalled();
+        });
+
+        it("calls correct method for 'draft.updated' event", async () => {
+          const draftUpdatedEvent = { ...baseDraftEvent, type: 'draft.updated' } as Event;
+
+          const result = await offlineDb.handleDraftEvent({
+            event: draftUpdatedEvent,
+            execute: true,
+          });
+
+          expect(offlineDb['upsertDraft']).toHaveBeenCalledWith({
+            draft: draftUpdatedEvent.draft,
+            execute: true,
+          });
+
+          expect(result).toEqual(['INSERT INTO drafts']);
+        });
+
+        it("should return empty array if event's cid is missing for draft.deleted", async () => {
+          const noCidEvent = {
+            ...baseDraftEvent,
+            cid: undefined,
+            type: 'draft.deleted',
+          } as Event;
+          const result = await offlineDb.handleDraftEvent({ event: noCidEvent });
+          expect(result).toEqual([]);
+          expect(offlineDb.queriesWithChannelGuard).not.toHaveBeenCalled();
+        });
+
+        it("calls deleteDraft for 'draft.deleted' event", async () => {
+          const draftDeletedEvent = { ...baseDraftEvent, type: 'draft.deleted' } as Event;
+
+          const result = await offlineDb.handleDraftEvent({
+            event: draftDeletedEvent,
+            execute: true,
+          });
+
+          expect(offlineDb.deleteDraft).toHaveBeenCalledWith({
+            cid: draftDeletedEvent.cid,
+            parent_id: draftDeletedEvent.draft?.parent_id,
+            execute: true,
+          });
+
+          expect(result).toEqual(['DELETE FROM drafts']);
+        });
+      });
+
       describe('handleReactionEvent', () => {
         const reaction = { type: 'like' };
 
@@ -1474,8 +1542,7 @@ describe('OfflineSupportApi', () => {
             .mockResolvedValue(['truncate-channel']);
           offlineDb.upsertChannelData.mockResolvedValue(['upsert-channel']);
           offlineDb.deleteChannel.mockResolvedValue(['delete-channel']);
-          offlineDb.upsertDraft = vi.fn().mockResolvedValue(['upsert-draft']);
-          offlineDb.deleteDraft = vi.fn().mockResolvedValue(['delete-draft']);
+          offlineDb.handleDraftEvent = vi.fn().mockResolvedValue(['draft']);
         });
 
         afterEach(() => {
@@ -1499,8 +1566,8 @@ describe('OfflineSupportApi', () => {
           ['channel.hidden', 'handleChannelVisibilityEvent', 'channel-visibility'],
           ['channel.visible', 'handleChannelVisibilityEvent', 'channel-visibility'],
           ['channel.updated', 'upsertChannelData', 'upsert-channel'],
-          ['draft.updated', 'upsertDraft', 'upsert-draft'],
-          ['draft.deleted', 'deleteDraft', 'delete-draft'],
+          ['draft.updated', 'handleDraftEvent', 'draft'],
+          ['draft.deleted', 'handleDraftEvent', 'draft'],
           ['notification.message_new', 'upsertChannelData', 'upsert-channel'],
           ['notification.added_to_channel', 'upsertChannelData', 'upsert-channel'],
           ['channel.deleted', 'deleteChannel', 'delete-channel'],
@@ -1518,18 +1585,6 @@ describe('OfflineSupportApi', () => {
 
             if (['message.read', 'notification.mark_read'].includes(type)) {
               queryInput.unreadMessages = 0;
-            }
-
-            if (['draft.updated'].includes(type)) {
-              queryInput = { draft: event.draft, execute: true };
-            }
-
-            if (['draft.deleted'].includes(type)) {
-              queryInput = {
-                cid: event.channel!.cid,
-                parent_id: event.draft?.parent_id,
-                execute: true,
-              };
             }
 
             if (


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

The goal of the PR is to handle offline support for draft messages and also allow composing a message when the composition is not empty when the offline DB is enabled. Thanks to @isekovanic for the help with the offline support explanation here.

## Changelog

-
