### PR TITLE
feat: extend sort with field type

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -12,7 +12,6 @@ import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from './constants';
 import type {
   AIState,
   APIResponse,
-  AscDesc,
   BanUserOptions,
   ChannelAPIResponse,
   ChannelData,
@@ -66,6 +65,7 @@ import type {
   SendMessageAPIResponse,
   SendMessageOptions,
   SendReactionOptions,
+  Sort,
   StaticLocationPayload,
   TruncateChannelAPIResponse,
   TruncateOptions,
@@ -1305,7 +1305,7 @@ export class Channel {
   async getReplies(
     parent_id: string,
     options: MessagePaginationOptions & { user?: UserResponse; user_id?: string },
-    sort?: { created_at: AscDesc }[],
+    sort?: Required<Sort<'created_at'>>[],
   ) {
     const normalizedSort = sort ? normalizeQuerySort(sort) : undefined;
     const data = await this.getClient().get<GetRepliesAPIResponse>(

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -6,12 +6,12 @@ import {
   throttle,
 } from './utils';
 import type {
-  AscDesc,
   EventTypes,
   LocalMessage,
   MessagePaginationOptions,
   MessageResponse,
   ReadResponse,
+  Sort,
   ThreadResponse,
   UserResponse,
 } from './types';
@@ -22,7 +22,7 @@ import { MessageComposer } from './messageComposer';
 import { WithSubscriptions } from './utils/WithSubscriptions';
 
 type QueryRepliesOptions = {
-  sort?: { created_at: AscDesc }[];
+  sort?: Required<Sort<'created_at'>>[];
 } & MessagePaginationOptions & { user?: UserResponse; user_id?: string };
 
 export type ThreadState = {
@@ -68,7 +68,7 @@ export type ThreadUserReadState = {
 export type ThreadReadState = Record<string, ThreadUserReadState | undefined>;
 
 const DEFAULT_PAGE_LIMIT = 50;
-const DEFAULT_SORT: { created_at: AscDesc }[] = [{ created_at: -1 }];
+const DEFAULT_SORT: QueryRepliesOptions['sort'] = [{ created_at: -1 }];
 const MARK_AS_READ_THROTTLE_TIMEOUT = 1000;
 // TODO: remove this once we move to API v2
 export const THREAD_RESPONSE_RESERVED_KEYS: Record<keyof ThreadResponse, true> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2168,32 +2168,37 @@ export type MemberFilters = QueryFilters<
 
 export type BannedUsersSort = BannedUsersSortBase | Array<BannedUsersSortBase>;
 
-export type BannedUsersSortBase = { created_at?: AscDesc };
+export type BannedUsersSortBase = Sort<'created_at'>;
 
 export type ReactionSort = ReactionSortBase | Array<ReactionSortBase>;
 
-export type ReactionSortBase = Sort<CustomReactionData> & {
-  created_at?: AscDesc;
-};
+export type ReactionSortBase = Sort<CustomReactionData> & Sort<'created_at'>;
 
 export type ChannelSort = ChannelSortBase | Array<ChannelSortBase>;
 
-export type ChannelSortBase = Sort<CustomChannelData> & {
-  created_at?: AscDesc;
-  has_unread?: AscDesc;
-  last_message_at?: AscDesc;
-  last_updated?: AscDesc;
-  member_count?: AscDesc;
-  pinned_at?: AscDesc;
-  unread_count?: AscDesc;
-  updated_at?: AscDesc;
-};
+export type ChannelSortBase = Sort<CustomChannelData> &
+  Sort<
+    | 'created_at'
+    | 'has_unread'
+    | 'last_message_at'
+    | 'last_updated'
+    | 'member_count'
+    | 'pinned_at'
+    | 'unread_count'
+    | 'updated_at'
+  >;
 
 export type PinnedMessagesSort = PinnedMessagesSortBase | Array<PinnedMessagesSortBase>;
-export type PinnedMessagesSortBase = { pinned_at?: AscDesc };
+export type PinnedMessagesSortBase = Sort<'pinned_at'>;
 
-export type Sort<T> = {
-  [P in keyof T]?: AscDesc;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Sort<T extends string | Record<string, any>> = {
+  [P in T extends string ? T : keyof T]?:
+    | AscDesc
+    | {
+        direction: AscDesc;
+        type?: 'string' | 'number';
+      };
 };
 
 export type UserSort = Sort<UserResponse> | Array<Sort<UserResponse>>;
@@ -2212,51 +2217,40 @@ export type MemberSort =
       >
     >;
 
-export type SearchMessageSortBase = Sort<CustomMessageData> & {
-  attachments?: AscDesc;
-  'attachments.type'?: AscDesc;
-  created_at?: AscDesc;
-  id?: AscDesc;
-  'mentioned_users.id'?: AscDesc;
-  parent_id?: AscDesc;
-  pinned?: AscDesc;
-  relevance?: AscDesc;
-  reply_count?: AscDesc;
-  text?: AscDesc;
-  type?: AscDesc;
-  updated_at?: AscDesc;
-  'user.id'?: AscDesc;
-};
+export type SearchMessageSortBase = Sort<CustomMessageData> &
+  Sort<
+    | 'attachments'
+    | 'attachments.type'
+    | 'created_at'
+    | 'id'
+    | 'mentioned_users.id'
+    | 'parent_id'
+    | 'pinned'
+    | 'relevance'
+    | 'reply_count'
+    | 'text'
+    | 'type'
+    | 'updated_at'
+    | 'user.id'
+  >;
 
 export type SearchMessageSort = SearchMessageSortBase | Array<SearchMessageSortBase>;
 
 export type QuerySort = BannedUsersSort | ChannelSort | SearchMessageSort | UserSort;
 
-export type DraftSortBase = {
-  created_at?: AscDesc;
-};
+export type DraftSortBase = Sort<'created_ats'>;
 
 export type DraftSort = DraftSortBase | Array<DraftSortBase>;
 
 export type PollSort = PollSortBase | Array<PollSortBase>;
 
-export type PollSortBase = {
-  created_at?: AscDesc;
-  id?: AscDesc;
-  is_closed?: AscDesc;
-  name?: AscDesc;
-  updated_at?: AscDesc;
-};
+export type PollSortBase = Sort<
+  'created_at' | 'id' | 'is_closed' | 'name' | 'updated_at'
+>;
 
 export type VoteSort = VoteSortBase | Array<VoteSortBase>;
 
-export type VoteSortBase = {
-  created_at?: AscDesc;
-  id?: AscDesc;
-  is_closed?: AscDesc;
-  name?: AscDesc;
-  updated_at?: AscDesc;
-};
+export type VoteSortBase = PollSortBase;
 
 /**
  * Base Types
@@ -3569,10 +3563,9 @@ export type QueryMessageHistorySort =
   | QueryMessageHistorySortBase
   | Array<QueryMessageHistorySortBase>;
 
-export type QueryMessageHistorySortBase = {
-  message_updated_at?: AscDesc;
-  message_updated_by_id?: AscDesc;
-};
+export type QueryMessageHistorySortBase = Sort<
+  'message_updated_at' | 'message_updated_by_id'
+>;
 
 export type QueryMessageHistoryOptions = Pager;
 
@@ -4321,15 +4314,15 @@ export type LiveLocationPayload = {
 
 export type ThreadSort = ThreadSortBase | Array<ThreadSortBase>;
 
-export type ThreadSortBase = {
-  active_participant_count?: AscDesc;
-  created_at?: AscDesc;
-  last_message_at?: AscDesc;
-  parent_message_id?: AscDesc;
-  participant_count?: AscDesc;
-  reply_count?: AscDesc;
-  updated_at?: AscDesc;
-};
+export type ThreadSortBase = Sort<
+  | 'active_participant_count'
+  | 'created_at'
+  | 'last_message_at'
+  | 'parent_message_id'
+  | 'participant_count'
+  | 'reply_count'
+  | 'updated_at'
+>;
 
 export type ThreadFilters = QueryFilters<
   {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -1753,13 +1753,17 @@ describe('Channel search', async () => {
 
 	it('search with sorting by defined field', async () => {
 		client.get = (url, config) => {
-			expect(config.payload.sort).to.be.eql([{ field: 'updated_at', direction: -1 }]);
+			expect(config.payload.sort).toEqual([
+				{ field: 'updated_at', direction: -1, type: null },
+			]);
 		};
 		await channel.search('query', { sort: [{ updated_at: -1 }] });
 	});
 	it('search with sorting by custom field', async () => {
 		client.get = (url, config) => {
-			expect(config.payload.sort).to.be.eql([{ field: 'custom_field', direction: -1 }]);
+			expect(config.payload.sort).toEqual([
+				{ field: 'custom_field', direction: -1, type: null },
+			]);
 		};
 		await channel.search('query', { sort: [{ custom_field: -1 }] });
 	});

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -518,7 +518,9 @@ describe('Client search', async () => {
 
 	it('search with sorting by defined field', async () => {
 		client.get = (url, config) => {
-			expect(config.payload.sort).to.be.eql([{ field: 'updated_at', direction: -1 }]);
+			expect(config.payload.sort).toEqual([
+				{ field: 'updated_at', direction: -1, type: null },
+			]);
 		};
 		await client.search({ cid: 'messaging:my-cid' }, 'query', {
 			sort: [{ updated_at: -1 }],
@@ -526,7 +528,9 @@ describe('Client search', async () => {
 	});
 	it('search with sorting by custom field', async () => {
 		client.get = (url, config) => {
-			expect(config.payload.sort).to.be.eql([{ field: 'custom_field', direction: -1 }]);
+			expect(config.payload.sort).toEqual([
+				{ field: 'custom_field', direction: -1, type: null },
+			]);
 		};
 		await client.search({ cid: 'messaging:my-cid' }, 'query', {
 			sort: [{ custom_field: -1 }],
@@ -536,7 +540,7 @@ describe('Client search', async () => {
 		await expect(
 			client.search({ cid: 'messaging:my-cid' }, 'query', {
 				offset: 1,
-				sort: [{ custom_field: -1 }],
+				sort: [{ custom_field: -1, type: null }],
 			}),
 		).resolves.toEqual();
 	});

--- a/test/unit/reminders/reminder.api.test.js
+++ b/test/unit/reminders/reminder.api.test.js
@@ -223,7 +223,7 @@ describe('Reminder', () => {
 					channel_cid: 'messaging:123',
 					remind_at: { $gt: '2024-01-01T00:00:00.000Z' },
 				},
-				sort: [{ field: 'remind_at', direction: 1 }],
+				sort: [{ field: 'remind_at', direction: 1, type: null }],
 				limit: 10,
 			});
 			expect(result).toEqual(queryResponse);

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -67,12 +67,36 @@ describe('test if sort is deterministic', () => {
 		expect(sort).to.have.length(4);
 		expect(sort[0].field).to.be.equal('created_at');
 		expect(sort[0].direction).to.be.equal(1);
+		expect(sort[0].type).toBe(null);
 		expect(sort[1].field).to.be.equal('has_unread');
 		expect(sort[1].direction).to.be.equal(-1);
+		expect(sort[1].type).toBe(null);
 		expect(sort[2].field).to.be.equal('last_active');
 		expect(sort[2].direction).to.be.equal(1);
+		expect(sort[2].type).toBe(null);
 		expect(sort[3].field).to.be.equal('deleted_at');
 		expect(sort[3].direction).to.be.equal(-1);
+		expect(sort[3].type).toBe(null);
+	});
+	it('test sort array with typed fields', () => {
+		let sort = normalizeQuerySort([
+			{ created_at: { direction: -1, type: 'string' }, has_unread: -1 },
+			{ last_active: 1, deleted_at: -1 },
+		]);
+
+		expect(sort).to.have.length(4);
+		expect(sort[0].field).to.be.equal('created_at');
+		expect(sort[0].direction).to.be.equal(-1);
+		expect(sort[0].type).toBe('string');
+		expect(sort[1].field).to.be.equal('has_unread');
+		expect(sort[1].direction).to.be.equal(-1);
+		expect(sort[1].type).toBe(null);
+		expect(sort[2].field).to.be.equal('last_active');
+		expect(sort[2].direction).to.be.equal(1);
+		expect(sort[2].type).toBe(null);
+		expect(sort[3].field).to.be.equal('deleted_at');
+		expect(sort[3].direction).to.be.equal(-1);
+		expect(sort[3].type).toBe(null);
 	});
 });
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

This PR allows integrators to decide how the target field should be asserted during sorting.

https://getstream.slack.com/archives/C06CF5TKRGA/p1767637494321509?thread_ts=1767298663.322459&cid=C06CF5TKRGA

```ts
const sort: ChannelSort = {
  member_count: { direction: -1, type: 'number' },
  has_unread: -1,
};
```