### PR TITLE
fix: poll composer improvements

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -664,9 +664,8 @@ export class MessageComposer extends WithSubscriptions {
     const composition = await this.pollComposer.compose();
     if (!composition || !composition.data.id) return;
     try {
-      const { poll } = await this.client.createPoll(composition.data);
-      this.state.partialNext({ pollId: poll.id });
-      this.pollComposer.initState();
+      const poll = await this.client.polls.createPoll(composition.data);
+      this.state.partialNext({ pollId: poll?.id });
     } catch (error) {
       this.client.notifications.add({
         message: 'Failed to create the poll',

--- a/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
@@ -30,6 +30,7 @@ import {
   createCustomDataCompositionMiddleware,
   createDraftCustomDataCompositionMiddleware,
 } from './customData';
+import { createUserDataInjectionMiddleware } from './userDataInjection';
 import { createPollOnlyCompositionMiddleware } from './pollOnly';
 
 export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<
@@ -41,6 +42,7 @@ export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<
     // todo: document how to add custom data to a composed message using middleware
     //  or adding custom composer components (apart from AttachmentsManager, TextComposer etc.)
     this.use([
+      createUserDataInjectionMiddleware(composer),
       createPollOnlyCompositionMiddleware(composer),
       createTextComposerCompositionMiddleware(composer),
       createAttachmentsCompositionMiddleware(composer),

--- a/src/messageComposer/middleware/messageComposer/cleanData.ts
+++ b/src/messageComposer/middleware/messageComposer/cleanData.ts
@@ -29,7 +29,6 @@ export const createCompositionDataCleanupMiddleware = (
           ...composer.editedMessage,
           ...state.localMessage,
           ...common,
-          user: composer.client.user,
         }),
         message: {
           ...editedMessagePayloadToBeSent,

--- a/src/messageComposer/middleware/messageComposer/userDataInjection.ts
+++ b/src/messageComposer/middleware/messageComposer/userDataInjection.ts
@@ -1,0 +1,43 @@
+import type { MessageComposer } from '../../messageComposer';
+import type {
+  MessageComposerMiddlewareState,
+  MessageCompositionMiddleware,
+} from './types';
+import type { MiddlewareHandlerParams } from '../../../middleware';
+import type { OwnUserResponse } from '../../../types';
+
+export const createUserDataInjectionMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
+  id: 'stream-io/message-composer-middleware/user-data-injection',
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
+      if (!composer.client.user) {
+        return forward();
+      }
+      // Exclude the following properties from client.user as they can be large objects
+      // that provide no value for localMessage (and will never exist within message.user).
+      // This way we make sure that our localMessage is enriched with data as close as
+      // possible to the actual user.
+      // The reason why we need to explicitly cast is because OwnUserResponse only takes
+      // precedence after we connectUser the first time and we get the connection health
+      // check event. Due to how liberal the type of client.user is, we have to do it this
+      // way to maintain type safety.
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { channel_mutes, devices, mutes, ...messageUser } = composer.client
+        .user as OwnUserResponse;
+      return next({
+        ...state,
+        localMessage: {
+          ...state.localMessage,
+          user: messageUser,
+          user_id: messageUser.id,
+        },
+      });
+    },
+  },
+});

--- a/src/poll_manager.ts
+++ b/src/poll_manager.ts
@@ -49,7 +49,13 @@ export class PollManager extends WithSubscriptions {
   public createPoll = async (poll: CreatePollData) => {
     const { poll: createdPoll } = await this.client.createPoll(poll);
 
-    return new Poll({ client: this.client, poll: createdPoll });
+    if (!createdPoll.vote_counts_by_option) {
+      createdPoll.vote_counts_by_option = {};
+    }
+
+    this.setOrOverwriteInCache(createdPoll);
+
+    return this.fromState(createdPoll.id);
   };
 
   public getPoll = async (id: string) => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -719,7 +719,7 @@ describe('MessageComposer', () => {
 
       expect(spyCompose).toHaveBeenCalled();
       expect(spyCreatePoll).toHaveBeenCalledWith(mockPoll);
-      expect(messageComposer.pollComposer.initState).toHaveBeenCalled();
+      expect(messageComposer.pollComposer.initState).not.toHaveBeenCalled();
       expect(messageComposer.state.getLatestValue().pollId).toBe('test-poll-id');
     });
 

--- a/test/unit/MessageComposer/middleware/messageComposer/userDataInjection.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/userDataInjection.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MessageComposerMiddlewareState } from '../../../../../src';
+import { createUserDataInjectionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/userDataInjection';
+
+const setupMiddlewareApi = (initialState: MessageComposerMiddlewareState) => {
+  return {
+    state: initialState,
+    next: vi.fn().mockReturnValue(null),
+    complete: vi.fn().mockReturnValue(null),
+    discard: vi.fn().mockReturnValue(null),
+    forward: vi.fn().mockReturnValue(null),
+  };
+};
+
+const stateSeed: MessageComposerMiddlewareState = {
+  message: {
+    id: 'test-id',
+    parent_id: undefined,
+    type: 'regular',
+  },
+  localMessage: {
+    attachments: [],
+    created_at: new Date(),
+    deleted_at: null,
+    error: undefined,
+    id: 'test-id',
+    mentioned_users: [],
+    parent_id: undefined,
+    pinned_at: null,
+    reaction_groups: null,
+    status: 'sending',
+    text: '',
+    type: 'regular',
+    updated_at: new Date(),
+  },
+  sendOptions: {},
+};
+
+const mockComposer = {
+  client: {
+    user: {
+      id: 'test-user',
+      name: 'Cool Person',
+    },
+  },
+} as any;
+
+describe('stream-io/message-composer-middleware/user-data-injection', () => {
+  it('should complete if composer.client.user is defined', async () => {
+    const middleware = createUserDataInjectionMiddleware(mockComposer);
+    const middlewareApi = setupMiddlewareApi(stateSeed);
+    await middleware.handlers.compose(middlewareApi);
+
+    expect(middlewareApi.next).toHaveBeenCalledWith({
+      ...stateSeed,
+      localMessage: {
+        ...stateSeed.localMessage,
+        user: mockComposer.client.user,
+        user_id: mockComposer.client.user.id,
+      },
+    });
+    expect(middlewareApi.forward).not.toHaveBeenCalled();
+  });
+
+  it('should complete if composer.client.user is undefined', async () => {
+    const composerWithoutUser = {
+      ...mockComposer,
+      client: {
+        ...mockComposer.client,
+        user: undefined,
+      },
+    };
+
+    const middleware = createUserDataInjectionMiddleware(composerWithoutUser);
+    const middlewareApi = setupMiddlewareApi(stateSeed);
+    await middleware.handlers.compose(middlewareApi);
+
+    expect(middlewareApi.next).not.toHaveBeenCalled();
+    expect(middlewareApi.forward).toHaveBeenCalled();
+  });
+
+  it('should exclude mutes, channel_mutes and devices from OwnUserResponse if available', async () => {
+    const composerWithOwnUserData = {
+      ...mockComposer,
+      client: {
+        ...mockComposer.client,
+        user: {
+          ...mockComposer.client.user,
+          mutes: [1, 2, 3],
+          channel_mutes: [3, 4, 5],
+          devices: [5, 6, 7],
+        },
+      },
+    };
+    const middleware = createUserDataInjectionMiddleware(composerWithOwnUserData);
+    const middlewareApi = setupMiddlewareApi(stateSeed);
+    await middleware.handlers.compose(middlewareApi);
+
+    expect(middlewareApi.next).toHaveBeenCalledWith({
+      ...stateSeed,
+      localMessage: {
+        ...stateSeed.localMessage,
+        user: mockComposer.client.user,
+        user_id: mockComposer.client.user.id,
+      },
+    });
+    expect(middlewareApi.forward).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR does a couple of things:

- Removes `messageComposer.pollComposer.initState()` from the `createPoll` api
  - This is being done because we both do not yet know if the composer should clear the state or not; especially if sending the message fails or the creation dialog gets closed with a delay (while the HTTP requests finish)
- Introduces a new middleware for injection of `user` data from the `client` for each `localMessage`
  - This serves as an enriched optimistic update for messages, since the `user` was missing for polls as the middleware chain quits earlier than that
- An optimistic update for poll creation
  - We now populate the `poll_manager`'s cache whenever we create a poll so that by the time the optimistic update for the poll message arrives we already have the data in the cache, ready to be used  

## Changelog

-
