### PR TITLE
fix: query reminders filter key and add channel to the reminder response

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4575,7 +4575,7 @@ export class StreamChat {
    */
   async queryReminders({ filter, sort, ...rest }: QueryRemindersOptions = {}) {
     return await this.post<QueryRemindersResponse>(`${this.baseURL}/reminders/query`, {
-      filter_conditions: filter,
+      filter,
       sort: sort && normalizeQuerySort(sort),
       ...rest,
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -4055,6 +4055,7 @@ export type ReminderResponseBase = {
 };
 
 export type ReminderResponse = ReminderResponseBase & {
+  channel: ChannelResponse;
   user: UserResponse;
   message: MessageResponse;
 };
@@ -4092,7 +4093,7 @@ export type ReminderFilters = QueryFilters<{
     | RequireOnlyOne<
         Pick<
           QueryFilter<ReminderResponseBase['remind_at']>,
-          '$eq' | '$gt' | '$lt' | '$gte' | '$lte'
+          '$exists' | '$eq' | '$gt' | '$lt' | '$gte' | '$lte'
         >
       >
     | PrimitiveFilter<ReminderResponseBase['remind_at']>;


### PR DESCRIPTION
The following are fixed/added on this PR:
1. The curl for the reminder query is as follows:

```
curl -X POST "https://chat.stream-io-api.com/reminders/query?api_key=pd67s34fzpgw&user_id=luke_skywalker&connection_id=685e4531-0a15-1dfe-0200-0000000000a8" \
  -H "Content-Type: application/json" \
  -H "Content-Encoding: application/gzip" \
  -H "X-Stream-Client: stream-chat-flutter-v10.0.0-beta.2|app=ChatSample|app_version=2.2.0|os=ios 18.0|device_model=iPhone17,1" \
  -H "Authorization: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibHVrZV9za3l3YWxrZXIifQ.hZ59SWtp_zLKVV9ShkqkTsCGi_jdPHly7XNCf5T_Ev0" \
  -H "stream-auth-type: jwt" \
  --data-raw '{"filter":{"remind_at":{"$lte":"2025-06-30T12:08:56.502809Z"}},"sort":[{"field":"remind_at","direction":1}],"limit":30}'
```

We had the filter key as `filter_conditions`, which was not working, and I noticed it when working on the reminders listing page.

2. Added a `channel` response to the reminder response, which was needed.
3. Added the `$exists` filter key for the `remind_at` as the BE supports it, and we have to use it to show only "Scheduled" reminders.