### PR TITLE
feat: add ephemeralUpdateMessage server-side operation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3102,6 +3102,41 @@ export class StreamChat {
   }
 
   /**
+   * Updates message fields without storing them in the database, only sends update event.
+   *
+   * Available only on the server-side.
+   *
+   * @param messageId the message id to update.
+   * @param partialMessageObject the message payload.
+   * @param partialUserOrUserId the user id linked to this action.
+   * @param options additional options.
+   */
+  async ephemeralUpdateMessage(
+    messageId: string,
+    partialMessageObject: PartialMessageUpdate,
+    partialUserOrUserId?: string | { id: string },
+    options?: UpdateMessageOptions,
+  ) {
+    if (!messageId) throw Error('messageId is required');
+
+    let user: { id: string } | undefined = undefined;
+    if (typeof partialUserOrUserId === 'string') {
+      user = { id: partialUserOrUserId };
+    } else if (typeof partialUserOrUserId?.id === 'string') {
+      user = { id: partialUserOrUserId.id };
+    }
+
+    return await this.patch<UpdateMessageAPIResponse>(
+      `${this.baseURL}/messages/${encodeURIComponent(messageId)}/ephemeral`,
+      {
+        ...partialMessageObject,
+        ...options,
+        user,
+      },
+    );
+  }
+
+  /**
    * deleteMessage - Delete a message
    *
    * @param {string} messageID The id of the message to delete


### PR DESCRIPTION
## Changelog

Extends the server-side client with `ephemeralUpdateMessage` operation.
When this API is used, the "updates" aren't stored in the database, but they do generate the `message.updated` event.
This is useful for a flow where a certain message is frequently updated (e.g, integration with LLM).

To preserve the updates, a `client.partialUpdateMessage` must be performed, as otherwise there will be a data loss.
