### PR TITLE
refactor: make channel and client protected in CommandSearchSource and MentionsSearchSource

### DIFF
--- a/src/messageComposer/middleware/textComposer/commands.ts
+++ b/src/messageComposer/middleware/textComposer/commands.ts
@@ -14,7 +14,7 @@ import type { TextComposerMiddlewareExecutorState } from './TextComposerMiddlewa
 
 export class CommandSearchSource extends BaseSearchSourceSync<CommandSuggestion> {
   readonly type = 'commands';
-  private channel: Channel;
+  protected channel: Channel;
 
   constructor(channel: Channel, options?: SearchSourceOptions) {
     super(options);

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -84,8 +84,8 @@ export type MentionsSearchSourceOptions = SearchSourceOptions & {
 
 export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
   readonly type = 'mentions';
-  private client: StreamChat;
-  private channel: Channel;
+  protected client: StreamChat;
+  protected channel: Channel;
   userFilters: UserFilters | undefined;
   memberFilters: MemberFilters | undefined;
   userSort: UserSort | undefined;


### PR DESCRIPTION
## Goal

Allow integrators to access channel and client in classes derived from CommandSearchSource and MentionsSearchSource
