### PR TITLE
fix: offline drafts issues and optimistic update implementation

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1474,19 +1474,7 @@ export class Channel {
     this.getClient().polls.hydratePollCache(state.messages, true);
     this.getClient().reminders.hydrateState(state.messages);
 
-    if (state.draft) {
-      this.messageComposer.initState({ composition: state.draft });
-    } else if (this.messageComposer.state.getLatestValue().draftId) {
-      this.messageComposer.clear();
-      this.getClient().offlineDb?.executeQuerySafely(
-        (db) =>
-          db.deleteDraft({
-            cid: this.cid,
-            parent_id: undefined, // makes sure that we don't delete thread drafts while upserting channels
-          }),
-        { method: 'deleteDraft' },
-      );
-    }
+    this.messageComposer.initStateFromChannelResponse(state);
 
     const areCapabilitiesChanged =
       [...(state.channel.own_capabilities || [])].sort().join() !==

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1476,6 +1476,16 @@ export class Channel {
 
     if (state.draft) {
       this.messageComposer.initState({ composition: state.draft });
+    } else if (this.messageComposer.state.getLatestValue().draftId) {
+      this.messageComposer.clear();
+      this.getClient().offlineDb?.executeQuerySafely(
+        (db) =>
+          db.deleteDraft({
+            cid: this.cid,
+            parent_id: undefined, // makes sure that we don't delete thread drafts while upserting channels
+          }),
+        { method: 'deleteDraft' },
+      );
     }
 
     const areCapabilitiesChanged =

--- a/src/client.ts
+++ b/src/client.ts
@@ -1969,19 +1969,7 @@ export class StreamChat {
         this.reminders.hydrateState(channelState.messages);
       }
 
-      if (channelState.draft) {
-        c.messageComposer.initState({ composition: channelState.draft });
-      } else if (c.messageComposer.state.getLatestValue().draftId) {
-        c.messageComposer.clear();
-        this.offlineDb?.executeQuerySafely(
-          (db) =>
-            db.deleteDraft({
-              cid: c.cid,
-              parent_id: undefined, // makes sure that we don't delete thread drafts while upserting channels
-            }),
-          { method: 'deleteDraft' },
-        );
-      }
+      c.messageComposer.initStateFromChannelResponse(channelState);
 
       channels.push(c);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1971,6 +1971,16 @@ export class StreamChat {
 
       if (channelState.draft) {
         c.messageComposer.initState({ composition: channelState.draft });
+      } else if (c.messageComposer.state.getLatestValue().draftId) {
+        c.messageComposer.clear();
+        this.offlineDb?.executeQuerySafely(
+          (db) =>
+            db.deleteDraft({
+              cid: c.cid,
+              parent_id: undefined, // makes sure that we don't delete thread drafts while upserting channels
+            }),
+          { method: 'deleteDraft' },
+        );
       }
 
       channels.push(c);

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -453,6 +453,7 @@ export class MessageComposer extends WithSubscriptions {
       if (
         !draft ||
         !!draft.parent_id !== !!this.threadId ||
+        draft.parent_id !== this.threadId ||
         draft.channel_cid !== this.channel.cid
       )
         return;
@@ -465,6 +466,7 @@ export class MessageComposer extends WithSubscriptions {
       if (
         !draft ||
         !!draft.parent_id !== !!this.threadId ||
+        draft.parent_id !== this.threadId ||
         draft.channel_cid !== this.channel.cid
       ) {
         return;

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -351,7 +351,6 @@ export class MessageComposer extends WithSubscriptions {
     if (this.channel.cid !== channelApiResponse.channel.cid) {
       return;
     }
-
     if (channelApiResponse.draft) {
       this.initState({ composition: channelApiResponse.draft });
     } else if (this.state.getLatestValue().draftId) {

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -452,8 +452,7 @@ export class MessageComposer extends WithSubscriptions {
       const draft = event.draft as DraftResponse;
       if (
         !draft ||
-        !!draft.parent_id !== !!this.threadId ||
-        draft.parent_id !== this.threadId ||
+        (draft.parent_id ?? null) !== (this.threadId ?? null) ||
         draft.channel_cid !== this.channel.cid
       )
         return;
@@ -465,8 +464,7 @@ export class MessageComposer extends WithSubscriptions {
       const draft = event.draft as DraftResponse;
       if (
         !draft ||
-        !!draft.parent_id !== !!this.threadId ||
-        draft.parent_id !== this.threadId ||
+        (draft.parent_id ?? null) !== (this.threadId ?? null) ||
         draft.channel_cid !== this.channel.cid
       ) {
         return;

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1125,6 +1125,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
         return await channel._createDraft(...task.payload);
       }
 
+      if (task.type === 'delete-draft') {
+        return await channel._deleteDraft(...task.payload);
+      }
+
       if (task.type === 'send-message') {
         const newMessageResponse = await channel._sendMessage(...task.payload);
         const newMessage = newMessageResponse?.message;

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1121,6 +1121,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
         return await channel._deleteReaction(...task.payload);
       }
 
+      if (task.type === 'create-draft') {
+        return await channel._createDraft(...task.payload);
+      }
+
       if (task.type === 'send-message') {
         const newMessageResponse = await channel._sendMessage(...task.payload);
         const newMessage = newMessageResponse?.message;

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -399,14 +399,16 @@ export type PendingTaskTypes = {
   deleteReaction: 'delete-reaction';
   sendReaction: 'send-reaction';
   sendMessage: 'send-message';
+  createDraft: 'create-draft';
 };
 
 // TODO: Please rethink the definition of PendingTasks as it seems awkward
 export type PendingTask = {
   channelId?: string;
   channelType?: string;
-  messageId: string;
+  messageId?: string;
   id?: number;
+  parentId?: string;
 } & (
   | {
       payload: Parameters<Channel['sendReaction']>;
@@ -423,6 +425,10 @@ export type PendingTask = {
   | {
       payload: Parameters<Channel['sendMessage']>;
       type: PendingTaskTypes['sendMessage'];
+    }
+  | {
+      payload: Parameters<Channel['createDraft']>;
+      type: PendingTaskTypes['createDraft'];
     }
 );
 

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -400,6 +400,7 @@ export type PendingTaskTypes = {
   sendReaction: 'send-reaction';
   sendMessage: 'send-message';
   createDraft: 'create-draft';
+  deleteDraft: 'delete-draft';
 };
 
 // TODO: Please rethink the definition of PendingTasks as it seems awkward
@@ -429,6 +430,10 @@ export type PendingTask = {
   | {
       payload: Parameters<Channel['createDraft']>;
       type: PendingTaskTypes['createDraft'];
+    }
+  | {
+      payload: Parameters<Channel['deleteDraft']>;
+      type: PendingTaskTypes['deleteDraft'];
     }
 );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -297,9 +297,9 @@ export const axiosParamsSerializer: AxiosRequestConfig['paramsSerializer'] = (pa
 
 /**
  * Takes the message object, parses the dates, sets `__html`
- * and sets the status to `received` if missing; returns a new message object.
+ * and sets the status to `received` if missing; returns a new LocalMessage object.
  *
- * @param {MessageResponse} message `MessageResponse` object
+ * @param {LocalMessage} message `LocalMessage` object
  */
 export function formatMessage(
   message: MessageResponse | MessageResponseBase | LocalMessage,
@@ -331,8 +331,8 @@ export function formatMessage(
 }
 
 /**
- * Takes the message object, parses the dates, sets `__html`
- * and sets the status to `received` if missing; returns a new message object.
+ * Takes a LocalMessage, parses the dates back to strings,
+ * and converts the message back to a MessageResponse.
  *
  * @param {MessageResponse} message `MessageResponse` object
  */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -330,6 +330,33 @@ export function formatMessage(
   } as LocalMessage;
 }
 
+/**
+ * Takes the message object, parses the dates, sets `__html`
+ * and sets the status to `received` if missing; returns a new message object.
+ *
+ * @param {MessageResponse} message `MessageResponse` object
+ */
+export function unformatMessage(message: LocalMessage): MessageResponse {
+  const toMessageResponseBase = (
+    msg: LocalMessage | null | undefined,
+  ): MessageResponseBase | null => {
+    if (!msg) return null;
+    const newDateString = new Date().toISOString();
+    return {
+      ...msg,
+      created_at: message.created_at ? message.created_at.toISOString() : newDateString,
+      deleted_at: message.deleted_at ? message.deleted_at.toISOString() : undefined,
+      pinned_at: message.pinned_at ? message.pinned_at.toISOString() : undefined,
+      updated_at: message.updated_at ? message.updated_at.toISOString() : newDateString,
+    };
+  };
+
+  return {
+    ...toMessageResponseBase(message),
+    quoted_message: toMessageResponseBase((message as LocalMessage).quoted_message),
+  } as MessageResponse;
+}
+
 export const localMessageToNewMessagePayload = (localMessage: LocalMessage): Message => {
   /* eslint-disable @typescript-eslint/no-unused-vars */
   const {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

This PR addresses a couple of bugs with drafts, most notable of which:

1. Removed drafts are not reflected on the state upon an additional `queryChannels` (for example, going offline and regaining connection while having changed the drafts from another device)
2. A removed draft from a channel is not reflected on the state (same case as above)
3. Drafts are left as zombie objects within the offline DB in certain scenarios
4. Drafts not working at all while offline and trying to add a draft
5. Drafts in `ThreadList` that belong to threads from the same channel all update their state in unison (and also delete their state)

Additionally, it introduces:

- Optimistic updates in the offline DB for drafts (both creation and deletion)
- Draft updates/deletes while offline
- Pending `createDraft` tasks
- Pending `deleteDraft` tasks
