### PR TITLE
feat: add app_banned and has_unread properties to ChannelFilters

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1754,6 +1754,7 @@ export type ReactionFilters = QueryFilters<
 export type ChannelFilters = QueryFilters<
   ContainsOperator<Omit<CustomChannelData, 'name'>> & {
     app_banned?: 'only' | 'excluded';
+    has_unread?: boolean;
     archived?: boolean;
     'member.user.name'?:
       | RequireOnlyOne<{

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -690,35 +690,6 @@ describe('Channel pinning and archiving utils', () => {
       expect(shouldConsiderArchivedChannels(mockFilters)).to.be.true;
     });
   });
-
-  describe('app_banned filter', () => {
-    it('should accept "only" as a valid value', () => {
-      const mockFilters: ChannelFilters = { app_banned: 'only' };
-      expect(mockFilters.app_banned).to.equal('only');
-    });
-
-    it('should accept "excluded" as a valid value', () => {
-      const mockFilters: ChannelFilters = { app_banned: 'excluded' };
-      expect(mockFilters.app_banned).to.equal('excluded');
-    });
-
-    it('should allow app_banned to be combined with other filters', () => {
-      const mockFilters: ChannelFilters = {
-        type: 'messaging',
-        app_banned: 'excluded',
-        archived: false,
-        members: { $in: ['user-1'] },
-      };
-      expect(mockFilters.app_banned).to.equal('excluded');
-      expect(mockFilters.type).to.equal('messaging');
-      expect(mockFilters.archived).to.be.false;
-    });
-
-    it('should allow app_banned to be undefined', () => {
-      const mockFilters: ChannelFilters = { type: 'messaging' };
-      expect(mockFilters.app_banned).to.be.undefined;
-    });
-  });
 });
 
 describe('promoteChannel', () => {


### PR DESCRIPTION
## CLA

- [ YES] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [YES] Code changes are tested

## Description of the changes, What, Why and How?
 - The QueryChannels filter currently supports `app_banned` in the filter: https://getstream.io/chat/docs/javascript/query_channels/
 - But this is not included in the Filter types, causing TS error
<img width="1142" height="403" alt="Screenshot 2025-11-07 at 10 47 30" src="https://github.com/user-attachments/assets/19874bf5-01d4-47b9-9ad8-908f317df06b" />
- Add `app_banned` type to the Channel Filter types


## Changelog
-
