### PR TITLE
fix(bundle): upgrade axios and externalize previously bundled packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@types/jsonwebtoken": "^9.0.8",
     "@types/ws": "^8.5.14",
-    "axios": "^1.6.0",
+    "axios": "^1.12.2",
     "base64-js": "^1.5.1",
     "form-data": "^4.0.4",
     "isomorphic-ws": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -12,20 +12,20 @@
     "url": "https://github.com/GetStream/stream-chat-js.git"
   },
   "types": "./dist/types/index.d.ts",
-  "main": "./dist/esm/index.js",
+  "main": "./dist/esm/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
       "browser": {
-        "import": "./dist/esm/index.js",
-        "require": "./dist/cjs/index.browser.cjs"
+        "import": "./dist/esm/index.mjs",
+        "require": "./dist/cjs/index.browser.js"
       },
       "react-native": {
-        "import": "./dist/esm/index.js",
-        "require": "./dist/cjs/index.browser.cjs"
+        "import": "./dist/esm/index.mjs",
+        "require": "./dist/cjs/index.browser.js"
       },
-      "node": "./dist/cjs/index.node.cjs",
-      "default": "./dist/esm/index.js"
+      "node": "./dist/cjs/index.node.js",
+      "default": "./dist/esm/index.mjs"
     }
   },
   "browser": {

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -22,7 +22,7 @@ const commonBuildOptions = {
   entryPoints: [resolve(__dirname, '../src/index.ts')],
   bundle: true,
   target: 'ES2020',
-  sourcemap: 'linked',
+  sourcemap: watchModeEnabled ? 'inline' : 'linked',
   define: {
     'process.env.PKG_VERSION': JSON.stringify(version),
   },
@@ -45,7 +45,6 @@ const bundles = [
     ...commonBuildOptions,
     format: 'cjs',
     external,
-    outExtension: { '.js': '.cjs' },
     entryNames: `[dir]/[name].${platform}`,
     outdir: resolve(__dirname, '../dist/cjs'),
     platform,
@@ -58,6 +57,8 @@ const bundles = [
   {
     ...commonBuildOptions,
     format: 'esm',
+    external,
+    outExtension: { '.js': '.mjs' },
     outdir: resolve(__dirname, '../dist/esm'),
     entryNames: `[dir]/[name]`,
     platform: 'browser',

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -10,17 +10,12 @@ const __dirname = import.meta.dirname;
 
 const watchModeEnabled = process.argv.includes('--watch') || process.argv.includes('-w');
 
-// Those dependencies are distributed as ES modules, and cannot be externalized
-// in our CJS bundle. We convert them to CJS and bundle them instead.
-const bundledDeps = ['axios', 'form-data', 'isomorphic-ws', 'base64-js'];
-
 const version = getPackageVersion();
 
-const deps = Object.keys({
+const external = Object.keys({
   ...packageJson.dependencies,
   ...packageJson.peerDependencies,
 });
-const external = deps.filter((dep) => !bundledDeps.includes(dep));
 
 /** @type esbuild.BuildOptions */
 const commonBuildOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1562,13 +1562,13 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.0.tgz#f1e5292f26b2fd5c2e66876adc5b06cdbd7d2102"
-  integrity sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==
+axios@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
+  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
   dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
 balanced-match@^1.0.0:
@@ -2722,10 +2722,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.15.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+follow-redirects@^1.15.6:
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 for-each@^0.3.3:
   version "0.3.5"
@@ -2741,15 +2741,6 @@ foreground-child@^3.1.0:
   dependencies:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 form-data@^4.0.4:
   version "4.0.4"


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Upgrade `axios` to `v1.12.2` and externalize packages that were previously bundled with the client.