### PR TITLE
feat: handle user.messages.deleted WS event

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1903,6 +1903,15 @@ export class Channel {
           }
         }
         break;
+      case 'user.messages.deleted':
+        if (event.user) {
+          this.state.deleteUserMessages(
+            event.user,
+            !!event.hard_delete,
+            new Date(event.created_at ?? Date.now()),
+          );
+        }
+        break;
       case 'message.new':
         if (event.message) {
           /* if message belongs to current user, always assume timestamp is changed to filter it out and add again to avoid duplication */

--- a/src/events.ts
+++ b/src/events.ts
@@ -45,6 +45,7 @@ export const EVENT_MAP = {
   'typing.stop': true,
   'user.banned': true,
   'user.deleted': true,
+  'user.messages.deleted': true,
   'user.presence.changed': true,
   'user.unbanned': true,
   'user.unread_message_reminder': true,

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -461,6 +461,184 @@ describe('Channel _handleChannelEvent', function () {
 		).to.be.null;
 	});
 
+	describe('user.messages.deleted', () => {
+		const bannedUser = { id: 'banned-user' };
+		const otherUser = { id: 'other-user' };
+		const messageSet1 = [
+			{
+				attachments: [
+					{
+						type: 'image',
+						title: 'YouTube',
+						title_link: 'https://www.youtube.com/',
+						text: 'Enjoy the videos and music you love, upload original content, and share it all with friends, family, and the world on YouTube.',
+						image_url: 'https://www.youtube.com/img/desktop/yt_1200.png',
+						thumb_url: 'https://www.youtube.com/img/desktop/yt_1200.png',
+						og_scrape_url: 'https://www.youtube.com/',
+					},
+				],
+				created_at: '2021-01-01T00:01:00',
+				pinned: true,
+				pinned_at: '2022-01-01T00:01:00',
+				user: bannedUser,
+			},
+			{
+				created_at: '2021-01-01T00:02:00',
+				pinned: true,
+				pinned_at: '2022-01-01T00:02:00',
+				user: otherUser,
+			},
+			{ created_at: '2021-01-01T00:03:00', user: bannedUser },
+		].map(generateMsg);
+
+		const quoted_message = messageSet1[0];
+		const messageSet2 = [
+			{
+				created_at: '2020-01-01T00:01:00',
+				pinned: true,
+				pinned_at: '2022-01-01T00:03:00',
+				user: bannedUser,
+			},
+			{
+				created_at: '2020-01-01T00:02:00',
+				quoted_message,
+				quoted_message_id: quoted_message.id,
+				user: otherUser,
+			},
+			{ created_at: '2020-01-01T00:03:00', user: bannedUser },
+			{ created_at: '2020-01-01T00:04:00', user: otherUser },
+		].map(generateMsg);
+
+		const parent_id = messageSet2[0].id;
+		const thread1 = [
+			{ created_at: '2020-01-01T00:01:30', parent_id, user: bannedUser, type: 'reply' },
+			{ created_at: '2020-01-01T00:02:35', parent_id, user: otherUser, type: 'reply' },
+			{ created_at: '2020-01-01T00:03:45', parent_id, user: bannedUser, type: 'reply' },
+			{ created_at: '2020-01-01T00:04:00', parent_id, user: otherUser, type: 'reply' },
+		];
+
+		const pinnedMessages = [messageSet1[0], messageSet1[1], messageSet2[0]];
+
+		const setupChannel = (channel) => {
+			channel.state.addMessagesSorted(messageSet1);
+			channel.state.addMessagesSorted(messageSet2, false, false, true, 'new');
+
+			// pinned messages
+			channel.state.addPinnedMessages(pinnedMessages);
+
+			// thread replies
+			channel.state.addMessagesSorted(thread1);
+		};
+
+		it('removes the messages on hard delete', () => {
+			setupChannel(channel);
+			expect(channel.state.messageSets).toHaveLength(2);
+			expect(channel.state.messageSets[0].messages).toHaveLength(messageSet1.length);
+			expect(channel.state.messageSets[1].messages).toHaveLength(messageSet2.length);
+			expect(channel.state.pinnedMessages).toHaveLength(pinnedMessages.length);
+			expect(channel.state.threads[parent_id]).toHaveLength(thread1.length);
+
+			const event = {
+				type: 'user.messages.deleted',
+				cid: channel.cid,
+				channel_type: channel.type,
+				channel_id: channel.id,
+				user: bannedUser,
+				hard_delete: true,
+				created_at: '2025-02-01T14:01:30.000Z',
+			};
+			channel._handleChannelEvent(event);
+			expect(channel.state.messageSets[0].messages).toHaveLength(3);
+
+			const check = (message) => {
+				const deletedMessage = {
+					attachments: [],
+					cid: message.cid,
+					created_at: message.created_at,
+					deleted_at: new Date(event.created_at),
+					id: message.id,
+					latest_reactions: [],
+					mentioned_users: [],
+					own_reactions: [],
+					parent_id: message.parent_id,
+					reply_count: message.reply_count,
+					status: message.status,
+					thread_participants: message.thread_participants,
+					type: 'deleted',
+					updated_at: message.updated_at,
+					user: message.user,
+				};
+				if (message.user.id === bannedUser.id) {
+					expect(message).toStrictEqual(deletedMessage);
+				} else if (message.quoted_message) {
+					expect(message).toStrictEqual({
+						...message,
+						quoted_message: {
+							...deletedMessage,
+							id: message.quoted_message.id,
+							user: message.quoted_message.user,
+						},
+					});
+				} else {
+					expect(message).toEqual(message);
+				}
+			};
+
+			channel.state.messageSets[0].messages.forEach(check);
+			channel.state.messageSets[1].messages.forEach(check);
+			channel.state.pinnedMessages.forEach(check);
+			Object.values(channel.state.threads).forEach((replies) => replies.forEach(check));
+		});
+		it('removes the messages on soft delete', () => {
+			setupChannel(channel);
+			expect(channel.state.messageSets).toHaveLength(2);
+			expect(channel.state.messageSets[0].messages).toHaveLength(messageSet1.length);
+			expect(channel.state.messageSets[1].messages).toHaveLength(messageSet2.length);
+			expect(channel.state.pinnedMessages).toHaveLength(pinnedMessages.length);
+			expect(channel.state.threads[parent_id]).toHaveLength(thread1.length);
+
+			const event = {
+				type: 'user.messages.deleted',
+				cid: channel.cid,
+				channel_type: channel.type,
+				channel_id: channel.id,
+				user: bannedUser,
+				soft_delete: true,
+				created_at: '2025-02-01T14:01:30.000Z',
+			};
+			channel._handleChannelEvent(event);
+			expect(channel.state.messageSets[0].messages).toHaveLength(3);
+
+			const check = (message) => {
+				if (message.user.id === bannedUser.id) {
+					expect(message).toStrictEqual({
+						...message,
+						attachments: [],
+						deleted_at: new Date(event.created_at),
+						type: 'deleted',
+					});
+				} else if (message.quoted_message) {
+					expect(message).toStrictEqual({
+						...message,
+						quoted_message: {
+							...message.quoted_message,
+							attachments: [],
+							deleted_at: new Date(event.created_at),
+							type: 'deleted',
+						},
+					});
+				} else {
+					expect(message).toEqual(message);
+				}
+			};
+
+			channel.state.messageSets[0].messages.forEach(check);
+			channel.state.messageSets[1].messages.forEach(check);
+			channel.state.pinnedMessages.forEach(check);
+			Object.values(channel.state.threads).forEach((replies) => replies.forEach(check));
+		});
+	});
+
 	describe('notification.mark_unread', () => {
 		let initialCountUnread;
 		let initialReadState;


### PR DESCRIPTION
## Goal

Closes REACT-523

Upon receiving the said event we convert all the messages of the banned user into deleted messages. They are kept in the state as deleted and not removed until the next reload, where the messages are not received from the server (hard delete) or are still received with text "This message has been deleted" (soft delete).
If the WS event concerns a specific channel (`channel.banUser()`)only messages in that given channel are converted to deleted. If the event is global (`client.banUser()`), then all the messages of the banned user in all the locally loaded channels are converted into deleted messages.

