### PR TITLE
fix: do not add error to client notifications for getDrafts

### DIFF
--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -812,12 +812,9 @@ export class MessageComposer extends WithSubscriptions {
 
       this.initState({ composition: draft });
     } catch (error) {
-      this.client.notifications.add({
-        message: 'Failed to get the draft',
-        origin: {
-          emitter: 'MessageComposer',
-          context: { composer: this },
-        },
+      this.client.logger('error', `messageComposer:getDraft`, {
+        tags: ['channel', 'messageComposer'],
+        error,
       });
     }
   };

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -1642,7 +1642,7 @@ describe('MessageComposer', () => {
       const spyChannelGetDraft = vi.spyOn(mockChannel, 'getDraft');
       spyChannelGetDraft.mockRejectedValue(new Error('Failed to get draft'));
 
-      const spyAddNotification = vi.spyOn(mockClient.notifications, 'add');
+      const spyLogger = vi.spyOn(mockClient, 'logger');
 
       await messageComposer.getDraft();
 
@@ -1653,13 +1653,7 @@ describe('MessageComposer', () => {
       expect(initStateSpy).toHaveBeenCalledTimes(1);
       expect(spyChannelGetDraft).toHaveBeenCalled();
       expect(messageComposer.state.getLatestValue().draftId).toBe('test-message-id');
-      expect(spyAddNotification).toHaveBeenCalledWith({
-        message: 'Failed to get the draft',
-        origin: {
-          emitter: 'MessageComposer',
-          context: { composer: messageComposer },
-        },
-      });
+      expect(spyLogger).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
Currently, if you listen to client notifications on your app and move from channel screen to thread screen. This will trigger the notification if a draft is not present for a parent message id as `this.channel.getDrafts` would error out. Ideally, this should be gracefully handled without showing a client-side notification. This has been fixed in the PR. 