### PR TITLE
feat: add hide_history_before option for adding members

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -331,6 +331,7 @@ export type ChannelAPIResponse = {
 
 export type ChannelUpdateOptions = {
   hide_history?: boolean;
+  hide_history_before?: string | Date;
   skip_push?: boolean;
 };
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

When adding members to a channel, it is now possible to not only hide all channel history for them (via hide_history), but also select a timestamp in the past via hide_history_before. Any activity before that will be hidden.

This PR adds an option to enable this feature.

## Changelog

- feat: add hide_history_before option for adding members
