### PR TITLE
feat: add attachment manager middleware for pre-upload and post-upload events

### DIFF
--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -386,11 +386,20 @@ export class AttachmentManager {
   private ensureLocalUploadAttachment = async (
     attachment: Partial<LocalUploadAttachment>,
   ) => {
-    if (!attachment.localMetadata?.file || !attachment.localMetadata.id) {
+    if (!attachment.localMetadata?.file) {
       this.client.notifications.addError({
         message: 'File is required for upload attachment',
         origin: { emitter: 'AttachmentManager', context: { attachment } },
         options: { type: 'validation:attachment:file:missing' },
+      });
+      return;
+    }
+
+    if (!attachment.localMetadata.id) {
+      this.client.notifications.addError({
+        message: 'Local upload attachment missing local id',
+        origin: { emitter: 'AttachmentManager', context: { attachment } },
+        options: { type: 'validation:attachment:id:missing' },
       });
       return;
     }
@@ -556,10 +565,7 @@ export class AttachmentManager {
     );
 
     return Promise.all(
-      attachments
-        .filter(this.fileUploadFilter)
-        .slice(0, this.availableUploadSlots)
-        .map(this.uploadAttachment),
+      attachments.slice(0, this.availableUploadSlots).map(this.uploadAttachment),
     );
   };
 }

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -2,7 +2,9 @@ import type { LinkPreview } from '../linkPreviewsManager';
 import type { FileUploadFilter } from '../attachmentManager';
 import type { FileLike, FileReference } from '../types';
 
-export type MinimumUploadRequestResult = { file: string; thumb_url?: string };
+export type MinimumUploadRequestResult = { file: string; thumb_url?: string } & Partial<
+  Record<string, unknown>
+>;
 
 export type UploadRequestFn = (
   fileLike: FileReference | FileLike,
@@ -39,7 +41,6 @@ export type AttachmentManagerConfig = {
    * describing which file types are allowed to be selected when uploading files.
    */
   acceptedFiles: string[];
-  // todo: refactor this. We want a pipeline where it would be possible to customize the preparation, upload, and post-upload steps.
   /** Function that allows to customize the upload request. */
   doUploadRequest?: UploadRequestFn;
 };

--- a/src/messageComposer/middleware/attachmentManager/index.ts
+++ b/src/messageComposer/middleware/attachmentManager/index.ts
@@ -1,0 +1,3 @@
+export * from './postUpload';
+export * from './preUpload';
+export * from './types';

--- a/src/messageComposer/middleware/attachmentManager/postUpload/AttachmentPostUploadMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/AttachmentPostUploadMiddlewareExecutor.ts
@@ -1,0 +1,20 @@
+import { MiddlewareExecutor } from '../../../../middleware';
+import type {
+  AttachmentPostUploadMiddlewareExecutorOptions,
+  AttachmentPostUploadMiddlewareState,
+} from '../types';
+import { createPostUploadAttachmentEnrichmentMiddleware } from './attachmentEnrichment';
+import { createUploadErrorHandlerMiddleware } from './uploadErrorHandler';
+
+export class AttachmentPostUploadMiddlewareExecutor extends MiddlewareExecutor<
+  AttachmentPostUploadMiddlewareState,
+  'postProcess'
+> {
+  constructor({ composer }: AttachmentPostUploadMiddlewareExecutorOptions) {
+    super();
+    this.use([
+      createUploadErrorHandlerMiddleware(composer),
+      createPostUploadAttachmentEnrichmentMiddleware(),
+    ]);
+  }
+}

--- a/src/messageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.ts
@@ -1,0 +1,43 @@
+import type { MiddlewareHandlerParams } from '../../../../middleware';
+import type {
+  AttachmentPostUploadMiddleware,
+  AttachmentPostUploadMiddlewareState,
+} from '../types';
+import { isLocalImageAttachment } from '../../../attachmentIdentity';
+import type { LocalNotImageAttachment } from '../../../types';
+
+export const createPostUploadAttachmentEnrichmentMiddleware =
+  (): AttachmentPostUploadMiddleware => ({
+    id: 'stream-io/attachment-manager-middleware/post-upload-enrichment',
+    handlers: {
+      postProcess: ({
+        state,
+        discard,
+        forward,
+        next,
+      }: MiddlewareHandlerParams<AttachmentPostUploadMiddlewareState>) => {
+        const { attachment, error, response } = state;
+        if (error) return forward();
+        if (!attachment || !response) return discard();
+
+        const enrichedAttachment = { ...attachment };
+        if (isLocalImageAttachment(attachment)) {
+          if (attachment.localMetadata.previewUri) {
+            URL.revokeObjectURL(attachment.localMetadata.previewUri);
+            delete enrichedAttachment.localMetadata.previewUri;
+          }
+          enrichedAttachment.image_url = response.file;
+        } else {
+          (enrichedAttachment as LocalNotImageAttachment).asset_url = response.file;
+        }
+        if (response.thumb_url) {
+          (enrichedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
+        }
+
+        return next({
+          ...state,
+          attachment: enrichedAttachment,
+        });
+      },
+    },
+  });

--- a/src/messageComposer/middleware/attachmentManager/postUpload/index.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/index.ts
@@ -1,0 +1,3 @@
+export * from './attachmentEnrichment';
+export * from './AttachmentPostUploadMiddlewareExecutor';
+export * from './uploadErrorHandler';

--- a/src/messageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.ts
@@ -1,0 +1,39 @@
+import type { MiddlewareHandlerParams } from '../../../../middleware';
+import type { MessageComposer } from '../../../messageComposer';
+import type {
+  AttachmentPostUploadMiddleware,
+  AttachmentPostUploadMiddlewareState,
+} from '../types';
+
+export const createUploadErrorHandlerMiddleware = (
+  composer: MessageComposer,
+): AttachmentPostUploadMiddleware => ({
+  id: 'stream-io/attachment-manager-middleware/upload-error',
+  handlers: {
+    postProcess: ({
+      state,
+      discard,
+      forward,
+    }: MiddlewareHandlerParams<AttachmentPostUploadMiddlewareState>) => {
+      const { attachment, error } = state;
+      if (!error) return forward();
+      if (!attachment) return discard();
+
+      const reason = error instanceof Error ? error.message : 'unknown error';
+      composer.client.notifications.addError({
+        message: 'Error uploading attachment',
+        origin: {
+          emitter: 'AttachmentManager',
+          context: { attachment },
+        },
+        options: {
+          type: 'api:attachment:upload:failed',
+          metadata: { reason },
+          originalError: error,
+        },
+      });
+
+      return forward();
+    },
+  },
+});

--- a/src/messageComposer/middleware/attachmentManager/preUpload/AttachmentPreUploadMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/attachmentManager/preUpload/AttachmentPreUploadMiddlewareExecutor.ts
@@ -1,0 +1,20 @@
+import { MiddlewareExecutor } from '../../../../middleware';
+import type {
+  AttachmentPreUploadMiddlewareExecutorOptions,
+  AttachmentPreUploadMiddlewareState,
+} from '../types';
+import { createUploadConfigCheckMiddleware } from './serverUploadConfigCheck';
+import { createBlockedAttachmentUploadNotificationMiddleware } from './blockedUploadNotification';
+
+export class AttachmentPreUploadMiddlewareExecutor extends MiddlewareExecutor<
+  AttachmentPreUploadMiddlewareState,
+  'prepare'
+> {
+  constructor({ composer }: AttachmentPreUploadMiddlewareExecutorOptions) {
+    super();
+    this.use([
+      createUploadConfigCheckMiddleware(composer),
+      createBlockedAttachmentUploadNotificationMiddleware(composer),
+    ]);
+  }
+}

--- a/src/messageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.ts
+++ b/src/messageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.ts
@@ -1,0 +1,38 @@
+import type { MiddlewareHandlerParams } from '../../../../middleware';
+import type { MessageComposer } from '../../../messageComposer';
+import type {
+  AttachmentPreUploadMiddleware,
+  AttachmentPreUploadMiddlewareState,
+} from '../types';
+
+export const createBlockedAttachmentUploadNotificationMiddleware = (
+  composer: MessageComposer,
+): AttachmentPreUploadMiddleware => ({
+  id: 'stream-io/attachment-manager-middleware/blocked-upload-notification',
+  handlers: {
+    prepare: ({
+      state: { attachment },
+      forward,
+    }: MiddlewareHandlerParams<AttachmentPreUploadMiddlewareState>) => {
+      if (!attachment) return forward();
+
+      if (attachment.localMetadata.uploadPermissionCheck?.uploadBlocked) {
+        composer.client.notifications.addError({
+          message: `The attachment upload was blocked`,
+          origin: {
+            emitter: 'AttachmentManager',
+            context: { blockedAttachment: attachment },
+          },
+          options: {
+            type: 'validation:attachment:upload:blocked',
+            metadata: {
+              reason: attachment.localMetadata.uploadPermissionCheck?.reason,
+            },
+          },
+        });
+      }
+
+      return forward();
+    },
+  },
+});

--- a/src/messageComposer/middleware/attachmentManager/preUpload/index.ts
+++ b/src/messageComposer/middleware/attachmentManager/preUpload/index.ts
@@ -1,0 +1,3 @@
+export * from './AttachmentPreUploadMiddlewareExecutor';
+export * from './blockedUploadNotification';
+export * from './serverUploadConfigCheck';

--- a/src/messageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.ts
+++ b/src/messageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.ts
@@ -1,0 +1,40 @@
+import type { MiddlewareHandlerParams } from '../../../../middleware';
+import type { MessageComposer } from '../../../messageComposer';
+import type {
+  AttachmentPreUploadMiddleware,
+  AttachmentPreUploadMiddlewareState,
+} from '../types';
+import type { LocalUploadAttachment } from '../../../types';
+
+export const createUploadConfigCheckMiddleware = (
+  composer: MessageComposer,
+): AttachmentPreUploadMiddleware => ({
+  id: 'stream-io/attachment-manager-middleware/file-upload-config-check',
+  handlers: {
+    prepare: async ({
+      state,
+      next,
+      discard,
+    }: MiddlewareHandlerParams<AttachmentPreUploadMiddlewareState>) => {
+      const { attachmentManager } = composer;
+      if (!attachmentManager || !state.attachment) return discard();
+      const uploadPermissionCheck = await attachmentManager.getUploadConfigCheck(
+        state.attachment.localMetadata.file,
+      );
+
+      const attachment: LocalUploadAttachment = {
+        ...state.attachment,
+        localMetadata: {
+          ...state.attachment.localMetadata,
+          uploadPermissionCheck,
+          uploadState: uploadPermissionCheck.uploadBlocked ? 'blocked' : 'pending',
+        },
+      };
+
+      return next({
+        ...state,
+        attachment,
+      });
+    },
+  },
+});

--- a/src/messageComposer/middleware/attachmentManager/types.ts
+++ b/src/messageComposer/middleware/attachmentManager/types.ts
@@ -1,0 +1,32 @@
+import type { LocalUploadAttachment } from '../../types';
+import type { Middleware } from '../../../middleware';
+import type { MessageComposer } from '../../messageComposer';
+import type { MinimumUploadRequestResult } from '../../configuration';
+
+export type AttachmentPreUploadMiddlewareState = {
+  attachment: LocalUploadAttachment;
+};
+
+export type AttachmentPostUploadMiddlewareState = {
+  attachment: LocalUploadAttachment;
+  error?: Error;
+  response?: MinimumUploadRequestResult;
+};
+
+export type AttachmentPreUploadMiddleware = Middleware<
+  AttachmentPreUploadMiddlewareState,
+  'prepare'
+>;
+
+export type AttachmentPostUploadMiddleware = Middleware<
+  AttachmentPostUploadMiddlewareState,
+  'postProcess'
+>;
+
+export type AttachmentPostUploadMiddlewareExecutorOptions = {
+  composer: MessageComposer;
+};
+
+export type AttachmentPreUploadMiddlewareExecutorOptions = {
+  composer: MessageComposer;
+};

--- a/src/messageComposer/types.ts
+++ b/src/messageComposer/types.ts
@@ -113,6 +113,12 @@ export type LocalImageAttachmentUploadMetadata = LocalAttachmentUploadMetadata &
   previewUri?: string;
 };
 
+export type LocalNotImageAttachment =
+  | LocalFileAttachment
+  | LocalAudioAttachment
+  | LocalVideoAttachment
+  | LocalVoiceRecordingAttachment;
+
 export type AttachmentLoadingState =
   | 'uploading'
   | 'finished'

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -1201,9 +1201,9 @@ describe('AttachmentManager', () => {
       });
 
       expect(mockClient.notifications.addError).toHaveBeenCalledWith({
-        message: 'File is required for upload attachment',
+        message: 'Local upload attachment missing local id',
         options: {
-          type: 'validation:attachment:file:missing',
+          type: 'validation:attachment:id:missing',
         },
         origin: {
           emitter: 'AttachmentManager',

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -1005,7 +1005,7 @@ describe('AttachmentManager', () => {
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
 
       await attachmentManager.uploadAttachment(
-        attachmentManager.fileToLocalUploadAttachment(file),
+        await attachmentManager.fileToLocalUploadAttachment(file),
       );
 
       expect(attachmentManager.successfulUploadsCount).toBe(1);
@@ -1022,7 +1022,7 @@ describe('AttachmentManager', () => {
 
       await expect(
         attachmentManager.uploadAttachment(
-          attachmentManager.fileToLocalUploadAttachment(file),
+          await attachmentManager.fileToLocalUploadAttachment(file),
         ),
       ).resolves.toEqual({
         fallback: 'test.jpg',
@@ -1032,6 +1032,9 @@ describe('AttachmentManager', () => {
           file,
           uploadState: 'failed',
           previewUri: expect.any(String),
+          uploadPermissionCheck: {
+            uploadBlocked: false,
+          },
         },
         mime_type: 'image/jpeg',
         type: 'image',
@@ -1110,7 +1113,6 @@ describe('AttachmentManager', () => {
       // Create a file to upload
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
 
-      // Mock fileToLocalUploadAttachment to return a valid attachment
       const attachment = {
         type: 'image',
         localMetadata: {
@@ -1357,7 +1359,6 @@ describe('AttachmentManager', () => {
         'fileToLocalUploadAttachment',
       );
 
-      // Set a fileUploadFilter that allows all files
       attachmentManager.fileUploadFilter = () => true;
 
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
@@ -1381,7 +1382,6 @@ describe('AttachmentManager', () => {
       // Set a fileUploadFilter that allows all files
       attachmentManager.fileUploadFilter = () => true;
 
-      // Mock the fileToLocalUploadAttachment method to return a specific value
       const expectedAttachment = {
         type: 'image',
         image_url: 'test-url',
@@ -1420,7 +1420,6 @@ describe('AttachmentManager', () => {
       const originalId = 'original-test-id';
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
 
-      // Mock fileToLocalUploadAttachment to return a new attachment
       const newAttachment = {
         type: 'image',
         image_url: 'test-url',
@@ -1453,11 +1452,14 @@ describe('AttachmentManager', () => {
       const {
         messageComposer: { attachmentManager },
       } = setup();
-      vi.spyOn(Utils, 'generateUUIDv4').mockReturnValue('mock-uuid');
-      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue({
+      const uploadConfigCheckResult = {
         uploadBlocked: false,
         reason: '',
-      });
+      };
+      vi.spyOn(Utils, 'generateUUIDv4').mockReturnValue('mock-uuid');
+      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue(
+        uploadConfigCheckResult,
+      );
       // Create a file of size 1234 bytes
       const fileContent = new Uint8Array(1234);
       const file = new File([fileContent], 'test.jpg', { type: 'image/jpeg' });
@@ -1473,7 +1475,7 @@ describe('AttachmentManager', () => {
         }),
         fallback: 'test.jpg',
       });
-      expect(result.localMetadata.uploadPermissionCheck).toBeUndefined();
+      expect(result.localMetadata.uploadPermissionCheck).toEqual(uploadConfigCheckResult);
       expect(result.localMetadata.uploadState).toMatch(/pending|blocked/);
       expect(result.localMetadata.previewUri).toBeDefined();
     });
@@ -1483,10 +1485,13 @@ describe('AttachmentManager', () => {
         messageComposer: { attachmentManager },
       } = setup();
       vi.spyOn(Utils, 'generateUUIDv4').mockReturnValue('mock-uuid');
-      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue({
+      const uploadConfigCheckResult = {
         uploadBlocked: false,
         reason: '',
-      });
+      };
+      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue(
+        uploadConfigCheckResult,
+      );
       const fileReference = {
         name: 'test.jpg',
         type: 'image/jpeg',
@@ -1509,7 +1514,7 @@ describe('AttachmentManager', () => {
         original_height: 1000,
         original_width: 1200,
       });
-      expect(result.localMetadata.uploadPermissionCheck).toBeUndefined();
+      expect(result.localMetadata.uploadPermissionCheck).toEqual(uploadConfigCheckResult);
       expect(result.localMetadata.uploadState).toMatch(/pending|blocked/);
     });
 
@@ -1518,10 +1523,13 @@ describe('AttachmentManager', () => {
         messageComposer: { attachmentManager },
       } = setup();
       vi.spyOn(Utils, 'generateUUIDv4').mockReturnValue('mock-uuid');
-      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue({
+      const uploadConfigCheckResult = {
         uploadBlocked: false,
         reason: '',
-      });
+      };
+      vi.spyOn(attachmentManager, 'getUploadConfigCheck').mockResolvedValue(
+        uploadConfigCheckResult,
+      );
       const fileReference = {
         name: 'test.mp4',
         type: 'video/mp4',
@@ -1546,8 +1554,7 @@ describe('AttachmentManager', () => {
         duration: 12.34,
         thumb_url: 'file://thumb.jpg',
       });
-      expect(result.localMetadata.uploadPermissionCheck).toBeUndefined();
-      expect(result.localMetadata.uploadState).toMatch(/pending|blocked/);
+      expect(result.localMetadata.uploadPermissionCheck).toEqual(uploadConfigCheckResult);
     });
   });
 });

--- a/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
@@ -1,4 +1,8 @@
-import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import {
+  AttachmentManager,
+  MessageComposer,
+  MiddlewareStatus,
+} from '../../../../../../src';
 import { describe, expect, it, vi } from 'vitest';
 import {
   AttachmentPostUploadMiddlewareState,
@@ -25,7 +29,7 @@ const setupHandlerParams = (initialState: AttachmentPostUploadMiddlewareState) =
 const getInitialState = (
   composer: MessageComposer,
 ): AttachmentPostUploadMiddlewareState => ({
-  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+  attachment: AttachmentManager.toLocalUploadAttachment(
     new File([''], 'test.jpg', { type: 'image/jpeg' }),
   ),
 });

--- a/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
@@ -1,0 +1,134 @@
+import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AttachmentPostUploadMiddlewareState,
+  createPostUploadAttachmentEnrichmentMiddleware,
+} from '../../../../../../src/messageComposer/middleware/attachmentManager';
+
+vi.mock('../../../../../src/utils', () => ({
+  generateUUIDv4: vi.fn().mockReturnValue('test-uuid'),
+}));
+
+const setupHandlerParams = (initialState: AttachmentPostUploadMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: AttachmentPostUploadMiddlewareState) => ({ state }),
+    complete: async (state: AttachmentPostUploadMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const getInitialState = (
+  composer: MessageComposer,
+): AttachmentPostUploadMiddlewareState => ({
+  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+    new File([''], 'test.jpg', { type: 'image/jpeg' }),
+  ),
+});
+
+describe('createPostUploadAttachmentEnrichmentMiddleware', () => {
+  it('discards if attachment is not present in middleware state', async () => {
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware();
+    const initialAttachment = undefined;
+    const initialResponse = {};
+    const {
+      status,
+      state: { attachment, response },
+    } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment: initialAttachment, response: initialResponse }),
+    );
+    expect(status).toBe('discard');
+    expect(attachment).toEqual(initialAttachment);
+    expect(response).toEqual(initialResponse);
+  });
+  it('discards if response is not present in middleware state', async () => {
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware();
+    const initialAttachment = {};
+    const initialResponse = undefined;
+    const {
+      status,
+      state: { attachment, response },
+    } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment: initialAttachment, response: initialResponse }),
+    );
+    expect(status).toBe('discard');
+    expect(attachment).toEqual(initialAttachment);
+    expect(response).toEqual(initialResponse);
+  });
+  it('forwards if error is present in middleware state', async () => {
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware();
+    const initialAttachment = {};
+    const {
+      status,
+      state: { attachment },
+    } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment: initialAttachment, error: new Error() }),
+    );
+    expect(status).toBeUndefined();
+    expect(attachment).toEqual(initialAttachment);
+  });
+
+  it('enriches image attachment', async () => {
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware();
+    const initialAttachment = {
+      localMetadata: {
+        id: 'id',
+        file: new File([''], 'test.jpg', { type: 'image/jpeg' }),
+        previewUri: 'previewUri',
+        uploadPermissionCheck: { uploadBlocked: false, reason: '' },
+      },
+      type: 'image',
+    };
+    const response = {
+      file: 'https://example.com/file/url',
+    };
+    const {
+      status,
+      state: { attachment },
+    } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment: initialAttachment, response }),
+    );
+    expect(status).toBeUndefined();
+    expect(attachment).toEqual({
+      ...initialAttachment,
+      image_url: response.file,
+      localMetadata: {
+        id: 'id',
+        file: initialAttachment.localMetadata.file,
+        uploadPermissionCheck: { uploadBlocked: false, reason: '' },
+      },
+    });
+  });
+
+  it('enriches non-image attachment', async () => {
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware();
+    const initialAttachment = {
+      localMetadata: {
+        id: 'id',
+        file: new File([''], 'test.jpg', { type: 'image/jpeg' }),
+        uploadPermissionCheck: { uploadBlocked: false, reason: '' },
+      },
+      // type: 'file',
+    };
+    const response = {
+      file: 'https://example.com/file/url',
+      thumb_url: 'https://example.com/thumb/url',
+    };
+    const {
+      status,
+      state: { attachment },
+    } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment: initialAttachment, response }),
+    );
+    expect(status).toBeUndefined();
+    expect(attachment).toEqual({
+      ...initialAttachment,
+      asset_url: response.file,
+      thumb_url: response.thumb_url,
+    });
+  });
+});

--- a/test/unit/MessageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.test.ts
@@ -1,0 +1,88 @@
+import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AttachmentPostUploadMiddlewareState,
+  createUploadErrorHandlerMiddleware,
+} from '../../../../../../src/messageComposer/middleware/attachmentManager';
+import { getClientWithUser } from '../../../../test-utils/getClient';
+
+vi.mock('../../../../../src/utils', () => ({
+  generateUUIDv4: vi.fn().mockReturnValue('test-uuid'),
+}));
+
+const setupHandlerParams = (initialState: AttachmentPostUploadMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: AttachmentPostUploadMiddlewareState) => ({ state }),
+    complete: async (state: AttachmentPostUploadMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setup = () => {
+  const client = getClientWithUser({ id: 'user-id' });
+  const composer = new MessageComposer({
+    client,
+    compositionContext: client.channel('type', 'id'),
+  });
+  return { composer, middleware: createUploadErrorHandlerMiddleware(composer) };
+};
+
+describe('createUploadErrorHandlerMiddleware', () => {
+  it('discards if attachment is not present in middleware state', async () => {
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+    const { status } = await middleware.handlers.postProcess(
+      setupHandlerParams({ error: new Error() }),
+    );
+    expect(status).toBe('discard');
+    expect(addErrorNotificationSpy).not.toHaveBeenCalled();
+  });
+  it('forwards if error is not present in middleware state', async () => {
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+    const { status } = await middleware.handlers.postProcess(setupHandlerParams({}));
+    expect(status).toBeUndefined();
+    expect(addErrorNotificationSpy).not.toHaveBeenCalled();
+  });
+
+  it('publishes error notification if the attachment upload was blocked', async () => {
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+    const attachment = {
+      localMetadata: {
+        id: 'id',
+        file: {},
+        uploadPermissionCheck: { uploadBlocked: true, reason: 'reason' },
+      },
+      type: 'file',
+    };
+    const error = new Error('message');
+    const { status } = await middleware.handlers.postProcess(
+      setupHandlerParams({ attachment, error }),
+    );
+    expect(status).toBeUndefined();
+    expect(addErrorNotificationSpy).toHaveBeenCalledWith({
+      message: 'Error uploading attachment',
+      origin: {
+        emitter: 'AttachmentManager',
+        context: { attachment },
+      },
+      options: {
+        type: 'api:attachment:upload:failed',
+        metadata: { reason: error.message },
+        originalError: error,
+      },
+    });
+  });
+});

--- a/test/unit/MessageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.test.ts
@@ -1,4 +1,8 @@
-import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import {
+  AttachmentManager,
+  MessageComposer,
+  MiddlewareStatus,
+} from '../../../../../../src';
 import { describe, expect, it, vi } from 'vitest';
 import {
   AttachmentPreUploadMiddlewareState,
@@ -38,7 +42,7 @@ const setup = () => {
 const getInitialState = (
   composer: MessageComposer,
 ): AttachmentPreUploadMiddlewareState => ({
-  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+  attachment: AttachmentManager.toLocalUploadAttachment(
     new File([''], 'test.jpg', { type: 'image/jpeg' }),
   ),
 });

--- a/test/unit/MessageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/preUpload/blockedUploadNotification.test.ts
@@ -1,0 +1,104 @@
+import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AttachmentPreUploadMiddlewareState,
+  createBlockedAttachmentUploadNotificationMiddleware,
+} from '../../../../../../src/messageComposer/middleware/attachmentManager';
+import { getClientWithUser } from '../../../../test-utils/getClient';
+
+vi.mock('../../../../../src/utils', () => ({
+  generateUUIDv4: vi.fn().mockReturnValue('test-uuid'),
+}));
+
+const setupHandlerParams = (initialState: AttachmentPreUploadMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: AttachmentPreUploadMiddlewareState) => ({ state }),
+    complete: async (state: AttachmentPreUploadMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+const setup = () => {
+  const client = getClientWithUser({ id: 'user-id' });
+  const composer = new MessageComposer({
+    client,
+    compositionContext: client.channel('type', 'id'),
+  });
+  return {
+    composer,
+    middleware: createBlockedAttachmentUploadNotificationMiddleware(composer),
+  };
+};
+
+const getInitialState = (
+  composer: MessageComposer,
+): AttachmentPreUploadMiddlewareState => ({
+  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+    new File([''], 'test.jpg', { type: 'image/jpeg' }),
+  ),
+});
+
+describe('createBlockedAttachmentUploadNotificationMiddleware', () => {
+  it('forwards if attachment is not present in middleware state', async () => {
+    const middleware = createBlockedAttachmentUploadNotificationMiddleware({});
+    const { status } = await middleware.handlers.prepare(setupHandlerParams({}));
+    expect(status).toBeUndefined();
+  });
+
+  it('publishes error notification if the attachment upload was blocked', async () => {
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+    const attachment = {
+      localMetadata: {
+        id: 'id',
+        file: {},
+        uploadPermissionCheck: { uploadBlocked: true, reason: 'reason' },
+      },
+      type: 'file',
+    };
+    const { status } = await middleware.handlers.prepare(
+      setupHandlerParams({ attachment }),
+    );
+    expect(status).toBeUndefined();
+    expect(addErrorNotificationSpy).toHaveBeenCalledWith({
+      message: `The attachment upload was blocked`,
+      origin: {
+        emitter: 'AttachmentManager',
+        context: { blockedAttachment: attachment },
+      },
+      options: {
+        type: 'validation:attachment:upload:blocked',
+        metadata: {
+          reason: attachment.localMetadata.uploadPermissionCheck?.reason,
+        },
+      },
+    });
+  });
+
+  it('does not publish error notification if the attachment upload was not blocked', async () => {
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+    const attachment = {
+      localMetadata: {
+        id: 'id',
+        file: {},
+        uploadPermissionCheck: { uploadBlocked: false, reason: '' },
+      },
+      type: 'file',
+    };
+    const { status } = await middleware.handlers.prepare(
+      setupHandlerParams({ attachment }),
+    );
+    expect(status).toBeUndefined();
+    expect(addErrorNotificationSpy).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/MessageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.test.ts
@@ -1,0 +1,90 @@
+import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AttachmentPreUploadMiddlewareState,
+  createUploadConfigCheckMiddleware,
+} from '../../../../../../src/messageComposer/middleware/attachmentManager';
+import { getClientWithUser } from '../../../../test-utils/getClient';
+
+const setupHandlerParams = (initialState: AttachmentPreUploadMiddlewareState) => {
+  return {
+    state: initialState,
+    next: async (state: AttachmentPreUploadMiddlewareState) => ({ state }),
+    complete: async (state: AttachmentPreUploadMiddlewareState) => ({
+      state,
+      status: 'complete' as MiddlewareStatus,
+    }),
+    discard: async () => ({ state: initialState, status: 'discard' as MiddlewareStatus }),
+    forward: async () => ({ state: initialState }),
+  };
+};
+
+// Mock dependencies
+vi.mock('../../../../../src/utils', () => ({
+  generateUUIDv4: vi.fn().mockReturnValue('test-uuid'),
+}));
+
+const setup = () => {
+  const client = getClientWithUser({ id: 'user-id' });
+  const composer = new MessageComposer({
+    client,
+    compositionContext: client.channel('type', 'id'),
+  });
+  return { composer, middleware: createUploadConfigCheckMiddleware(composer) };
+};
+
+const getInitialState = (
+  composer: MessageComposer,
+): AttachmentPreUploadMiddlewareState => ({
+  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+    new File([''], 'test.jpg', { type: 'image/jpeg' }),
+  ),
+});
+
+describe('createUploadConfigCheckMiddleware', () => {
+  it('discards when attachment manager is not in message composer', async () => {
+    const middleware = createUploadConfigCheckMiddleware({});
+    const { status } = await middleware.handlers.prepare(
+      setupHandlerParams({
+        attachment: {
+          localMetadata: { id: 'id', file: {}, uploadState: '' },
+          type: 'file',
+        },
+      }),
+    );
+    expect(status).toBe('discard');
+  });
+  it('discards when attachment is missing in the state', async () => {
+    const { middleware } = setup();
+    const { status } = await middleware.handlers.prepare(setupHandlerParams({}));
+    expect(status).toBe('discard');
+  });
+  it('enriches the attachment with uploadPermissionCheck and updates the attachment.uploadState to blocked', async () => {
+    const { composer, middleware } = setup();
+    const uploadPermissionCheck = { uploadBlocked: true };
+    vi.spyOn(composer.attachmentManager, 'getUploadConfigCheck').mockResolvedValue(
+      uploadPermissionCheck,
+    );
+    const {
+      status,
+      state: { attachment },
+    } = await middleware.handlers.prepare(setupHandlerParams(getInitialState(composer)));
+    expect(status).toBeUndefined();
+    expect(attachment.localMetadata.uploadPermissionCheck).toBe(uploadPermissionCheck);
+    expect(attachment.localMetadata.uploadState).toBe('blocked');
+  });
+  it('updates the attachment.uploadState to pending', async () => {
+    const { composer, middleware } = setup();
+    const uploadPermissionCheck = { uploadBlocked: false };
+    vi.spyOn(composer.attachmentManager, 'getUploadConfigCheck').mockResolvedValue(
+      uploadPermissionCheck,
+    );
+    const {
+      status,
+      state: { attachment },
+    } = await middleware.handlers.prepare(setupHandlerParams(getInitialState(composer)));
+    expect(status).toBeUndefined();
+    expect(attachment.localMetadata.uploadPermissionCheck).toBe(uploadPermissionCheck);
+    expect(attachment.localMetadata.uploadState).toBe('pending');
+  });
+});

--- a/test/unit/MessageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/preUpload/serverUploadConfigCheck.test.ts
@@ -1,4 +1,8 @@
-import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
+import {
+  AttachmentManager,
+  MessageComposer,
+  MiddlewareStatus,
+} from '../../../../../../src';
 import { describe, expect, it, vi } from 'vitest';
 import {
   AttachmentPreUploadMiddlewareState,
@@ -36,7 +40,7 @@ const setup = () => {
 const getInitialState = (
   composer: MessageComposer,
 ): AttachmentPreUploadMiddlewareState => ({
-  attachment: composer.attachmentManager.fileToLocalUploadAttachment(
+  attachment: AttachmentManager.toLocalUploadAttachment(
     new File([''], 'test.jpg', { type: 'image/jpeg' }),
   ),
 });

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -83,6 +83,7 @@ describe('ChannelManager', () => {
         },
       };
       const queryChannelsOverride = async () => {
+        console.log('Called from override.');
         return new Promise<Channel[]>((resolve) => {
           resolve([]);
         });
@@ -162,6 +163,7 @@ describe('ChannelManager', () => {
 
     it('should properly set queryChannelRequest', async () => {
       const queryChannelsOverride = async () => {
+        console.log('Called from override.');
         return new Promise<Channel[]>((resolve) => {
           resolve([]);
         });

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -83,7 +83,6 @@ describe('ChannelManager', () => {
         },
       };
       const queryChannelsOverride = async () => {
-        console.log('Called from override.');
         return new Promise<Channel[]>((resolve) => {
           resolve([]);
         });
@@ -163,7 +162,6 @@ describe('ChannelManager', () => {
 
     it('should properly set queryChannelRequest', async () => {
       const queryChannelsOverride = async () => {
-        console.log('Called from override.');
         return new Promise<Channel[]>((resolve) => {
           resolve([]);
         });


### PR DESCRIPTION
## Goal

Allow integrators to customize the pre-upload and post-upload logic for attachments.

```
chatClient.setMessageComposerSetupFunction(({ composer }) => {
      ...
      composer.attachmentManager.preUploadMiddlewareExecutor.insert({
        middleware: [createCustomPreUploadMiddleware(composer)],
        position: {
          after: 'stream-io/attachment-manager-middleware/blocked-upload-notification',
        },
        unique: true,
      });

      composer.attachmentManager.postUploadMiddlewareExecutor.insert({
        middleware: [createCustomPostUploadMiddleware(composer)],
        position: {
          before: 'stream-io/attachment-manager-middleware/post-upload-enrichment',
        },
        unique: true,
      });
    });
```

Middleware handlers of the same eventName can now be executed concurrently. This is necessary to perform all the attachment uploads.


### Details

- The upload config check has been moved to pre-upload middleware and thus can be replaced with custom upload config check for a CDN other than Stream's
- It is not necessary to provide a filter function (`fileUploadFilter`) as the filtering can take place inside the middleware
- The post upload middleware executor allows for handling upload errors, further attachment enrichment, notifications etc.

**Deprecations**
- `AttachmentManager.fileUploadFilter()` getter and setter - replaced with middleware handlers
- `AttachmentManager.fileToLocalUploadAttachment(file)` - replaced with static `AttachmentManager.toLocalUploadAttachment(file)`
- `AttachmentManager.uploadAttachment(attachment)` - replaced with `AttachmentManager.uploadFile(file)`
