### PR TITLE
fix: use ref counting in WithSubscriptions abstract

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -114,8 +114,6 @@ const initState = (
   };
 };
 
-const noop = () => undefined;
-
 export class MessageComposer extends WithSubscriptions {
   readonly channel: Channel;
   readonly state: StateStore<MessageComposerState>;
@@ -363,23 +361,23 @@ export class MessageComposer extends WithSubscriptions {
   }
 
   public registerSubscriptions = (): UnregisterSubscriptions => {
-    if (this.hasSubscriptions) {
-      // Already listening for events and changes
-      return noop;
+    if (!this.hasSubscriptions) {
+      this.addUnsubscribeFunction(this.subscribeMessageComposerSetupStateChange());
+      this.addUnsubscribeFunction(this.subscribeMessageUpdated());
+      this.addUnsubscribeFunction(this.subscribeMessageDeleted());
+
+      this.addUnsubscribeFunction(this.subscribeTextComposerStateChanged());
+      this.addUnsubscribeFunction(this.subscribeAttachmentManagerStateChanged());
+      this.addUnsubscribeFunction(this.subscribeLinkPreviewsManagerStateChanged());
+      this.addUnsubscribeFunction(this.subscribePollComposerStateChanged());
+      this.addUnsubscribeFunction(this.subscribeCustomDataManagerStateChanged());
+      this.addUnsubscribeFunction(this.subscribeMessageComposerStateChanged());
+      this.addUnsubscribeFunction(this.subscribeMessageComposerConfigStateChanged());
     }
-    this.addUnsubscribeFunction(this.subscribeMessageComposerSetupStateChange());
-    this.addUnsubscribeFunction(this.subscribeMessageUpdated());
-    this.addUnsubscribeFunction(this.subscribeMessageDeleted());
 
-    this.addUnsubscribeFunction(this.subscribeTextComposerStateChanged());
-    this.addUnsubscribeFunction(this.subscribeAttachmentManagerStateChanged());
-    this.addUnsubscribeFunction(this.subscribeLinkPreviewsManagerStateChanged());
-    this.addUnsubscribeFunction(this.subscribePollComposerStateChanged());
-    this.addUnsubscribeFunction(this.subscribeCustomDataManagerStateChanged());
-    this.addUnsubscribeFunction(this.subscribeMessageComposerStateChanged());
-    this.addUnsubscribeFunction(this.subscribeMessageComposerConfigStateChanged());
+    this.incrementRefCount();
 
-    return this.unregisterSubscriptions.bind(this);
+    return () => this.unregisterSubscriptions();
   };
 
   private subscribeMessageUpdated = () => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -447,6 +447,28 @@ describe('MessageComposer', () => {
       expect(unsubscribeFunctions.size).toBe(0);
     });
 
+    it('should unregister subscriptions only if refCount drops to 1', () => {
+      const { messageComposer } = setup();
+
+      const spy = vi.spyOn(messageComposer, 'incrementRefCount');
+
+      const unsub1 = messageComposer.registerSubscriptions();
+      const unsub2 = messageComposer.registerSubscriptions();
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      const lastResult = spy.mock.results.at(-1);
+
+      expect(lastResult?.value).toEqual(2);
+
+      unsub1();
+
+      expect(messageComposer.hasSubscriptions).toBe(true);
+
+      unsub2();
+
+      expect(messageComposer.hasSubscriptions).toBe(false);
+    });
+
     it('should set quoted message', () => {
       const { messageComposer } = setup();
       const quotedMessage = {


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Stack-based cleanups don't work with components as components may dissapear from the view at any point in time, ref counting is a better approach to this problem.

Co-authored-by: Ivan <@isekovanic>