### PR TITLE
feat: add channel state reactive stores

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -86,9 +86,19 @@ export class Channel {
   _client: StreamChat;
   type: string;
   id: string | undefined;
-  data: Partial<ChannelData & ChannelResponse> | undefined;
+  /** Backing store for {@link Channel#data}; use the public `data` getter/setter. */
+  private _channelData: Partial<ChannelData & ChannelResponse> | undefined;
   _data: Partial<ChannelData & ChannelResponse>;
   cid: string;
+
+  /** Channel custom data (and API response fields). Updates trigger display refresh when state exists. */
+  get data(): Partial<ChannelData & ChannelResponse> | undefined {
+    return this._channelData;
+  }
+  set data(value: Partial<ChannelData & ChannelResponse> | undefined) {
+    this._channelData = value;
+    this.state?.refreshDisplay?.();
+  }
   /**  */
   listeners: { [key: string]: (string | EventHandler)[] };
   state: ChannelState;
@@ -115,6 +125,8 @@ export class Channel {
   public readonly messageComposer: MessageComposer;
   public readonly messageReceiptsTracker: MessageReceiptsTracker;
   public readonly cooldownTimer: CooldownTimer;
+  public customDisplayNameGenerator?: (channel: Channel) => string | null | undefined;
+  public customDisplayImageGenerator?: (channel: Channel) => string | null | undefined;
 
   /**
    * constructor - Create a channel
@@ -153,6 +165,7 @@ export class Channel {
     this.listeners = {};
     // perhaps the state variable should be private
     this.state = new ChannelState(this);
+    this.state.refreshDisplay(); // initial display after state exists
     this.initialized = false;
     this.offlineMode = false;
     this.lastTypingEvent = null;
@@ -194,6 +207,82 @@ export class Channel {
   getConfig() {
     const client = this.getClient();
     return client.configs[this.cid];
+  }
+
+  /**
+   * Returns the display name for this channel using the following fallback chain:
+   * 1. Result of `customDisplayNameGenerator` (if set on this instance)
+   * 2. The channel's `name` custom data property
+   * 3. For DM channels (exactly 2 members): the other member's name, then id, then "Direct Message"
+   * 4. For group channels (3+ members): comma-separated list of 2 other members' names
+   * 5. `null` if none of the above produced a value
+   *
+   * @return {string | null}
+   */
+  getDisplayName(): string | null {
+    // 1. Try custom logic
+    if (this.customDisplayNameGenerator) {
+      const custom = this.customDisplayNameGenerator(this);
+      if (custom) return custom;
+    }
+
+    // 2. Fall back to name
+    if (
+      this.data &&
+      'name' in this.data &&
+      typeof this.data.name === 'string' &&
+      this.data.name
+    ) {
+      return this.data.name;
+    }
+
+    const members = Object.values(this.state.members);
+    const currentUserId = this._client.userID;
+    const otherMembers = members.filter((member) => member.user?.id !== currentUserId);
+
+    // 3. Fall back 1:1 channels: other member's name, then id, then "Direct Message"
+    if (members.length === 2 && otherMembers.length === 1) {
+      const otherUser = otherMembers[0].user;
+      return otherUser?.name || otherUser?.id || 'Direct Message';
+    }
+
+    // 4. Fall back group channels: comma-separated list of other members' names (or ids); ellipsis if >2
+    if (otherMembers.length > 0) {
+      const names = otherMembers
+        .map((member) => member.user?.name || member.user?.id)
+        .filter(Boolean);
+      if (names.length > 0) {
+        return names.length > 2 ? `${names.slice(0, 2).join(', ')}...` : names.join(', ');
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Returns the display image URL for this channel using the following fallback chain:
+   * 1. Result of `customDisplayImageGenerator` (if set on this instance)
+   * 2. The channel's `image` custom data property
+   * 3. `null` if none of the above produced a value
+   *
+   * @return {string | null}
+   */
+  getDisplayImage(): string | null {
+    if (this.customDisplayImageGenerator) {
+      const custom = this.customDisplayImageGenerator(this);
+      if (custom) return custom;
+    }
+
+    if (
+      this.data &&
+      'image' in this.data &&
+      typeof this.data.image === 'string' &&
+      this.data.image
+    ) {
+      return this.data.image;
+    }
+
+    return null;
   }
 
   /**
@@ -2249,20 +2338,32 @@ export class Channel {
         break;
       case 'user.banned':
         if (!event.user?.id) break;
-        channelState.members[event.user.id] = {
-          ...(channelState.members[event.user.id] || {}),
-          shadow_banned: !!event.shadow,
-          banned: !event.shadow,
-          user: { ...(channelState.members[event.user.id]?.user || {}), ...event.user },
+        channel.state.members = {
+          ...channel.state.members,
+          [event.user.id]: {
+            ...(channel.state.members[event.user.id] || {}),
+            shadow_banned: !!event.shadow,
+            banned: !event.shadow,
+            user: {
+              ...(channel.state.members[event.user.id]?.user || {}),
+              ...event.user,
+            },
+          },
         };
         break;
       case 'user.unbanned':
         if (!event.user?.id) break;
-        channelState.members[event.user.id] = {
-          ...(channelState.members[event.user.id] || {}),
-          shadow_banned: false,
-          banned: false,
-          user: { ...(channelState.members[event.user.id]?.user || {}), ...event.user },
+        channel.state.members = {
+          ...channel.state.members,
+          [event.user.id]: {
+            ...(channel.state.members[event.user.id] || {}),
+            shadow_banned: false,
+            banned: false,
+            user: {
+              ...(channel.state.members[event.user.id]?.user || {}),
+              ...event.user,
+            },
+          },
         };
         break;
       default:

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -213,7 +213,7 @@ export class Channel {
    * Returns the display name for this channel using the following fallback chain:
    * 1. Result of `customDisplayNameGenerator` (if set on this instance)
    * 2. The channel's `name` custom data property
-   * 3. For DM channels (exactly 2 members): the other member's name, then id, then "Direct Message"
+   * 3. For DM channels (exactly 2 members): the other member's name, then "Direct Message"
    * 4. For group channels (3+ members): comma-separated list of 2 other members' names
    * 5. `null` if none of the above produced a value
    *
@@ -240,19 +240,17 @@ export class Channel {
     const currentUserId = this._client.userID;
     const otherMembers = members.filter((member) => member.user?.id !== currentUserId);
 
-    // 3. Fall back 1:1 channels: other member's name, then id, then "Direct Message"
+    // 3. Fall back 1:1 channels: other member's name, then "Direct Message" (no user id in title)
     if (members.length === 2 && otherMembers.length === 1) {
       const otherUser = otherMembers[0].user;
-      return otherUser?.name || otherUser?.id || 'Direct Message';
+      return otherUser?.name || 'Direct Message';
     }
 
-    // 4. Fall back group channels: comma-separated list of other members' names (or ids); ellipsis if >2
+    // 4. Fall back group channels: comma-separated list of other members' names only (no user ids, no ellipsis)
     if (otherMembers.length > 0) {
-      const names = otherMembers
-        .map((member) => member.user?.name || member.user?.id)
-        .filter(Boolean);
+      const names = otherMembers.map((member) => member.user?.name).filter(Boolean);
       if (names.length > 0) {
-        return names.length > 2 ? `${names.slice(0, 2).join(', ')}...` : names.join(', ');
+        return names.join(', ');
       }
     }
 

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -18,6 +18,7 @@ import {
   isBlockedMessage,
 } from './utils';
 import { DEFAULT_MESSAGE_SET_PAGINATION } from './constants';
+import { StateStore } from './store';
 
 type ChannelReadStatus = Record<
   string,
@@ -31,6 +32,37 @@ type ChannelReadStatus = Record<
     last_delivered_message_id?: string;
   }
 >;
+
+export type WatcherState = {
+  watcherCount: number;
+  watchers: Record<string, UserResponse>;
+};
+
+export type TypingUsersState = {
+  typing: Record<string, Event>;
+};
+
+export type ReadState = {
+  read: ChannelReadStatus;
+};
+
+export type MutedUsersState = {
+  mutedUsers: Array<UserResponse>;
+};
+
+export type MembersState = {
+  members: Record<string, ChannelMemberResponse>;
+  memberCount: number;
+};
+
+export type OwnCapabilitiesState = {
+  ownCapabilities: string[];
+};
+
+export type ChannelDisplayState = {
+  displayName: string | null;
+  displayImage: string | null;
+};
 
 const messageSetBounds = (
   a: LocalMessage[] | MessageResponse[],
@@ -69,15 +101,16 @@ const messageSetsOverlapByTimestamp = (a: LocalMessage[], b: LocalMessage[]) =>
  */
 export class ChannelState {
   _channel: Channel;
-  watcher_count: number;
-  typing: Record<string, Event>;
-  read: ChannelReadStatus;
+  readonly watcherStore: StateStore<WatcherState>;
+  readonly typingStore: StateStore<TypingUsersState>;
+  readonly readStore: StateStore<ReadState>;
+  readonly membersStore: StateStore<MembersState>;
+  readonly ownCapabilitiesStore: StateStore<OwnCapabilitiesState>;
+  readonly mutedUsersStore: StateStore<MutedUsersState>;
+  readonly displayStore: StateStore<ChannelDisplayState>;
   pinnedMessages: Array<ReturnType<ChannelState['formatMessage']>>;
   pending_messages: Array<PendingMessageResponse>;
   threads: Record<string, Array<ReturnType<ChannelState['formatMessage']>>>;
-  mutedUsers: Array<UserResponse>;
-  watchers: Record<string, UserResponse>;
-  members: Record<string, ChannelMemberResponse>;
   unreadCount: number;
   membership: ChannelMemberResponse;
   last_message_at: Date | null;
@@ -98,17 +131,29 @@ export class ChannelState {
 
   constructor(channel: Channel) {
     this._channel = channel;
-    this.watcher_count = 0;
-    this.typing = {};
-    this.read = {};
+    this.watcherStore = new StateStore<WatcherState>({
+      watcherCount: 0,
+      watchers: {},
+    });
+    this.typingStore = new StateStore<TypingUsersState>({
+      typing: {},
+    });
+    this.readStore = new StateStore<ReadState>({ read: {} });
+    this.mutedUsersStore = new StateStore<MutedUsersState>({ mutedUsers: [] });
+    this.membersStore = new StateStore<MembersState>({ members: {}, memberCount: 0 });
+    this.ownCapabilitiesStore = new StateStore<OwnCapabilitiesState>({
+      ownCapabilities: [],
+    });
+    this.displayStore = new StateStore<ChannelDisplayState>({
+      displayName: null,
+      displayImage: null,
+    });
+    this.syncMemberCountFromChannelData(channel?.data);
+    this.syncOwnCapabilitiesFromChannelData(channel?.data);
     this.initMessages();
     this.pinnedMessages = [];
     this.pending_messages = [];
     this.threads = {};
-    // a list of users to hide messages from
-    this.mutedUsers = [];
-    this.watchers = {};
-    this.members = {};
     this.membership = {};
     this.unreadCount = 0;
     /**
@@ -122,6 +167,148 @@ export class ChannelState {
       channel?.state?.last_message_at != null
         ? new Date(channel.state.last_message_at)
         : null;
+  }
+
+  /**
+   * Recomputes display name and image from channel and pushes to displayStore so subscribers update.
+   */
+  refreshDisplay(): void {
+    const displayName = this._channel.getDisplayName();
+    const displayImage = this._channel.getDisplayImage();
+    this.displayStore.next({ displayName, displayImage });
+  }
+
+  get members() {
+    return this.membersStore.getLatestValue().members;
+  }
+
+  set members(members: Record<string, ChannelMemberResponse>) {
+    this.membersStore.partialNext({ members });
+    this.refreshDisplay();
+  }
+
+  get member_count() {
+    return this.membersStore.getLatestValue().memberCount;
+  }
+
+  set member_count(memberCount: number) {
+    this.membersStore.partialNext({ memberCount });
+  }
+
+  get read() {
+    return this.readStore.getLatestValue().read;
+  }
+
+  set read(read: ChannelReadStatus) {
+    this.readStore.next({ read });
+  }
+
+  get typing() {
+    return this.typingStore.getLatestValue().typing;
+  }
+
+  set typing(typing: Record<string, Event>) {
+    this.typingStore.next({ typing });
+  }
+
+  syncMemberCountFromChannelData(
+    data: Channel['data'],
+    fallbackData: Channel['data'] = this._channel?.data,
+  ) {
+    const fallbackMemberCount =
+      typeof fallbackData?.member_count === 'number'
+        ? fallbackData.member_count
+        : this.membersStore.getLatestValue().memberCount;
+
+    if (!data || typeof data !== 'object') {
+      this.membersStore.partialNext({ memberCount: fallbackMemberCount ?? 0 });
+      return;
+    }
+
+    const dataDescriptor = Object.getOwnPropertyDescriptor(data, 'member_count');
+    let memberCount =
+      typeof data.member_count === 'number'
+        ? data.member_count
+        : typeof fallbackMemberCount === 'number'
+          ? fallbackMemberCount
+          : undefined;
+
+    this.membersStore.partialNext({ memberCount: memberCount ?? 0 });
+
+    Object.defineProperty(data, 'member_count', {
+      configurable: true,
+      enumerable: dataDescriptor?.enumerable ?? false,
+      get: () => memberCount,
+      set: (nextMemberCount: number | undefined) => {
+        memberCount = typeof nextMemberCount === 'number' ? nextMemberCount : undefined;
+        this.membersStore.partialNext({ memberCount: memberCount ?? 0 });
+      },
+    });
+  }
+
+  syncOwnCapabilitiesFromChannelData(
+    data: Channel['data'],
+    fallbackData: Channel['data'] = this._channel?.data,
+  ) {
+    if (!data || typeof data !== 'object') {
+      this.ownCapabilitiesStore.next({ ownCapabilities: [] });
+      return;
+    }
+
+    let ownCapabilities = Array.isArray(data.own_capabilities)
+      ? [...data.own_capabilities]
+      : Array.isArray(fallbackData?.own_capabilities)
+        ? [...fallbackData.own_capabilities]
+        : [];
+
+    this.ownCapabilitiesStore.next({ ownCapabilities });
+
+    Object.defineProperty(data, 'own_capabilities', {
+      configurable: true,
+      enumerable: false,
+      get: () => ownCapabilities,
+      set: (nextOwnCapabilities: string[] | undefined) => {
+        ownCapabilities = Array.isArray(nextOwnCapabilities)
+          ? [...nextOwnCapabilities]
+          : [];
+        this.ownCapabilitiesStore.next({ ownCapabilities });
+      },
+    });
+  }
+
+  setTypingEvent(userID: string, event: Event) {
+    this.typing = { ...this.typing, [userID]: event };
+  }
+
+  removeTypingEvent(userID: string) {
+    if (!this.typing[userID]) return;
+    const typing = { ...this.typing };
+    delete typing[userID];
+    this.typing = typing;
+  }
+
+  get mutedUsers() {
+    return this.mutedUsersStore.getLatestValue().mutedUsers;
+  }
+
+  set mutedUsers(mutedUsers: Array<UserResponse>) {
+    this.mutedUsersStore.next({ mutedUsers });
+  }
+
+  get watchers() {
+    return this.watcherStore.getLatestValue().watchers;
+  }
+
+  set watchers(watchers: Record<string, UserResponse>) {
+    this.watcherStore.partialNext({ watchers });
+  }
+
+  get watcher_count() {
+    return this.watcherStore.getLatestValue().watcherCount;
+  }
+
+  set watcher_count(watcherCount: number) {
+    this.watcherStore.partialNext({ watcherCount });
   }
 
   get messages() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -1378,14 +1378,21 @@ export class StreamChat {
     for (const channelID in refMap) {
       const channel = this.activeChannels[channelID];
       if (channel?.state) {
-        if (channel.state.members[user.id]) {
-          channel.state.members[user.id].user = user;
+        const state = channel.state;
+        if (state.members[user.id]) {
+          state.members = {
+            ...state.members,
+            [user.id]: { ...state.members[user.id], user },
+          };
         }
-        if (channel.state.watchers[user.id]) {
-          channel.state.watchers[user.id] = user;
+        if (state.watchers[user.id]) {
+          state.watchers = { ...state.watchers, [user.id]: user };
         }
-        if (channel.state.read[user.id]) {
-          channel.state.read[user.id].user = user;
+        if (state.read[user.id]) {
+          state.read = {
+            ...state.read,
+            [user.id]: { ...state.read[user.id], user },
+          };
         }
       }
     }

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -7,6 +7,7 @@ import {
 } from './utils';
 import type {
   AscDesc,
+  DraftResponse,
   EventTypes,
   LocalMessage,
   MessagePaginationOptions,
@@ -34,6 +35,8 @@ export type ThreadState = {
   channel: Channel;
   createdAt: Date;
   custom: CustomThreadData;
+  /** Reactive display name; kept in sync when custom or channel display change. */
+  displayName: string | null;
   deletedAt: Date | null;
   isLoading: boolean;
   isStateStale: boolean;
@@ -113,71 +116,115 @@ export class Thread extends WithSubscriptions {
   public readonly state: StateStore<ThreadState>;
   public readonly id: string;
   public readonly messageComposer: MessageComposer;
+  public customDisplayNameGenerator?: (thread: Thread) => string | null | undefined;
 
   private client: StreamChat;
   private failedRepliesMap: Map<string, LocalMessage> = new Map();
 
+  private refreshDisplay = (): void => {
+    this.state.partialNext({ displayName: this.getDisplayName() });
+  };
+
   constructor({
     client,
     threadData,
+    channel,
+    parentMessage,
+    draft,
   }: {
     client: StreamChat;
-    threadData: ThreadResponse;
+    threadData?: ThreadResponse;
+    channel?: Channel;
+    parentMessage?: MessageResponse | LocalMessage;
+    draft?: DraftResponse;
   }) {
     super();
 
-    const channel = client.channel(threadData.channel.type, threadData.channel.id, {
-      // @ts-expect-error name is a "custom" property
-      name: threadData.channel.name,
-    });
-    channel._hydrateMembers({
-      members: threadData.channel.members ?? [],
-      overrideCurrentState: false,
-    });
+    if (threadData) {
+      const threadChannel = client.channel(
+        threadData.channel.type,
+        threadData.channel.id,
+        {
+          // @ts-expect-error name is a "custom" property
+          name: threadData.channel.name,
+        },
+      );
+      threadChannel._hydrateMembers({
+        members: threadData.channel.members ?? [],
+        overrideCurrentState: false,
+      });
 
-    // For when read object is undefined and due to that unreadMessageCount for
-    // the current user isn't being incremented on message.new
-    const placeholderReadResponse: ReadResponse[] = client.userID
-      ? [
-          {
-            user: { id: client.userID },
-            unread_messages: 0,
-            last_read: new Date().toISOString(),
-          },
-        ]
-      : [];
+      this.state = new StateStore<ThreadState>({
+        active: false,
+        isLoading: false,
+        isStateStale: false,
+        channel: threadChannel,
+        createdAt: new Date(threadData.created_at),
+        deletedAt: threadData.deleted_at ? new Date(threadData.deleted_at) : null,
+        displayName: null,
+        pagination: repliesPaginationFromInitialThread(threadData),
+        parentMessage: formatMessage(threadData.parent_message),
+        participants: threadData.thread_participants,
+        read: formatReadState(
+          !threadData.read || threadData.read.length === 0
+            ? getPlaceholderReadResponse(client.userID)
+            : threadData.read,
+        ),
+        replies: threadData.latest_replies.map(formatMessage),
+        replyCount: threadData.reply_count ?? 0,
+        updatedAt: threadData.updated_at ? new Date(threadData.updated_at) : null,
+        title: threadData.title,
+        custom: constructCustomDataObject(threadData),
+      });
+      this.refreshDisplay();
+      this.id = threadData.parent_message_id;
+    } else {
+      if (!channel) {
+        throw new Error('Channel is required when threadData is not provided');
+      }
+      if (!parentMessage || !parentMessage.id) {
+        throw new Error(
+          'Parent message with a valid id is required when threadData is not provided',
+        );
+      }
 
-    this.state = new StateStore<ThreadState>({
-      // local only
-      active: false,
-      isLoading: false,
-      isStateStale: false,
-      // 99.9% should never change
-      channel,
-      createdAt: new Date(threadData.created_at),
-      // rest
-      deletedAt: threadData.deleted_at ? new Date(threadData.deleted_at) : null,
-      pagination: repliesPaginationFromInitialThread(threadData),
-      parentMessage: formatMessage(threadData.parent_message),
-      participants: threadData.thread_participants,
-      read: formatReadState(
-        !threadData.read || threadData.read.length === 0
-          ? placeholderReadResponse
-          : threadData.read,
-      ),
-      replies: threadData.latest_replies.map(formatMessage),
-      replyCount: threadData.reply_count ?? 0,
-      updatedAt: threadData.updated_at ? new Date(threadData.updated_at) : null,
-      title: threadData.title,
-      custom: constructCustomDataObject(threadData),
-    });
+      const formattedParentMessage = formatMessage(parentMessage);
+      const createdAt = parentMessage.created_at
+        ? new Date(parentMessage.created_at)
+        : new Date();
 
-    this.id = threadData.parent_message_id;
+      this.state = new StateStore<ThreadState>({
+        active: false,
+        channel,
+        createdAt,
+        custom: {},
+        deletedAt: formattedParentMessage.deleted_at,
+        displayName: null,
+        isLoading: false,
+        isStateStale: false,
+        pagination: {
+          isLoadingNext: false,
+          isLoadingPrev: false,
+          nextCursor: null,
+          prevCursor: null,
+        },
+        parentMessage: formattedParentMessage,
+        participants: [],
+        read: formatReadState(getPlaceholderReadResponse(client.userID)),
+        replies: [],
+        replyCount: parentMessage.reply_count ?? 0,
+        title: '',
+        updatedAt: parentMessage.updated_at ? new Date(parentMessage.updated_at) : null,
+      });
+      this.refreshDisplay();
+      this.id = parentMessage.id;
+    }
+
     this.client = client;
 
     this.messageComposer = new MessageComposer({
       client,
-      composition: threadData.draft,
+      composition: threadData?.draft ?? draft,
       compositionContext: this,
     });
   }
@@ -192,6 +239,28 @@ export class Thread extends WithSubscriptions {
 
   get ownUnreadCount() {
     return ownUnreadCountSelector(this.client.userID)(this.state.getLatestValue());
+  }
+
+  /**
+   * Returns the display name for this thread using the following fallback chain:
+   * 1. Result of `customDisplayNameGenerator` (if set on this instance)
+   * 2. The channel's display name (from channel display store)
+   * 3. `null` if none of the above produced a value
+   *
+   * Does not use thread.title nor participant names.
+   *
+   * @return {string | null}
+   */
+  getDisplayName(): string | null {
+    if (this.customDisplayNameGenerator) {
+      const custom = this.customDisplayNameGenerator(this);
+      if (custom) return custom;
+    }
+
+    const channelDisplayName = this.channel.getDisplayName();
+    if (channelDisplayName) return channelDisplayName;
+
+    return null;
   }
 
   public activate = () => {
@@ -234,6 +303,7 @@ export class Thread extends WithSubscriptions {
       custom,
       title,
       deletedAt,
+      pagination,
       parentMessage,
       participants,
       read,
@@ -254,10 +324,12 @@ export class Thread extends WithSubscriptions {
       participants,
       read,
       replyCount,
+      pagination,
       replies: pendingReplies.length ? replies.concat(pendingReplies) : replies,
       updatedAt,
       isStateStale: false,
     });
+    this.refreshDisplay();
   };
 
   public registerSubscriptions = () => {
@@ -291,6 +363,7 @@ export class Thread extends WithSubscriptions {
         // TODO: use threadData.custom once we move to API v2
         custom: constructCustomDataObject(threadData),
       });
+      this.refreshDisplay();
     }).unsubscribe;
 
   private subscribeMarkActiveThreadRead = () =>
@@ -617,6 +690,17 @@ const formatReadState = (read: ReadResponse[]): ThreadReadState =>
     };
     return state;
   }, {});
+
+const getPlaceholderReadResponse = (currentUserId?: string): ReadResponse[] =>
+  currentUserId
+    ? [
+        {
+          user: { id: currentUserId },
+          unread_messages: 0,
+          last_read: new Date().toISOString(),
+        },
+      ]
+    : [];
 
 const repliesPaginationFromInitialThread = (
   thread: ThreadResponse,

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2552,7 +2552,7 @@ describe('Channel getDisplayName', () => {
 		});
 	});
 
-	describe('fallback 3: DM (exactly 2 members) – other member name, then id, then "Direct Message"', () => {
+	describe('fallback 3: DM (exactly 2 members) – other member name, then "Direct Message" (no user id in title)', () => {
 		it('returns other member name', () => {
 			const channel = client.channel('messaging', 'test-id');
 			channel.state.members = {
@@ -2562,13 +2562,13 @@ describe('Channel getDisplayName', () => {
 			expect(channel.getDisplayName()).to.equal('Other User');
 		});
 
-		it('returns other member id when name is missing', () => {
+		it('returns "Direct Message" when other member has no name (no user id in title)', () => {
 			const channel = client.channel('messaging', 'test-id');
 			channel.state.members = {
 				'current-user': { user: currentUser },
 				'other-user': { user: { id: 'other-user' } },
 			};
-			expect(channel.getDisplayName()).to.equal('other-user');
+			expect(channel.getDisplayName()).to.equal('Direct Message');
 		});
 
 		it('returns "Direct Message" when other member has no name or id', () => {
@@ -2590,8 +2590,8 @@ describe('Channel getDisplayName', () => {
 		});
 	});
 
-	describe('fallback 4: group (3+ members) – comma-separated names, ellipsis when >2', () => {
-		it('returns two names without ellipsis when exactly 2 other members', () => {
+	describe('fallback 4: group (3+ members) – comma-separated names only (no ellipsis, no user ids)', () => {
+		it('returns all other member names when exactly 2 other members', () => {
 			const channel = client.channel('messaging', 'test-id');
 			channel.state.members = {
 				'current-user': { user: currentUser },
@@ -2601,17 +2601,17 @@ describe('Channel getDisplayName', () => {
 			expect(channel.getDisplayName()).to.equal('Alice, Bob');
 		});
 
-		it('uses user id when member has no name', () => {
+		it('uses only names (skips members with no name, no user id in title)', () => {
 			const channel = client.channel('messaging', 'test-id');
 			channel.state.members = {
 				'current-user': { user: currentUser },
 				'user-2': { user: { id: 'user-2', name: 'Alice' } },
 				'user-3': { user: { id: 'user-3' } },
 			};
-			expect(channel.getDisplayName()).to.equal('Alice, user-3');
+			expect(channel.getDisplayName()).to.equal('Alice');
 		});
 
-		it('returns first two names plus ellipsis when more than 2 other members', () => {
+		it('returns all names concatenated without ellipsis when more than 2 other members', () => {
 			const channel = client.channel('messaging', 'test-id');
 			channel.state.members = {
 				'current-user': { user: currentUser },
@@ -2619,7 +2619,7 @@ describe('Channel getDisplayName', () => {
 				'user-3': { user: { id: 'user-3', name: 'Bob' } },
 				'user-4': { user: { id: 'user-4', name: 'Charlie' } },
 			};
-			expect(channel.getDisplayName()).to.equal('Alice, Bob...');
+			expect(channel.getDisplayName()).to.equal('Alice, Bob, Charlie');
 		});
 
 		it('channel name wins over group member names', () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2499,3 +2499,198 @@ describe('share location', () => {
 		});
 	});
 });
+
+describe('Channel getDisplayName', () => {
+	let client;
+	const currentUser = { id: 'current-user', name: 'Current User', image: 'current.jpg' };
+
+	beforeEach(() => {
+		client = new StreamChat('apiKey');
+		client._setUser(currentUser);
+	});
+
+	describe('fallback 1: customDisplayNameGenerator', () => {
+		it('returns custom value when generator returns a string', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'My Channel' });
+			channel.customDisplayNameGenerator = () => 'Custom Title';
+			expect(channel.getDisplayName()).to.equal('Custom Title');
+		});
+
+		it('passes channel instance to generator', () => {
+			const channel = client.channel('messaging', 'test-id');
+			let received;
+			channel.customDisplayNameGenerator = (ch) => {
+				received = ch;
+				return null;
+			};
+			channel.getDisplayName();
+			expect(received).to.equal(channel);
+		});
+
+		it('falls through when generator returns null', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Fallback Name' });
+			channel.customDisplayNameGenerator = () => null;
+			expect(channel.getDisplayName()).to.equal('Fallback Name');
+		});
+
+		it('falls through when generator returns empty string', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Fallback Name' });
+			channel.customDisplayNameGenerator = () => '';
+			expect(channel.getDisplayName()).to.equal('Fallback Name');
+		});
+	});
+
+	describe('fallback 2: channel.data.name', () => {
+		it('returns channel name when set', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'My Channel' });
+			expect(channel.getDisplayName()).to.equal('My Channel');
+		});
+
+		it('returns null when name is empty string (then no members)', () => {
+			const channel = client.channel('messaging', 'test-id', { name: '' });
+			expect(channel.getDisplayName()).to.be.null;
+		});
+	});
+
+	describe('fallback 3: DM (exactly 2 members) – other member name, then id, then "Direct Message"', () => {
+		it('returns other member name', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user', name: 'Other User' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Other User');
+		});
+
+		it('returns other member id when name is missing', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user' } },
+			};
+			expect(channel.getDisplayName()).to.equal('other-user');
+		});
+
+		it('returns "Direct Message" when other member has no name or id', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: undefined },
+			};
+			expect(channel.getDisplayName()).to.equal('Direct Message');
+		});
+
+		it('channel name wins over DM member', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Custom Name' });
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'other-user': { user: { id: 'other-user', name: 'Other User' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Custom Name');
+		});
+	});
+
+	describe('fallback 4: group (3+ members) – comma-separated names, ellipsis when >2', () => {
+		it('returns two names without ellipsis when exactly 2 other members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, Bob');
+		});
+
+		it('uses user id when member has no name', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, user-3');
+		});
+
+		it('returns first two names plus ellipsis when more than 2 other members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+				'user-4': { user: { id: 'user-4', name: 'Charlie' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Alice, Bob...');
+		});
+
+		it('channel name wins over group member names', () => {
+			const channel = client.channel('messaging', 'test-id', { name: 'Custom Name' });
+			channel.state.members = {
+				'current-user': { user: currentUser },
+				'user-2': { user: { id: 'user-2', name: 'Alice' } },
+				'user-3': { user: { id: 'user-3', name: 'Bob' } },
+			};
+			expect(channel.getDisplayName()).to.equal('Custom Name');
+		});
+	});
+
+	describe('fallback 5: no value', () => {
+		it('returns null when no data and no members', () => {
+			const channel = client.channel('messaging', 'test-id');
+			expect(channel.getDisplayName()).to.be.null;
+		});
+	});
+});
+
+describe('Channel getDisplayImage', () => {
+	let client;
+	const currentUser = { id: 'current-user', name: 'Current User', image: 'current.jpg' };
+
+	beforeEach(() => {
+		client = new StreamChat('apiKey');
+		client._setUser(currentUser);
+	});
+
+	describe('fallback 1: customDisplayImageGenerator', () => {
+		it('returns custom value when generator returns a string', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'data.jpg' });
+			channel.customDisplayImageGenerator = () => 'custom-image.jpg';
+			expect(channel.getDisplayImage()).to.equal('custom-image.jpg');
+		});
+
+		it('passes channel instance to generator', () => {
+			const channel = client.channel('messaging', 'test-id');
+			let received;
+			channel.customDisplayImageGenerator = (ch) => {
+				received = ch;
+				return null;
+			};
+			channel.getDisplayImage();
+			expect(received).to.equal(channel);
+		});
+
+		it('falls through when generator returns null', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'fallback.jpg' });
+			channel.customDisplayImageGenerator = () => null;
+			expect(channel.getDisplayImage()).to.equal('fallback.jpg');
+		});
+	});
+
+	describe('fallback 2: channel.data.image', () => {
+		it('returns channel image when set', () => {
+			const channel = client.channel('messaging', 'test-id', { image: 'channel.jpg' });
+			expect(channel.getDisplayImage()).to.equal('channel.jpg');
+		});
+
+		it('returns null when image is empty string', () => {
+			const channel = client.channel('messaging', 'test-id', { image: '' });
+			expect(channel.getDisplayImage()).to.be.null;
+		});
+	});
+
+	describe('fallback 3: no value', () => {
+		it('returns null when no image available', () => {
+			const channel = client.channel('messaging', 'test-id');
+			expect(channel.getDisplayImage()).to.be.null;
+		});
+	});
+});

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -48,6 +48,26 @@ describe('Threads 2.0', () => {
     });
   }
 
+  function createMinimalThread({
+    parentMessageOverrides = {},
+    draft,
+  }: {
+    parentMessageOverrides?: Partial<MessageResponse>;
+    draft?: {
+      channel_cid: string;
+      created_at: string;
+      message: { id: string; text: string; parent_id?: string };
+      parent_id?: string;
+    };
+  } = {}) {
+    return new Thread({
+      client,
+      channel,
+      parentMessage: { ...parentMessageResponse, ...parentMessageOverrides },
+      draft,
+    });
+  }
+
   beforeEach(() => {
     client = new StreamChat('apiKey');
     client._setUser({ id: TEST_USER_ID });
@@ -71,6 +91,7 @@ describe('Threads 2.0', () => {
       const thread = new Thread({ client, threadData: threadResponse });
       const state = thread.state.getLatestValue();
 
+      expect(state.displayName).to.equal(thread.getDisplayName());
       expect(threadResponse.channel.members).to.have.lengthOf(0);
       expect(threadResponse.read).to.have.lengthOf(0);
       expect(state.read).to.have.keys([TEST_USER_ID]);
@@ -81,7 +102,135 @@ describe('Threads 2.0', () => {
       expect(thread.channel.data?.name).to.equal(channelResponse.name);
     });
 
+    it('initializes properly without threadData', () => {
+      const thread = createMinimalThread();
+      const state = thread.state.getLatestValue();
+
+      expect(thread.id).to.equal(parentMessageResponse.id);
+      expect(thread.channel.cid).to.equal(channel.cid);
+      expect(state.parentMessage.id).to.equal(parentMessageResponse.id);
+      expect(state.replies).to.deep.equal([]);
+      expect(state.participants).to.deep.equal([]);
+      expect(state.custom).to.deep.equal({});
+      expect(state.pagination.prevCursor).to.be.null;
+      expect(state.pagination.nextCursor).to.be.null;
+      expect(state.read).to.have.keys([TEST_USER_ID]);
+    });
+
+    it('throws if minimal init parent message id is missing', () => {
+      expect(() =>
+        createMinimalThread({
+          parentMessageOverrides: { id: '' },
+        }),
+      ).to.throw();
+    });
+
+    it('accepts draft in minimal init path', () => {
+      const draftId = uuidv4();
+      const thread = createMinimalThread({
+        draft: {
+          channel_cid: channel.cid,
+          created_at: new Date().toISOString(),
+          message: {
+            id: draftId,
+            text: 'draft text',
+            parent_id: parentMessageResponse.id,
+          },
+          parent_id: parentMessageResponse.id,
+        },
+      });
+
+      expect(thread.messageComposer.draftId).to.equal(draftId);
+    });
+
     describe('Methods', () => {
+      describe('getDisplayName', () => {
+        describe('fallback 1: customDisplayNameGenerator', () => {
+          it('returns custom value when generator returns a string', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => 'Custom Title';
+            expect(thread.getDisplayName()).to.equal('Custom Title');
+          });
+
+          it('passes current ThreadState to generator', () => {
+            const thread = createTestThread({ title: 'My Title' });
+            let receivedState: unknown;
+            thread.customDisplayNameGenerator = (state) => {
+              receivedState = state;
+              return null;
+            };
+            thread.getDisplayName();
+            expect(receivedState).to.equal(thread.state.getLatestValue());
+          });
+
+          it('falls through when generator returns null', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => null;
+            expect(thread.getDisplayName()).to.equal('Test channel');
+          });
+
+          it('falls through when generator returns empty string', () => {
+            const thread = createTestThread({ title: 'Thread Title' });
+            thread.customDisplayNameGenerator = () => '';
+            expect(thread.getDisplayName()).to.equal('Test channel');
+          });
+        });
+
+        describe('fallback 2: channel display name', () => {
+          it('returns channel display name when no custom generator', () => {
+            const thread = createTestThread({ title: '', thread_participants: [] });
+            expect(thread.getDisplayName()).to.equal('Test channel');
+          });
+
+          it('ignores thread.title and uses channel display name', () => {
+            const thread = createTestThread({ title: 'My Thread' });
+            expect(thread.getDisplayName()).to.equal('Test channel');
+          });
+
+          it('ignores participants and uses channel display name', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+              ],
+            });
+            expect(thread.getDisplayName()).to.equal('Test channel');
+          });
+        });
+
+        describe('fallback 3: no value', () => {
+          it('returns null when no custom and channel has no display name', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [],
+              channelOverrides: { name: '' },
+            });
+            expect(thread.getDisplayName()).to.be.null;
+          });
+
+          it('returns null when no custom, channel has no display name, and participants exist', () => {
+            const thread = createTestThread({
+              title: '',
+              thread_participants: [
+                {
+                  channel_cid: 'messaging:test',
+                  created_at: '',
+                  last_read_at: '',
+                  user: { id: 'u1', name: 'Alice' },
+                },
+              ],
+              channelOverrides: { name: '' },
+            });
+            expect(thread.getDisplayName()).to.be.null;
+          });
+        });
+      });
+
       describe('upsertReplyLocally', () => {
         it('prevents inserting a new message that does not belong to the associated thread', () => {
           const thread = createTestThread();
@@ -265,6 +414,30 @@ describe('Threads 2.0', () => {
           expect(stateAfter.participants).to.equal(hydrationState.participants);
         });
 
+        it('copies pagination state during hydration', () => {
+          const thread = createMinimalThread();
+          const hydrationThread = createTestThread({
+            latest_replies: [
+              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
+            ],
+            reply_count: 3,
+          });
+
+          hydrationThread.state.next((current) => ({
+            ...current,
+            pagination: {
+              ...current.pagination,
+              nextCursor: 'next-cursor',
+            },
+          }));
+
+          thread.hydrateState(hydrationThread);
+
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.pagination.prevCursor).to.not.be.null;
+          expect(stateAfter.pagination.nextCursor).to.equal('next-cursor');
+        });
+
         it('retains failed replies after hydration', () => {
           const thread = createTestThread();
           const hydrationThread = createTestThread({
@@ -284,6 +457,37 @@ describe('Threads 2.0', () => {
           const stateAfter = thread.state.getLatestValue();
           expect(stateAfter.replies).to.have.lengthOf(2);
           expect(stateAfter.replies[1].id).to.equal(failedMessage.id);
+        });
+      });
+
+      describe('reload', () => {
+        it('bootstraps pagination for minimally initialized threads', async () => {
+          const minimalThread = createMinimalThread();
+          const hydratedThread = createTestThread({
+            latest_replies: [
+              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
+            ],
+            reply_count: 3,
+          });
+          hydratedThread.state.next((current) => ({
+            ...current,
+            pagination: {
+              ...current.pagination,
+              nextCursor: 'next-cursor',
+            },
+          }));
+
+          sinon.stub(client, 'getThread').resolves(hydratedThread);
+
+          const stateBefore = minimalThread.state.getLatestValue();
+          expect(stateBefore.pagination.prevCursor).to.be.null;
+          expect(stateBefore.pagination.nextCursor).to.be.null;
+
+          await minimalThread.reload();
+
+          const stateAfter = minimalThread.state.getLatestValue();
+          expect(stateAfter.pagination.prevCursor).to.not.be.null;
+          expect(stateAfter.pagination.nextCursor).to.equal('next-cursor');
         });
       });
 


### PR DESCRIPTION
## Description

Adds reactive display state to channels and threads so UIs across different SDKs can subscribe to display name (and image) updates instead of maintain separate potentially diverging implementations. 

It also allows creating a Thread with only a channel and parent message (no threadData) and standardizes thread display name to custom → channel display name.

### Channel

**1. ChannelState – reactive display store**

- Channel state now exposes a display store (e.g. displayStore) holding displayName and displayImage.
- Display values are kept in sync when channel/members/custom data change.
- Consumers (e.g. React SDK) can subscribe to this store and re-render when display name/image changes, instead of using one-off helpers like getDisplayTitle.

```
Returns the display name for a channel using the following fallback chain:
1. Result of `customDisplayNameGenerator` (if set on this instance)
2. The channel's `name` custom data property
3. For DM channels (exactly 2 members): the other member's name, then "Direct Message"
4. For group channels (3+ members): comma-separated list of 2 other members' names. No ellipsis.
5. `null` if none of the above produced a value
```

**2. ChannelState -  convert static properties into backwards compatible reactive stores**
As we are adding reactive display store, we have opportunity to add stores for other `ChannelState` properties.

- `membersStore` — `{ members: Record<string, ChannelMemberResponse>; memberCount: number }`
Member list and count. Updated when members are hydrated or member events are applied.
- `readStore` — `{ read: ChannelReadStatus }`
Per-user read state (last read, unread counts, etc.). Updated from read events and channel sync.
- `typingStore` — `{ typing: Record<string, Event> }`
Active typing indicators by user. Updated from typing.start / typing.stop (and similar) events.
- `watcherStore` — `{ watchers: Record<string, UserResponse>; watcherCount: number }`
Current watchers and count. Updated when watcher presence events are applied.
- `ownCapabilitiesStore` — `{ ownCapabilities: string[] }`
Current user’s capabilities in this channel. Updated when membership/capabilities are synced from channel data or events. Sync over WS is current not supported from the server-side, but may be in the future.
- `mutedUsersStore `— `{ mutedUsers: UserResponse[] }`
Users muted in the channel. Updated when mute state is synced or changed.

### Thread

**1. Constructor with optional data** 

- Optional threadData: Thread can be constructed with only channel and parentMessage (no threadData), for “open thread from channel” flows.

**2. New `displayName` property in ThreadState**

- New property `displayName` on ThreadState: Thread state includes a reactive `displayName` derived from: (1) custom display name generator, (2) channel display name.
- Added for parity with Channel. Also there is a `title` property on `ThreadResponse` type and so it may be desirable in the future customize the logic to include this property to derive the display name. Also name could be derived from participants names, etc.

```
Returns the display name for thread using the following fallback chain:
1. Result of `customDisplayNameGenerator` (if set on this instance)
2. The channel's display name (from channel display store)
3. `null` if none of the above produced a value
```