### PR TITLE
feat: query channels request override

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -173,12 +173,12 @@ export class ChannelManager extends WithSubscriptions {
     client,
     eventHandlerOverrides = {},
     options = {},
-    queryChannelsRequest,
+    queryChannelsOverride,
   }: {
     client: StreamChat;
     eventHandlerOverrides?: ChannelManagerEventHandlerOverrides;
     options?: ChannelManagerOptions;
-    queryChannelsRequest?: QueryChannelsRequestType;
+    queryChannelsOverride?: QueryChannelsRequestType;
   }) {
     super();
 
@@ -199,7 +199,8 @@ export class ChannelManager extends WithSubscriptions {
     });
     this.setEventHandlerOverrides(eventHandlerOverrides);
     this.setOptions(options);
-    this.queryChannelsRequest = queryChannelsRequest ?? this.client.queryChannels;
+    this.queryChannelsRequest =
+      queryChannelsOverride ?? ((...params) => this.client.queryChannels(...params));
     this.eventHandlers = new Map(
       Object.entries<EventHandlerType>({
         channelDeletedHandler: this.channelDeletedHandler,

--- a/src/client.ts
+++ b/src/client.ts
@@ -233,6 +233,7 @@ import { PollManager } from './poll_manager';
 import type {
   ChannelManagerEventHandlerOverrides,
   ChannelManagerOptions,
+  QueryChannelsRequestType,
 } from './channel_manager';
 import { ChannelManager } from './channel_manager';
 import { NotificationManager } from './notifications';
@@ -720,10 +721,18 @@ export class StreamChat {
   createChannelManager = ({
     eventHandlerOverrides = {},
     options = {},
+    queryChannelsOverride,
   }: {
     eventHandlerOverrides?: ChannelManagerEventHandlerOverrides;
     options?: ChannelManagerOptions;
-  }) => new ChannelManager({ client: this, eventHandlerOverrides, options });
+    queryChannelsOverride?: QueryChannelsRequestType;
+  }) =>
+    new ChannelManager({
+      client: this,
+      eventHandlerOverrides,
+      options,
+      queryChannelsOverride,
+    });
 
   /**
    * Creates a new WebSocket connection with the current user. Returns empty promise, if there is an active connection
@@ -1832,10 +1841,12 @@ export class StreamChat {
       ...options,
     };
 
+    console.log('HERE');
     const data = await this.post<QueryChannelsAPIResponse>(
       this.baseURL + '/channels',
       payload,
     );
+    console.log('HERE2');
 
     return data.channels;
   }
@@ -1859,6 +1870,7 @@ export class StreamChat {
     options: ChannelOptions = {},
     stateOptions: ChannelStateOptions = {},
   ) {
+    console.log('TRY HERE ?');
     const channels = await this.queryChannelsRequest(filterConditions, sort, options);
 
     this.dispatchEvent({

--- a/src/client.ts
+++ b/src/client.ts
@@ -1841,12 +1841,10 @@ export class StreamChat {
       ...options,
     };
 
-    console.log('HERE');
     const data = await this.post<QueryChannelsAPIResponse>(
       this.baseURL + '/channels',
       payload,
     );
-    console.log('HERE2');
 
     return data.channels;
   }
@@ -1870,7 +1868,6 @@ export class StreamChat {
     options: ChannelOptions = {},
     stateOptions: ChannelStateOptions = {},
   ) {
-    console.log('TRY HERE ?');
     const channels = await this.queryChannelsRequest(filterConditions, sort, options);
 
     this.dispatchEvent({

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_CHANNEL_MANAGER_OPTIONS,
   channelManagerEventToHandlerMapping,
   DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS,
+  QueryChannelsRequestType,
 } from '../../src';
 
 import { generateChannel } from './test-utils/generateChannel';
@@ -158,6 +159,21 @@ describe('ChannelManager', () => {
       expect(
         Object.fromEntries((channelManager as any).eventHandlerOverrides),
       ).to.deep.equal(eventHandlerOverrides);
+    });
+
+    it('should properly set queryChannelRequest', async () => {
+      const queryChannelsOverride = async () => {
+        console.log('Called from override.');
+        return new Promise<Channel[]>((resolve) => {
+          resolve([]);
+        });
+      };
+
+      channelManager.setQueryChannelsRequest(queryChannelsOverride);
+
+      const consoleLogSpy = vi.spyOn(console, 'log');
+      await (channelManager as any).queryChannelsRequest({});
+      expect(consoleLogSpy).toHaveBeenCalledWith('Called from override.');
     });
 
     it('should properly set options', () => {
@@ -429,6 +445,7 @@ describe('ChannelManager', () => {
   describe('querying and pagination', () => {
     let clientQueryChannelsStub: sinon.SinonStub;
     let mockChannelPages: Array<Array<Channel>>;
+    let mockChannelCidMap: Record<string, Channel>;
     let channelManager: ChannelManager;
 
     beforeEach(() => {
@@ -444,9 +461,20 @@ describe('ChannelManager', () => {
           client.channel(c.channel.type, c.channel.id),
         );
       });
+      mockChannelCidMap = Object.fromEntries(
+        mockChannelPages.flat().map((obj) => [obj.cid, obj]),
+      );
       clientQueryChannelsStub = sinon
         .stub(client, 'queryChannels')
-        .callsFake((_filters, _sort, options) => {
+        .callsFake((filters, _sort, options) => {
+          if (
+            typeof filters.cid === 'object' &&
+            filters.cid !== null &&
+            '$in' in filters.cid
+          ) {
+            const toReturn = (filters.cid['$in'] ?? []) as string[];
+            return Promise.resolve(toReturn.map((cid) => mockChannelCidMap[cid]));
+          }
           const offset = options?.offset ?? 0;
           return Promise.resolve(mockChannelPages[Math.floor(offset / 10)]);
         });
@@ -899,6 +927,39 @@ describe('ChannelManager', () => {
         expect(offset).to.equal(5);
         expect(hasNext).to.be.false;
       });
+
+      it('should execute queryChannelsOverride if set', async () => {
+        const fetchedChannels = mockChannelPages[2].concat(mockChannelPages[1]);
+        const queryChannelsOverride = async (
+          ...params: Parameters<QueryChannelsRequestType>
+        ) => {
+          const [filters, ...restParams] = params;
+          filters.cid = { $in: fetchedChannels.map((c) => c.cid) };
+
+          return await client.queryChannels(filters, ...restParams);
+        };
+        channelManager.setQueryChannelsRequest(queryChannelsOverride);
+
+        await channelManager.queryChannels(
+          { filterA: true },
+          { asc: 1 },
+          { limit: 15, offset: 0 },
+        );
+
+        const {
+          channels,
+          pagination: {
+            hasNext,
+            options: { offset },
+          },
+        } = channelManager.state.getLatestValue();
+
+        expect(clientQueryChannelsStub.calledOnce).to.be.true;
+        expect(channels.length).to.equal(15);
+        expect(channels).to.deep.equal(fetchedChannels);
+        expect(offset).to.equal(15);
+        expect(hasNext).to.be.true;
+      });
     });
 
     describe('loadNext', () => {
@@ -1194,6 +1255,60 @@ describe('ChannelManager', () => {
         expect(lastPage.length).to.equal(25);
         expect(hasNext).to.be.false;
         expect(offset).to.equal(25);
+      });
+
+      it('should properly paginate with queryChannelsOverride if set', async () => {
+        const fetchedChannels = mockChannelPages[2].concat(mockChannelPages[1]);
+        const fetchedNextPageChannels = mockChannelPages[0];
+        const queryChannelsOverride = async (
+          ...params: Parameters<QueryChannelsRequestType>
+        ) => {
+          const [filters, sort, options, ...restParams] = params;
+          const isInitialPage = options?.offset === 0;
+          filters.cid = {
+            $in: (isInitialPage ? fetchedChannels : fetchedNextPageChannels).map(
+              (c) => c.cid,
+            ),
+          };
+
+          return await client.queryChannels(filters, sort, options, ...restParams);
+        };
+
+        channelManager.setQueryChannelsRequest(queryChannelsOverride);
+
+        await channelManager.queryChannels(
+          { filterA: true },
+          { asc: 1 },
+          { limit: 15, offset: 0 },
+        );
+
+        const {
+          channels: prevChannels,
+          pagination: {
+            hasNext: prevHasNext,
+            options: { offset: prevOffset },
+          },
+        } = channelManager.state.getLatestValue();
+
+        expect(prevChannels.length).to.equal(15);
+        expect(prevChannels).to.deep.equal(fetchedChannels);
+        expect(prevOffset).to.equal(15);
+        expect(prevHasNext).to.be.true;
+
+        await channelManager.loadNext();
+
+        const {
+          channels,
+          pagination: {
+            hasNext,
+            options: { offset },
+          },
+        } = channelManager.state.getLatestValue();
+
+        expect(channels.length).to.equal(25);
+        expect(channels).to.deep.equal(fetchedChannels.concat(fetchedNextPageChannels));
+        expect(offset).to.equal(25);
+        expect(hasNext).to.be.false;
       });
     });
   });


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR introduces a way for integrators to override the default `ChannelManager`'s `queryChannels` (which is essentially `client.queryChannels`.

This is particularly useful in certain niche' edge cases, where for example if querying channels relies heavily on `{ cid: { $in: [...] }}` filters (or something similar) it would be impossible to properly paginate through everything as changing the `filters` on the fly causes the entire state to be wiped as it's considered to be a brand new query.

It also comes with a set of rules:

- `client.queryChannels` must always be invoked by this override (the reason being that `queryChannels` additionally does a bunch of state updates under the hood, so it's mandatory that this is run)
- The `filters` stay intact during all of this (if they change, the `ChannelManager` will consider this to be a brand new query and wipe everything)
- The override still needs to respect `limit` and `offset`, so that pagination works properly (this comes as a given since we pin specific IDs, but worth mentioning still)

## Changelog

-
