### PR TITLE
feat: storing participant count in ThreadState

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -47,8 +47,6 @@ export type ThreadState = {
   read: ThreadReadState;
   replies: Array<LocalMessage>;
   replyCount: number;
-  participantCount: number;
-  activeParticipantCount: number;
   title: string;
   updatedAt: Date | null;
 };
@@ -113,6 +111,7 @@ const constructCustomDataObject = <T extends ThreadResponse>(threadData: T) => {
 
 export class Thread extends WithSubscriptions {
   public readonly state: StateStore<ThreadState>;
+  public readonly threadData: ThreadResponse;
   public readonly id: string;
   public readonly messageComposer: MessageComposer;
 
@@ -169,14 +168,13 @@ export class Thread extends WithSubscriptions {
       ),
       replies: threadData.latest_replies.map(formatMessage),
       replyCount: threadData.reply_count ?? 0,
-      participantCount: threadData.participant_count ?? 0,
-      activeParticipantCount: threadData.active_participant_count ?? 0,
       updatedAt: threadData.updated_at ? new Date(threadData.updated_at) : null,
       title: threadData.title,
       custom: constructCustomDataObject(threadData),
     });
 
     this.id = threadData.parent_message_id;
+    this.threadData = threadData;
     this.client = client;
 
     this.messageComposer = new MessageComposer({


### PR DESCRIPTION
## Linear

- https://linear.app/stream/issue/CHA-1051/expose-zero-value-for-participant-count

## Linked PR

- https://github.com/GetStream/chat/pull/9720

## CLA

Expose a Thread's participant count through storing it in the `ThreadState` 

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
