### PR TITLE
feat: support members_template property for campaigns

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3155,6 +3155,11 @@ export type CampaignData = {
     custom?: {};
     id?: string;
     members?: string[];
+    members_template?: Array<{
+      user_id: string;
+      channel_role?: string;
+      custom?: Record<string, unknown>;
+    }>;
     team?: string;
   };
   create_channels?: boolean;


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

The campaign API recently added support for a new property members_template that can be used as an alternative to members. Its benefit is that the client is also able to define the channel role and custom data for members that are added to newly created channels for campaigns.

## Changelog

- feat: support members_template property for campaigns
