### PR TITLE
fix: wait for WS disconnect before token reset

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -987,9 +987,13 @@ export class StreamChat {
     this.state = new ClientState({ client: this });
     // reset thread manager
     this.threads.resetState();
-    // reset token manager
-    // setTimeout(this.tokenManager.reset); // delay reseting to use token for disconnect calls
-    this.tokenManager.reset();
+
+    // Since we wipe all user data already, we should reset token manager as well
+    closePromise
+      .finally(() => {
+        this.tokenManager.reset();
+      })
+      .catch((err) => console.error(err));
 
     // close the WS connection
     return closePromise;

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -319,6 +319,33 @@ describe('Client connectUser', () => {
 	});
 });
 
+describe('Client disconnectUser', () => {
+	it(`it should reset token manager after WS is disconnected, but before disconnect promise is resolved`, async () => {
+		const client = new StreamChat('', '');
+		client.tokenManager = {
+			reset: sinon.spy(),
+		};
+		const { resolve, promise } = Promise.withResolvers();
+		client.wsConnection = { disconnect: () => promise };
+		client.wsFallback = null;
+		const disconnectPromise = client.disconnectUser();
+		expect(client.tokenManager.reset.called).to.be.false;
+		resolve();
+		await disconnectPromise;
+		expect(client.tokenManager.reset.called).to.be.true;
+	});
+
+	it('should reset token manager even if WS disconnect fails', async () => {
+		const client = new StreamChat('', '');
+		client.tokenManager = {
+			reset: sinon.spy(),
+		};
+		client.wsConnection = { disconnect: () => Promise.reject() };
+		await expect(client.disconnectUser()).rejects.toThrow();
+		expect(client.tokenManager.reset.called).to.be.true;
+	});
+});
+
 describe('Detect node environment', () => {
 	const client = new StreamChat('', '');
 	it('node property should be true', () => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Backend team spotted an intermittent issue when doing subsequent connect-disconnect calls.

@nijeesh-stream found out that the issue could be that `disconnectUser` resets the token independently from WS promise [code](https://github.com/GetStream/stream-chat-js/blob/master/src/client.ts#L991), so it's not guaranteed that by the time `disconnectUser` resolves, token is reset.

This code was added as part of the [WS fallback PR](https://github.com/GetStream/stream-chat-js/commit/d4e8c6aec215472de43c70b84a3b8f086cd7f8db). And in case of long-polling, the disconnect method does an [API call](https://github.com/GetStream/stream-chat-js/blob/d4e8c6aec215472de43c70b84a3b8f086cd7f8db/src/connection_fallback.ts#L198), so the `setTimeout` was added to make sure the token is usabale in the disconnect call.

I updated the logic to reset the token after WS disconnect promise settles (rejects or resolves).

One issue: in this [test](https://github.com/GetStream/stream-chat-js/pull/1623/files#diff-2ffd440df00c0414c15c86fb441fbac84cd018bda59091d45f56f6d95b93dc7eR338) vite complains about an unhandled rejection. Makes me go crazy, does someone have an idea why?

## Changelog

-
