### PR TITLE
fix: formatMessage - reference the correct msg in toLocalMessageBase

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -310,16 +310,16 @@ export function formatMessage(
     if (!msg) return null;
     return {
       ...msg,
-      created_at: message.created_at ? new Date(message.created_at) : new Date(),
-      deleted_at: message.deleted_at ? new Date(message.deleted_at) : null,
-      pinned_at: message.pinned_at ? new Date(message.pinned_at) : null,
+      created_at: msg.created_at ? new Date(msg.created_at) : new Date(),
+      deleted_at: msg.deleted_at ? new Date(msg.deleted_at) : null,
+      pinned_at: msg.pinned_at ? new Date(msg.pinned_at) : null,
       reaction_groups: maybeGetReactionGroupsFallback(
-        message.reaction_groups,
-        message.reaction_counts,
-        message.reaction_scores,
+        msg.reaction_groups,
+        msg.reaction_counts,
+        msg.reaction_scores,
       ),
-      status: message.status || 'received',
-      updated_at: message.updated_at ? new Date(message.updated_at) : new Date(),
+      status: msg.status || 'received',
+      updated_at: msg.updated_at ? new Date(msg.updated_at) : new Date(),
     };
   };
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -458,7 +458,7 @@ describe('Channel _handleChannelEvent', function () {
 		expect(
 			channel.state.messages.find((msg) => msg.id === quotingMessage.id).quoted_message
 				.deleted_at,
-		).to.be.null;
+		).to.be.ok;
 	});
 
 	describe('user.messages.deleted', () => {
@@ -577,6 +577,8 @@ describe('Channel _handleChannelEvent', function () {
 							...deletedMessage,
 							id: message.quoted_message.id,
 							user: message.quoted_message.user,
+							created_at: message.quoted_message.created_at,
+							updated_at: message.quoted_message.updated_at,
 						},
 					});
 				} else {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1172,6 +1172,8 @@ describe('user.messages.deleted', () => {
 							...deletedMessage,
 							id: message.quoted_message.id,
 							user: message.quoted_message.user,
+							created_at: message.quoted_message.created_at,
+							updated_at: message.quoted_message.updated_at,
 						},
 					});
 				} else {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

When upgrading our Stream packages at Glue, we noticed that our quoted messages were displaying the same `created_at` date and time as the messages they were attached to after the upgrade. After some debugging we isolated the issue to the upgrade, and after looking further, noticed that the code that converts `MessageResponse` to `LocalMessage` - i.e. `formatMessage` in `src/utils` - was referencing the original message in `toLocalMessageBase` rather than the `msg` passed to it, which would cause the issue we are seeing.

## Changelog

- Updated `message` references in `toLocalMessageBase` to `msg`
- Updated tests to correspond with this change
