### PR TITLE
feat: explicit event_hooks deletion

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2241,7 +2241,7 @@ export type AppSettings = {
   disable_permissions_checks?: boolean;
   enforce_unique_usernames?: 'no' | 'app' | 'team';
   event_hooks?: Array<EventHook> | null;
-  explicit_hook_v2_deletion?: boolean;
+  explicit_event_hooks_deletion?: boolean;
   // all possible file mime types are https://www.iana.org/assignments/media-types/media-types.xhtml
   file_upload_config?: FileUploadConfig;
   firebase_config?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4223,6 +4223,7 @@ export type EventHook = {
     mode: 'CALLBACK_MODE_NONE' | 'CALLBACK_MODE_REST' | 'CALLBACK_MODE_TWIRP';
   };
 
+  delete?: boolean;
   created_at?: string;
   updated_at?: string;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2241,6 +2241,7 @@ export type AppSettings = {
   disable_permissions_checks?: boolean;
   enforce_unique_usernames?: 'no' | 'app' | 'team';
   event_hooks?: Array<EventHook> | null;
+  explicit_hook_v2_deletion?: boolean;
   // all possible file mime types are https://www.iana.org/assignments/media-types/media-types.xhtml
   file_upload_config?: FileUploadConfig;
   firebase_config?: {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

In the current configuration, we must provide all hook configs in the event_hooks parameter of the UpdateApp API. This approach can lead to accidental hook deletion if we don't include existing configs in the request.

Providing full CRUD endpoints would be overkill. The simplest solution is to introduce an explicit marker in the request that indicates when a webhook should be deleted. We can use the existing update app API’s event_hooks parameter and mark delete: true when users want to remove a specific config.

The behavior would work as follows:

- If the id doesn't exist in the request, create the hook
- If the id exists in the request, update the hook in the DB. If the DB record doesn't exist, create a hook with the provided id
- If "delete": true exists in the request, delete the hook
- If hooks don't appear in the request at all, no action is taken - nothing will be deleted or updated

Example of request

```
// Get app settings
await client.getAppSettings();

// Response
{
  // ... all app settings
  "event_hooks": [
    {
      "id": "d2ce8c4f-bf5f-40b7-aeda-d2aef381fb54",
      "enabled": true,
      "hook_type": "webhook",
      "webhook_url": "<http://url1-webhook.com>",
      "event_types": ["channel.created"]
    },
    {
      "id": "e9b2c15b-53bd-4998-9791-adiqeq13mqw",
      "enabled": true,
      "hook_type": "sns",
      "sns_arn_topic": "arn:aws:sns:us-east-1:123456789012:MyTopic2",
      "sns_auth_type": "role",
      "sns_role_arn": "arn:aws:iam::123456789012:role/SNSPublishRole",
      "event_types": ["channel.created", "channel.updated"]
    },
    {
      "id": "44b80835-b490-4776-bf5b-6970045cbce1"
      "enabled": true,
      "hook_type": "pending_message",
      "webhook_url": "<http://test-url.com>",
      "timeout_ms": 500,
      "callback": {
        "mode": "CALLBACK_MODE_REST"
      }
    }
  ]
}

// Update app settings
await client.updateAppSettings(
{
  explicit_hook_v2_deletion: true,
  event_hooks: [
    {
      "id": "d2ce8c4f-bf5f-40b7-aeda-d2aef381fb54",
      "enabled": true,
      "hook_type": "webhook",
      "webhook_url": "<http://url1-new-webhook.com>", // change the URL
      "event_types": ["channel.created", "message.new"] // add a new event type
    },
    {
      "enabled": true, // adds a new SQS hook config
      "hook_type": "sqs",
      "sqs_queue_url": "<http://url1-sqs.com>",
      "sqs_auth_type": "keys",
      "sqs_key": "sqs-key",
      "sqs_secret": "sqs-secret",
      "event_types": ["channel.created"]
    },
    {
	    "delete": true, // delete a9sqh12-81hs-1231-4311-adiqeq13mqw. Providing only id is enough. But it is also fine to provide full config.
      "id": "a9sqh12-81hs-1231-4311-adiqeq13mqw"
    },
    // "44b80835-b490-4776-bf5b-6970045cbce1" remains the same because not included in the request
  ]
});
```

## Changelog

-
