### PR TITLE
fix: properly delete drafts with quoted messages

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -621,6 +621,7 @@ export class MessageComposer extends WithSubscriptions {
   };
 
   clear = () => {
+    this.setQuotedMessage(null);
     this.initState();
   };
 

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -701,6 +701,7 @@ describe('MessageComposer', () => {
       expect(spyPollComposer).toHaveBeenCalled();
       expect(spyCustomDataManager).toHaveBeenCalled();
       expect(spyInitState).toHaveBeenCalled();
+      expect(messageComposer.quotedMessage).to.be.null;
     });
 
     it('should restore state from edited message if available', () => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR fixes an issue where `draft`s containing a `quotedMessage` were never cleared from the `messageComposer` state unless manually deleted.

The easiest way to reproduce this is to:

- Create a `draft` that contains a quoted message
- Make sure the draft is there on the server (reload or whatever suits best)
- Send the draft message from whichever SDK is being used
- Reload the app again
- The draft will still be there and no matter how many times we send it it is never going to be removed

The reason this happens is [this check](https://github.com/GetStream/stream-chat-js/blob/7dcf10dd4f5234fbc228409222d003e90f6a020d/src/messageComposer/messageComposer.ts#L298), which is used to determine whether a draft should be deleted on pretty much all `state` listeners in the `messageComposer`, [like so](https://github.com/GetStream/stream-chat-js/blob/7dcf10dd4f5234fbc228409222d003e90f6a020d/src/messageComposer/messageComposer.ts#L512).

However, since we're doing `messageComposer.clear()` every time we send a message the composite invocation never clears the quoted message state whenever that happens (as seen [here](https://github.com/GetStream/stream-chat-js/blob/7dcf10dd4f5234fbc228409222d003e90f6a020d/src/messageComposer/messageComposer.ts#L624) and then [here](https://github.com/GetStream/stream-chat-js/blob/7dcf10dd4f5234fbc228409222d003e90f6a020d/src/messageComposer/messageComposer.ts#L328)).

This in turn causes `channel.deleteDraft` to never be invoked hence the bug.

## Changelog

-
