### PR TITLE
test: fix the uuidV4 generator import

### DIFF
--- a/test/typescript/response-generators/channel-type.js
+++ b/test/typescript/response-generators/channel-type.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 
 async function createChannelType() {

--- a/test/typescript/response-generators/channel.js
+++ b/test/typescript/response-generators/channel.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 const fs = require('fs');
 const url = require('url');

--- a/test/typescript/response-generators/client.js
+++ b/test/typescript/response-generators/client.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 
 async function addDevice() {

--- a/test/typescript/response-generators/event.js
+++ b/test/typescript/response-generators/event.js
@@ -1,11 +1,11 @@
-const { v4: uuid4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 
-const johnID = `john-${uuid4()}`;
+const johnID = `john-${uuidv4()}`;
 
 async function keystroke() {
 	const authClient = await utils.getTestClientForUser(johnID, {});
-	const channel = authClient.channel('messaging', `poppins-${uuid4()}`);
+	const channel = authClient.channel('messaging', `poppins-${uuidv4()}`);
 	await channel.watch();
 
 	return await channel.keystroke();
@@ -13,7 +13,7 @@ async function keystroke() {
 
 async function sendMessageReadEvent() {
 	const authClient = await utils.getTestClientForUser(johnID, {});
-	const channel = authClient.channel('messaging', `poppins-${uuid4()}`);
+	const channel = authClient.channel('messaging', `poppins-${uuidv4()}`);
 	await channel.watch();
 	const event = {
 		type: 'message.read',
@@ -24,7 +24,7 @@ async function sendMessageReadEvent() {
 
 async function stopTyping() {
 	const authClient = await utils.getTestClientForUser(johnID, {});
-	const channel = authClient.channel('messaging', `poppins-${uuid4()}`);
+	const channel = authClient.channel('messaging', `poppins-${uuidv4()}`);
 	await channel.watch();
 
 	return await channel.stopTyping();

--- a/test/typescript/response-generators/message.js
+++ b/test/typescript/response-generators/message.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 
 const johnID = `john-${uuidv4()}`;

--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -1,4 +1,4 @@
-const { v4: uuidv4 } = require('uuid');
+const { generateUUIDv4: uuidv4 } = require('../../../src/utils');
 const utils = require('../utils');
 const { sleep } = require('../utils');
 


### PR DESCRIPTION
## Goal

The "typescript" (why are these tests called like that?) tests were importing non-existent dependency (uuid) what lead to failing of ["Scheduled tests"](https://github.com/GetStream/stream-chat-js/actions/runs/19226944348) so I changed the import.
