### PR TITLE
feat: add MentionsSearchSource.toUserSuggestion method

### DIFF
--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -111,6 +111,14 @@ export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
     return countLoadedMembers < MAX_CHANNEL_MEMBER_COUNT_IN_CHANNEL_QUERY;
   }
 
+  toUserSuggestion = (user: UserResponse): UserSuggestion => ({
+    ...user,
+    ...getTokenizedSuggestionDisplayName({
+      displayName: user.name || user.id,
+      searchToken: this.searchQuery,
+    }),
+  });
+
   getStateBeforeFirstQuery(newSearchString: string) {
     const newState = super.getStateBeforeFirstQuery(newSearchString);
     const { items } = this.state.getLatestValue();
@@ -255,16 +263,7 @@ export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
     }
 
     return {
-      items: users.map(
-        (user) =>
-          ({
-            ...user,
-            ...getTokenizedSuggestionDisplayName({
-              displayName: user.name || user.id,
-              searchToken: this.searchQuery,
-            }),
-          }) as UserSuggestion,
-      ),
+      items: users.map(this.toUserSuggestion),
     };
   }
 


### PR DESCRIPTION
## Goal

Allow integrators to convert UserResponse objects in their custom `MentionsSearchSource.query()` implementation into `UserSuggestion` objects:


```ts
class CustomMentionsSearchSource extends MentionsSearchSource {
  constructor(channel: ChannelType) {
    super(channel);
  }

  query = async (searchQuery: string) => {
    const response = await this.channel.query({ watchers: { limit: 100 } });
    const items = (response.watchers ?? []).map(this.toUserSuggestion);
    return {
      items,
    };
  };
}
```

Closes REACT-610
Closes REACT-606