### PR TITLE
refactor: protect ReminderPaginator filters and sort properties

### DIFF
--- a/src/pagination/BasePaginator.ts
+++ b/src/pagination/BasePaginator.ts
@@ -38,7 +38,7 @@ export const DEFAULT_PAGINATION_OPTIONS: Required<PaginatorOptions> = {
 
 export abstract class BasePaginator<T> {
   state: StateStore<PaginatorState<T>>;
-  protected pageSize: number;
+  pageSize: number;
   protected _executeQueryDebounced!: DebouncedExecQueryFunction;
   protected _isCursorPagination = false;
 

--- a/src/pagination/ReminderPaginator.ts
+++ b/src/pagination/ReminderPaginator.ts
@@ -9,8 +9,26 @@ import type { StreamChat } from '../client';
 
 export class ReminderPaginator extends BasePaginator<ReminderResponse> {
   private client: StreamChat;
-  filters: ReminderFilters | undefined;
-  sort: ReminderSort | undefined;
+  protected _filters: ReminderFilters | undefined;
+  protected _sort: ReminderSort | undefined;
+
+  get filters(): ReminderFilters | undefined {
+    return this._filters;
+  }
+
+  get sort(): ReminderSort | undefined {
+    return this._sort;
+  }
+
+  set filters(filters: ReminderFilters | undefined) {
+    this._filters = filters;
+    this.resetState();
+  }
+
+  set sort(sort: ReminderSort | undefined) {
+    this._sort = sort;
+    this.resetState();
+  }
 
   constructor(client: StreamChat, options?: PaginatorOptions) {
     super(options);


### PR DESCRIPTION
## Goal

Make sure to reset pagination state on `filter` and `sort` change so that the pagination state cannot get corrupted in the middle of pagination process due to the change of `filter` or `sort` values.
