### PR TITLE
fix: escape strings interpolated into regular expressions

### DIFF
--- a/src/messageComposer/middleware/textComposer/textMiddlewareUtils.ts
+++ b/src/messageComposer/middleware/textComposer/textMiddlewareUtils.ts
@@ -16,15 +16,16 @@ export const getTriggerCharWithToken = ({
   isCommand?: boolean;
   acceptTrailingSpaces?: boolean;
 }) => {
-  const triggerNorWhitespace = `[^\\s${trigger}]*`;
+  const escapedTrigger = escapeRegExp(trigger);
+  const triggerNorWhitespace = `[^\\s${escapedTrigger}]*`;
 
   const match = text.match(
     new RegExp(
       isCommand
-        ? `^[${trigger}]${triggerNorWhitespace}$`
+        ? `^[${escapedTrigger}]${triggerNorWhitespace}$`
         : acceptTrailingSpaces
-          ? `(?!^|\\W)?[${trigger}]${triggerNorWhitespace}\\s?${triggerNorWhitespace}$`
-          : `(?!^|\\W)?[${trigger}]${triggerNorWhitespace}$`,
+          ? `(?!^|\\W)?[${escapedTrigger}]${triggerNorWhitespace}\\s?${triggerNorWhitespace}$`
+          : `(?!^|\\W)?[${escapedTrigger}]${triggerNorWhitespace}$`,
       'g',
     ),
   );


### PR DESCRIPTION
## Goal

Keep consistency in escaping strings interpolated into regular expressions.

#### Note:
Many thanks to **[Kilkat] Security Researcher @kilkat** for reporting this issue and providing a PoC for it.
