### PR TITLE
feat: add Channel and Thread display name and image generators

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -115,6 +115,8 @@ export class Channel {
   public readonly messageComposer: MessageComposer;
   public readonly messageReceiptsTracker: MessageReceiptsTracker;
   public readonly cooldownTimer: CooldownTimer;
+  public customDisplayNameGenerator?: (channel: Channel) => string | null | undefined;
+  public customDisplayImageGenerator?: (channel: Channel) => string | null | undefined;
 
   /**
    * constructor - Create a channel
@@ -194,6 +196,82 @@ export class Channel {
   getConfig() {
     const client = this.getClient();
     return client.configs[this.cid];
+  }
+
+  /**
+   * Returns the display name for this channel using the following fallback chain:
+   * 1. Result of `customDisplayNameGenerator` (if set on this instance)
+   * 2. The channel's `name` custom data property
+   * 3. For DM channels (exactly 2 members): the other member's name, then id, then "Direct Message"
+   * 4. For group channels (3+ members): comma-separated list of 2 other members' names
+   * 5. `null` if none of the above produced a value
+   *
+   * @return {string | null}
+   */
+  getDisplayName(): string | null {
+    // 1. Try custom logic
+    if (this.customDisplayNameGenerator) {
+      const custom = this.customDisplayNameGenerator(this);
+      if (custom) return custom;
+    }
+
+    // 2. Fall back to name
+    if (
+      this.data &&
+      'name' in this.data &&
+      typeof this.data.name === 'string' &&
+      this.data.name
+    ) {
+      return this.data.name;
+    }
+
+    const members = Object.values(this.state.members);
+    const currentUserId = this._client.userID;
+    const otherMembers = members.filter((member) => member.user?.id !== currentUserId);
+
+    // 3. Fall back 1:1 channels: other member's name, then id, then "Direct Message"
+    if (members.length === 2 && otherMembers.length === 1) {
+      const otherUser = otherMembers[0].user;
+      return otherUser?.name || otherUser?.id || 'Direct Message';
+    }
+
+    // 4. Fall back group channels: comma-separated list of other members' names (or ids); ellipsis if >2
+    if (otherMembers.length > 0) {
+      const names = otherMembers
+        .map((member) => member.user?.name || member.user?.id)
+        .filter(Boolean);
+      if (names.length > 0) {
+        return names.length > 2 ? `${names.slice(0, 2).join(', ')}...` : names.join(', ');
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the display image URL for this channel using the following fallback chain:
+   * 1. Result of `customDisplayImageGenerator` (if set on this instance)
+   * 2. The channel's `image` custom data property
+   * 3. `null` if none of the above produced a value
+   *
+   * @return {string | null}
+   */
+  getDisplayImage(): string | null {
+    if (this.customDisplayImageGenerator) {
+      const custom = this.customDisplayImageGenerator(this);
+      if (custom) return custom;
+    }
+
+    if (
+      this.data &&
+      'image' in this.data &&
+      typeof this.data.image === 'string' &&
+      this.data.image
+    ) {
+      return this.data.image;
+    }
+
+    return null;
   }
 
   /**

--- a/src/notifications/NotificationManager.ts
+++ b/src/notifications/NotificationManager.ts
@@ -44,6 +44,7 @@ export class NotificationManager {
     const now = Date.now();
     const severity = options.severity || 'info';
     const duration = options.duration ?? this.config.durations[severity];
+    const isPersistent = duration === 0;
 
     const notification: Notification = {
       id,
@@ -52,7 +53,7 @@ export class NotificationManager {
       type: options?.type,
       severity,
       createdAt: now,
-      expiresAt: now + duration,
+      expiresAt: isPersistent ? undefined : now + duration,
       actions: options.actions,
       metadata: options.metadata,
       originalError: options.originalError,
@@ -62,11 +63,10 @@ export class NotificationManager {
       notifications: [...this.store.getLatestValue().notifications, notification],
     });
 
-    if (notification.expiresAt) {
+    if (!isPersistent && notification.expiresAt != null) {
       const timeout = setTimeout(() => {
         this.remove(id);
-      }, options.duration || this.config.durations[notification.severity]);
-
+      }, duration);
       this.timeouts.set(id, timeout);
     }
 

--- a/src/notifications/types.ts
+++ b/src/notifications/types.ts
@@ -91,7 +91,10 @@ export type Notification = {
 export type NotificationOptions = Partial<
   Pick<Notification, 'type' | 'severity' | 'actions' | 'metadata' | 'originalError'>
 > & {
-  /** How long a notification should be displayed in milliseconds */
+  /**
+   * How long a notification should be displayed in milliseconds.
+   * Use `0` for persistent (no auto-dismiss); call `client.notifications.remove(id)` to dismiss.
+   */
   duration?: number;
 };
 

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -113,6 +113,9 @@ export class Thread extends WithSubscriptions {
   public readonly state: StateStore<ThreadState>;
   public readonly id: string;
   public readonly messageComposer: MessageComposer;
+  public customDisplayNameGenerator?: (
+    threadState: ThreadState,
+  ) => string | null | undefined;
 
   private client: StreamChat;
   private failedRepliesMap: Map<string, LocalMessage> = new Map();
@@ -192,6 +195,36 @@ export class Thread extends WithSubscriptions {
 
   get ownUnreadCount() {
     return ownUnreadCountSelector(this.client.userID)(this.state.getLatestValue());
+  }
+
+  /**
+   * Returns the display name for this thread using the following fallback chain:
+   * 1. Result of `customDisplayNameGenerator` (if set on this instance)
+   * 2. The thread's `title`
+   * 3. Comma-separated participant names (capped at 2), using `user.name` or `user.id`
+   * 4. `null` if none of the above produced a value
+   *
+   * @return {string | null}
+   */
+  getDisplayName(): string | null {
+    const currentState = this.state.getLatestValue();
+
+    if (this.customDisplayNameGenerator) {
+      const custom = this.customDisplayNameGenerator(currentState);
+      if (custom) return custom;
+    }
+
+    if (currentState.title) return currentState.title;
+
+    const { participants } = currentState;
+    if (participants && participants.length > 0) {
+      const names = participants.map((p) => p.user?.name || p.user?.id).filter(Boolean);
+      if (names.length > 0) {
+        return names.length > 2 ? `${names.slice(0, 2).join(', ')}...` : names.join(', ');
+      }
+    }
+
+    return null;
   }
 
   public activate = () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2499,3 +2499,198 @@ describe('share location', () => {
 		});
 	});
 });
+
+describe('Channel getDisplayName', () => {
+	let client;
+	const currentUser = { id: 'current-user', name: 'Current User', image: 'current.jpg' };
+
+	beforeEach(() => {
+		client = new StreamChat('apiKey');
+		client._setUser(currentUser);
+	});
+
+	describe('fallback 1: customDisplayNameGenerator', () => {
+		it('returns custom value when generator returns a string', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'My Channel' });
+			channel.customDisplayNameGenerator = () => 'Custom Title';
+			expect(channel.getDisplayName()).to.equal('Custom Title');
+		});
+
+		it('passes channel instance to generator', () => {
+			const channel = client.channel('messaging', 'test-id');
+			let received;
+			channel.customDisplayNameGenerator = (ch) => {
+				received = ch;
+				return null;
+			};
+			channel.getDisplayName();
+			expect(received).to.equal(channel);
+		});
+
+		it('falls through when generator returns null', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Fallback Name' });
+			channel.customDisplayNameGenerator = () => null;
+			expect(channel.getDisplayName()).to.equal('Fallback Name');
+		});
+
+		it('falls through when generator returns empty string', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Fallback Name' });
+			channel.customDisplayNameGenerator = () => '';
+			expect(channel.getDisplayName()).to.equal('Fallback Name');
+		});
+	});
+
+	describe('fallback 2: channel.data.name', () => {
+		it('returns channel name when set', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'My Channel' });
+			expect(channel.getDisplayName()).to.equal('My Channel');
+		});
+
+		it('returns null when name is empty string (then no members)', () => {
+			const channel = client.channel('messaging', 'test-id', { name: '' });
+			expect(channel.getDisplayName()).to.be.null;
+		});
+	});
+
+	describe('fallback 3: DM (exactly 2 members) – other member name, then id, then "Direct Message"', () => {
+		it('returns other member name', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user', name: 'Other User' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Other User');
+		});
+
+		it('returns other member id when name is missing', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user' } },
+			};
+			expect(channel.getDisplayName()).to.equal('other-user');
+		});
+
+		it('returns "Direct Message" when other member has no name or id', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: undefined },
+			};
+			expect(channel.getDisplayName()).to.equal('Direct Message');
+		});
+
+		it('channel name wins over DM member', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Custom Name' });
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user', name: 'Other User' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Custom Name');
+		});
+	});
+
+	describe('fallback 4: group (3+ members) – comma-separated names, ellipsis when >2', () => {
+		it('returns two names without ellipsis when exactly 2 other members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, Bob');
+		});
+
+		it('uses user id when member has no name', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, user-3');
+		});
+
+		it('returns first two names plus ellipsis when more than 2 other members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+				'user-4': { user: { id: 'user-4', name: 'Charlie' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, Bob...');
+		});
+
+		it('channel name wins over group member names', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Custom Name' });
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Custom Name');
+		});
+	});
+
+	describe('fallback 5: no value', () => {
+		it('returns null when no data and no members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			expect(channel.getDisplayName()).to.be.null;
+		});
+	});
+});
+
+describe('Channel getDisplayImage', () => {
+	let client;
+	const currentUser = { id: 'current-user', name: 'Current User', image: 'current.jpg' };
+
+	beforeEach(() => {
+		client = new StreamChat('apiKey');
+		client._setUser(currentUser);
+	});
+
+	describe('fallback 1: customDisplayImageGenerator', () => {
+		it('returns custom value when generator returns a string', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'data.jpg' });
+			channel.customDisplayImageGenerator = () => 'custom-image.jpg';
+			expect(channel.getDisplayImage()).to.equal('custom-image.jpg');
+		});
+
+		it('passes channel instance to generator', () => {
+			const channel = client.channel('messaging', 'test-id');
+			let received;
+			channel.customDisplayImageGenerator = (ch) => {
+				received = ch;
+				return null;
+			};
+			channel.getDisplayImage();
+			expect(received).to.equal(channel);
+		});
+
+		it('falls through when generator returns null', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'fallback.jpg' });
+			channel.customDisplayImageGenerator = () => null;
+			expect(channel.getDisplayImage()).to.equal('fallback.jpg');
+		});
+	});
+
+	describe('fallback 2: channel.data.image', () => {
+		it('returns channel image when set', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'channel.jpg' });
+			expect(channel.getDisplayImage()).to.equal('channel.jpg');
+		});
+
+		it('returns null when image is empty string', () => {
+			const channel = client.channel('messaging', 'test-id', { image: '' });
+			expect(channel.getDisplayImage()).to.be.null;
+		});
+	});
+
+	describe('fallback 3: no value', () => {
+		it('returns null when no image available', () => {
+			const channel = client.channel('messaging', 'test-id');
+			expect(channel.getDisplayImage()).to.be.null;
+		});
+	});
+});

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -82,6 +82,145 @@ describe('Threads 2.0', () => {
     });
 
     describe('Methods', () => {
+      describe('getDisplayName', () => {
+        describe('fallback 1: customDisplayNameGenerator', () => {
+          it('returns custom value when generator returns a string', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => 'Custom Title';
+            expect(thread.getDisplayName()).to.equal('Custom Title');
+          });
+
+          it('passes current ThreadState to generator', () => {
+            const thread = createTestThread({ title: 'My Title' });
+            let receivedState: unknown;
+            thread.customDisplayNameGenerator = (state) => {
+              receivedState = state;
+              return null;
+            };
+            thread.getDisplayName();
+            expect(receivedState).to.equal(thread.state.getLatestValue());
+          });
+
+          it('falls through when generator returns null', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => null;
+            expect(thread.getDisplayName()).to.equal('Thread Title');
+          });
+
+          it('falls through when generator returns empty string', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => '';
+            expect(thread.getDisplayName()).to.equal('Thread Title');
+          });
+        });
+
+        describe('fallback 2: thread.title', () => {
+          it('returns thread title when set', () => {
+            const thread = createTestThread({ title: 'My Thread' });
+            expect(thread.getDisplayName()).to.equal('My Thread');
+          });
+
+          it('title wins over participant names', () => {
+            const thread = createTestThread({
+              title: 'Explicit Title',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+              ],
+            });
+            expect(thread.getDisplayName()).to.equal('Explicit Title');
+          });
+        });
+
+        describe('fallback 3: participants (name or id, ellipsis when >2)', () => {
+          it('returns two names without ellipsis when exactly 2 participants', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u2', name: 'Bob' },
+                },
+              ],
+            });
+            expect(thread.getDisplayName()).to.equal('Alice, Bob');
+          });
+
+          it('uses user id when participant has no name', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u2' },
+                },
+              ],
+            });
+            expect(thread.getDisplayName()).to.equal('Alice, u2');
+          });
+
+          it('returns first two names plus ellipsis when more than 2 participants', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u2', name: 'Bob' },
+                },
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u3', name: 'Charlie' },
+                },
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u4', name: 'Diana' },
+                },
+              ],
+            });
+            expect(thread.getDisplayName()).to.equal('Alice, Bob...');
+          });
+        });
+
+        describe('fallback 4: no value', () => {
+          it('returns null when no title and no participants', () => {
+            const thread = createTestThread({ title: '', thread_participants: [] });
+            expect(thread.getDisplayName()).to.be.null;
+          });
+        });
+      });
+
       describe('upsertReplyLocally', () => {
         it('prevents inserting a new message that does not belong to the associated thread', () => {
           const thread = createTestThread();


### PR DESCRIPTION
## Goal

Have unified logic for Channel and Thread display name and image generation for all the UI SDKs.

In case of no image generated, the Avatar component would decide how many channel member images are used in it. 