### PR TITLE
feat: add delivery_events channel configuration parameter

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4749,17 +4749,14 @@ export class StreamChat {
   }
 
   /**
-   * Send the mark delivered event for this user
+   * Mark the channels delivered for the given messages and the user
    *
    * @param {MarkDeliveredOptions} data
    * @return {Promise<EventAPIResponse | void>} Description
    */
   async markChannelsDelivered(data: MarkDeliveredOptions) {
     if (!data?.latest_delivered_messages?.length) return;
-    return await this.post<EventAPIResponse>(
-      this.baseURL + '/channels/delivered',
-      data ?? {},
-    );
+    return await this.post<EventAPIResponse>(this.baseURL + '/channels/delivered', data);
   }
 
   syncDeliveredCandidates(collections: Channel[]) {

--- a/src/messageDelivery/MessageDeliveryReporter.ts
+++ b/src/messageDelivery/MessageDeliveryReporter.ts
@@ -54,6 +54,11 @@ export class MessageDeliveryReporter {
     return this.deliveryReportCandidates.size > 0;
   }
 
+  private static hasPermissionToReportDeliveryFor(collection: Channel | Thread) {
+    if (isChannel(collection)) return !!collection.getConfig()?.delivery_events;
+    if (isThread(collection)) return !!collection.channel.getConfig()?.delivery_events;
+  }
+
   /**
    * Build latest_delivered_messages payload from an arbitrary buffer (deliveryReportCandidates / nextDeliveryReportCandidates)
    */
@@ -142,8 +147,7 @@ export class MessageDeliveryReporter {
    * @param collection
    */
   private trackDeliveredCandidate(collection: Channel | Thread) {
-    if (isChannel(collection) && !collection.getConfig()?.read_events) return;
-    if (isThread(collection) && !collection.channel.getConfig()?.read_events) return;
+    if (!MessageDeliveryReporter.hasPermissionToReportDeliveryFor(collection)) return;
     const candidate = this.getNextDeliveryReportCandidate(collection);
     if (!candidate?.key) return;
     const buffer = this.markDeliveredRequestInFlight

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,7 @@ export type AppSettingsAPIResponse = APIResponse & {
         connect_events?: boolean;
         created_at?: string;
         custom_events?: boolean;
+        delivery_events?: boolean;
         mark_messages_pending?: boolean;
         max_message_length?: number;
         message_retention?: string;
@@ -1015,6 +1016,7 @@ export type CreateChannelOptions = {
   connect_events?: boolean;
   connection_id?: string;
   custom_events?: boolean;
+  delivery_events?: boolean;
   grants?: Record<string, string[]>;
   mark_messages_pending?: boolean;
   max_message_length?: number;
@@ -1120,6 +1122,7 @@ export type UpdateChannelTypeRequest =
     commands?: CommandVariants[];
     connect_events?: boolean;
     custom_events?: boolean;
+    delivery_events?: boolean;
     grants?: Record<string, string[]>;
     mark_messages_pending?: boolean;
     mutes?: boolean;
@@ -1151,6 +1154,7 @@ export type UpdateChannelTypeResponse = {
   connect_events: boolean;
   created_at: string;
   custom_events: boolean;
+  delivery_events: boolean;
   duration: string;
   grants: Record<string, string[]>;
   mark_messages_pending: boolean;
@@ -1188,6 +1192,7 @@ export type GetChannelTypeResponse = {
   connect_events: boolean;
   created_at: string;
   custom_events: boolean;
+  delivery_events: boolean;
   duration: string;
   grants: Record<string, string[]>;
   mark_messages_pending: boolean;
@@ -2384,6 +2389,7 @@ export type ChannelConfigFields = {
   blocklist_behavior?: ChannelConfigAutomodBehavior;
   connect_events?: boolean;
   custom_events?: boolean;
+  delivery_events?: boolean;
   mark_messages_pending?: boolean;
   max_message_length?: number;
   message_retention?: string;

--- a/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
+++ b/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
@@ -28,7 +28,8 @@ describe('MessageDeliveryReporter', () => {
     channel.initialized = true;
     client.configs[channel.cid] = {
       created_at: '',
-      read_events: true,
+      delivery_events: true,
+      read_events: false,
       reminders: false,
       updated_at: '',
     };
@@ -82,7 +83,8 @@ describe('MessageDeliveryReporter', () => {
     channels.forEach((ch) => {
       client.configs[ch.cid] = {
         created_at: '',
-        read_events: true,
+        delivery_events: true,
+        read_events: false,
         reminders: false,
         updated_at: '',
       };
@@ -130,6 +132,7 @@ describe('MessageDeliveryReporter', () => {
   it('does nothing when read events are disabled in channel config', async () => {
     client.configs[channel.cid] = {
       created_at: '',
+      delivery_events: false,
       read_events: false,
       reminders: false,
       updated_at: '',
@@ -228,14 +231,16 @@ describe('MessageDeliveryReporter', () => {
 
     client.configs[ch1.cid] = {
       created_at: '',
-      read_events: true,
+      delivery_events: true,
+      read_events: false,
       reminders: false,
       updated_at: '',
     };
 
     client.configs[ch2.cid] = {
       created_at: '',
-      read_events: true,
+      delivery_events: true,
+      read_events: false,
       reminders: false,
       updated_at: '',
     };


### PR DESCRIPTION
## Goal

Support new configuration parameter to control the delivery receipts enablement. Now the channel type has config param `delivery_events` that is then also reflected in `channel.own_capabilities` array as string `delivery-receipts`.
