### PR TITLE
fix: add last_updated field to ChannelFilters type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1742,7 +1742,9 @@ export type ChannelFilters = QueryFilters<
         >
       | PrimitiveFilter<string>;
     pinned?: boolean;
-    last_updated?: RequireOnlyOne<QueryFilter<string>> | PrimitiveFilter<string>;
+    last_updated?:
+      | RequireOnlyOne<Pick<QueryFilter<string>, '$eq' | '$gt' | '$gte' | '$lt' | '$lte'>>
+      | PrimitiveFilter<string>;
   } & {
     [Key in keyof Omit<ChannelResponse, 'name' | 'members' | keyof CustomChannelData>]:
       | RequireOnlyOne<QueryFilter<ChannelResponse[Key]>>


### PR DESCRIPTION
- Add last_updated field to ChannelFilters with string operators support
- Supports $eq, $gt, $lt, $gte, $lte  operators for filtering channels by last updated time
- Fixes missing type for queryChannels last_updated filter


