### PR TITLE
fix: improve type inference for $in filter in queryChannels

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2022,7 +2022,7 @@ export type QueryFilter<ObjectType = string> =
         $exists?: boolean;
         $gt?: PrimitiveFilter<ObjectType>;
         $gte?: PrimitiveFilter<ObjectType>;
-        $in?: PrimitiveFilter<Unpacked<ObjectType>>[];
+        $in?: PrimitiveFilter<ObjectType>[];
         $lt?: PrimitiveFilter<ObjectType>;
         $lte?: PrimitiveFilter<ObjectType>;
       }


### PR DESCRIPTION
## Changelog

Improves the type inference for the `$in` operator in `queryChannels()` filters. 
Fixes: #1661.

Array types weren't properly unpacked, so TS types required nested arrays:
```ts
const channels = await this.streamChat.queryChannels({
   filter_tags: { $in: [`my_tag`] }, // errors
   filter_tags: { $in: [[`my_tag`]]` }, // doesn't error on TS but our API expects a flat array
});
```