### PR TITLE
chore: export AttachmentManager middleware module for MessageComposer

### DIFF
--- a/src/messageComposer/middleware/index.ts
+++ b/src/messageComposer/middleware/index.ts
@@ -1,3 +1,4 @@
+export * from './attachmentManager';
 export * from './messageComposer';
 export * from './pollComposer';
 export * from './textComposer';


### PR DESCRIPTION
## Goal

The middleware factories should be exported in case integrators want to override the defaults doing their own mix.
