### PR TITLE
fix: set loading state to false when query channel errors out

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -317,7 +317,14 @@ export class ChannelManager extends WithSubscriptions {
           `Maximum number of retries reached in queryChannels. Last error message is: ${err}`,
         );
 
-        this.state.partialNext({ error: wrappedError });
+        this.state.partialNext({
+          error: wrappedError,
+          pagination: {
+            ...this.state.getLatestValue().pagination,
+            isLoading: false,
+            isLoadingNext: false,
+          },
+        });
         return;
       }
 
@@ -444,7 +451,11 @@ export class ChannelManager extends WithSubscriptions {
       this.client.logger('error', (error as Error).message);
       this.state.next((currentState) => ({
         ...currentState,
-        pagination: { ...currentState.pagination, isLoadingNext: false },
+        pagination: {
+          ...currentState.pagination,
+          isLoadingNext: false,
+          isLoading: false,
+        },
       }));
       throw error;
     }

--- a/src/offline-support/offline_sync_manager.ts
+++ b/src/offline-support/offline_sync_manager.ts
@@ -1,6 +1,7 @@
 import type { ExecuteBatchDBQueriesType } from './types';
 import type { StreamChat } from '../client';
 import type { AbstractOfflineDB } from './offline_support_api';
+import { AxiosError } from 'axios';
 
 /**
  * Manages synchronization between the local offline database and the Stream backend.
@@ -176,6 +177,10 @@ export class OfflineDBSyncManager {
       console.log('An error has occurred while syncing the DB.', e);
       // Error will be raised by the sync API if there are too many events.
       // In that case reset the entire DB and start fresh.
+      // We avoid resetting the DB if the error is due to timeout.
+      if (e instanceof AxiosError && e.response?.data?.code === 23) {
+        return;
+      }
       await this.offlineDb.resetDB();
     }
   };


### PR DESCRIPTION
The PR focuses on the following:
1. Set the loading state to false if the query channel API errors out. This was essential as currently the channel loads infinitely.
2. When the sync API returns an response timedout error from the BE we should not clear/reset the DB. Doing it was resulting in empty channel list even if the data should be there in the DB. This happened because we just cleared the DB.