### PR TITLE
fix: add $autocomplete and $q to string-type properties

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1787,7 +1787,7 @@ export type ReactionFilters = QueryFilters<
 >;
 
 export type ChannelFilters = QueryFilters<
-  ContainsOperator<Omit<CustomChannelData, 'name'>> & {
+  ContainsOperator<CustomChannelData & { name?: string }> & {
     app_banned?: 'only' | 'excluded';
     has_unread?: boolean;
     archived?: boolean;
@@ -1802,19 +1802,12 @@ export type ChannelFilters = QueryFilters<
       | RequireOnlyOne<Pick<QueryFilter<string>, '$in'>>
       | RequireOnlyOne<Pick<QueryFilter<string[]>, '$eq'>>
       | PrimitiveFilter<string[]>;
-    name?:
-      | RequireOnlyOne<
-          {
-            $autocomplete?: string;
-          } & QueryFilter<string>
-        >
-      | PrimitiveFilter<string>;
     pinned?: boolean;
     last_updated?:
       | RequireOnlyOne<Pick<QueryFilter<string>, '$eq' | '$gt' | '$gte' | '$lt' | '$lte'>>
       | PrimitiveFilter<string>;
   } & {
-    [Key in keyof Omit<ChannelResponse, 'name' | 'members' | keyof CustomChannelData>]:
+    [Key in keyof Omit<ChannelResponse, 'members' | keyof CustomChannelData>]:
       | RequireOnlyOne<QueryFilter<ChannelResponse[Key]>>
       | PrimitiveFilter<ChannelResponse[Key]>;
   }
@@ -2025,7 +2018,12 @@ export type QueryFilter<ObjectType = string> =
         $in?: PrimitiveFilter<ObjectType>[];
         $lt?: PrimitiveFilter<ObjectType>;
         $lte?: PrimitiveFilter<ObjectType>;
-      }
+      } & (NonNullable<ObjectType> extends string
+        ? {
+            $autocomplete?: PrimitiveFilter<ObjectType>;
+            $q?: PrimitiveFilter<ObjectType>;
+          }
+        : {})
     : {
         $eq?: PrimitiveFilter<ObjectType>;
         $exists?: boolean;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Extend `ContainsOperator` type to add `$autocomplete` and `$q` filters to string-type properties, including custom data. 