### PR TITLE
fix: allow to nullify reminder's remind_at value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4036,7 +4036,7 @@ export type ReminderAPIResponse = APIResponse & {
 
 export type CreateReminderOptions = {
   messageId: string;
-  remind_at?: string;
+  remind_at?: string | null;
   user_id?: string;
 };
 


### PR DESCRIPTION
## Goal

Allow to change the timed reminder to a non-timed reminder.
