### PR TITLE
fix: allow the composition of unchanged edited message

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -306,7 +306,7 @@ export class MessageComposer extends WithSubscriptions {
     const initiatedWithoutDraft = this.lastChange.draftUpdate === null;
     const composingMessageFromScratch = initiatedWithoutDraft && !this.editedMessage;
 
-    // does not mean that the original editted message is different from the current state
+    // does not mean that the original edited message is different from the current state
     const editedMessageWasUpdated =
       !!this.editedMessage?.updated_at &&
       new Date(this.editedMessage.updated_at).getTime() < this.lastChange.stateUpdate;

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -28,10 +28,7 @@ export const createCompositionValidationMiddleware = (
       const hasExceededMaxLength =
         typeof maxLengthOnSend === 'number' && inputText.length > maxLengthOnSend;
 
-      const editedMessageIsUnchanged =
-        composer.editedMessage && !composer.lastChangeOriginIsLocal;
-
-      if (isEmptyMessage || editedMessageIsUnchanged || hasExceededMaxLength) {
+      if (isEmptyMessage || hasExceededMaxLength) {
         return await discard();
       }
 

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -322,7 +322,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     expect(result.status).toBeUndefined;
   });
 
-  it('should discard composition for edited message without any local change', async () => {
+  it('should not discard composition for edited message without any local change', async () => {
     const { messageComposer, validationMiddleware } = setupMiddleware();
     const localMessage: LocalMessage = {
       attachments: [],
@@ -355,7 +355,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
       }),
     );
 
-    expect(result.status).toBe('discard');
+    expect(result.status).toBeUndefined();
   });
 
   it('should not discard composition for newly composed message initiated with draft', async () => {


### PR DESCRIPTION
## Goal

Fixes https://github.com/GetStream/stream-chat-react/issues/2755

We cannot reliably determine whether a message has changed semantically - e.g. adding a character and removing the same character gets us back to the initial state, but from the editing-timestamp point of view the message has changed. We would have to introduce a more sophisticated logic to determine, whether a message has changed semantically.
