### PR TITLE
feat: global upload manager to track file uploads outside of AttachmentManager

### DIFF
--- a/docs/fileUpload.md
+++ b/docs/fileUpload.md
@@ -122,6 +122,9 @@ const imageResponse = await channel.sendImage(file, file.name, file.type, undefi
 
 When using the message composer’s attachment manager, upload progress is tracked when `config.attachments.trackUploadProgress` is `true` (the default). Progress is stored on each attachment’s `localMetadata.uploadProgress` (0–100 for the default upload path, from the axios progress event; the initial state is 0% when the upload starts).
 
-With a custom `doUploadRequest`, the function receives an optional second argument `options` with `onProgress?: (percent: number | undefined) => void`. Call `onProgress` from your upload implementation to drive the same `localMetadata.uploadProgress` updates. If you do not call it, `uploadProgress` stays at 0 until the upload finishes.
+With a custom `doUploadRequest`, the function receives an optional second argument `options` with:
 
-Set `trackUploadProgress` to `false` to skip setting `uploadProgress` (will be `undefined` in this case) and to omit progress callbacks to both the default channel upload and custom `doUploadRequest`.
+- `onProgress?: (percent: number | undefined) => void` — call this from your upload implementation to drive the same `localMetadata.uploadProgress` updates. If you do not call it, `uploadProgress` stays at 0 until the upload finishes.
+- `abortSignal?: AbortSignal` — the SDK aborts this signal when the upload is cancelled (for example the user removes the attachment, or `client.uploadManager.reset()` runs on disconnect). Forward it to your transport (axios `signal`, `fetch` `signal`, etc.) if you want to cancel upload request.
+
+Set `trackUploadProgress` to `false` to skip setting `uploadProgress` (will be `undefined` in this case) and to omit `onProgress` to both the default channel upload and custom `doUploadRequest`.

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@types/jsonwebtoken": "^9.0.8",
     "@types/ws": "^8.5.14",
-    "axios": "^1.12.2",
+    "axios": "^1.15.1",
     "base64-js": "^1.5.1",
     "form-data": "^4.0.4",
     "isomorphic-ws": "^5.0.0",

--- a/src/client.ts
+++ b/src/client.ts
@@ -9,6 +9,7 @@ import type WebSocket from 'isomorphic-ws';
 import { Channel } from './channel';
 import { ClientState } from './client_state';
 import { StableWSConnection } from './connection';
+import { UploadManager } from './uploadManager';
 import { CheckSignature, DevToken, JWTUserToken } from './signing';
 import { TokenManager } from './token_manager';
 import { WSConnectionFallback } from './connection_fallback';
@@ -296,6 +297,10 @@ export type MessageComposerSetupState = {
 export class StreamChat {
   private static _instance?: unknown | StreamChat; // type is undefined|StreamChat, unknown is due to TS limitations with statics
   messageDeliveryReporter: MessageDeliveryReporter;
+  /**
+   * @internal
+   */
+  uploadManager: UploadManager;
   _user?: OwnUserResponse | UserResponse;
   appSettingsPromise?: Promise<AppSettingsAPIResponse>;
   activeChannels: {
@@ -401,6 +406,7 @@ export class StreamChat {
     this.moderation = new Moderation(this);
 
     this.notifications = options?.notifications ?? new NotificationManager();
+    this.uploadManager = new UploadManager(this);
 
     // set the secret
     if (secretOrOptions && isString(secretOrOptions)) {
@@ -1020,6 +1026,7 @@ export class StreamChat {
     this.state = new ClientState({ client: this });
     // reset thread manager
     this.threads.resetState();
+    this.uploadManager.reset();
 
     // Since we wipe all user data already, we should reset token manager as well
     closePromise

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
 export * from './thread_manager';
 export * from './token_manager';
 export * from './types';
+export * from './uploadManager';
 export * from './channel_manager';
 export * from './offline-support';
 export * from './LiveLocationManager';

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -273,15 +273,15 @@ export class AttachmentManager {
   removeAttachments = (localAttachmentIds: string[]) => {
     if (!localAttachmentIds.length) return;
 
-    for (const id of localAttachmentIds) {
-      this.client.uploadManager.deleteUploadRecord(id);
-    }
-
     this.state.partialNext({
       attachments: this.attachments.filter(
         (attachment) => !localAttachmentIds.includes(attachment.localMetadata?.id),
       ),
     });
+
+    for (const id of localAttachmentIds) {
+      this.client.uploadManager.deleteUploadRecord(id);
+    }
   };
 
   getUploadConfigCheck = async (
@@ -471,13 +471,21 @@ export class AttachmentManager {
         }
       : undefined;
 
+    const axiosUploadConfig =
+      progressHandler || options?.abortSignal
+        ? {
+            ...(progressHandler ? { onUploadProgress: progressHandler } : {}),
+            ...(options?.abortSignal ? { signal: options.abortSignal } : {}),
+          }
+        : undefined;
+
     if (isFileReference(fileLike)) {
       return this.channel[isImageFile(fileLike) ? 'sendImage' : 'sendFile'](
         fileLike.uri,
         fileLike.name,
         fileLike.type,
         undefined,
-        progressHandler ? { onUploadProgress: progressHandler } : undefined,
+        axiosUploadConfig,
       );
     }
 
@@ -492,13 +500,7 @@ export class AttachmentManager {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { duration, ...result } = await this.channel[
       isImageFile(fileLike) ? 'sendImage' : 'sendFile'
-    ](
-      file,
-      undefined,
-      undefined,
-      undefined,
-      progressHandler ? { onUploadProgress: progressHandler } : undefined,
-    );
+    ](file, undefined, undefined, undefined, axiosUploadConfig);
     return result;
   };
 

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -697,7 +697,7 @@ export class AttachmentManager {
 
     this.uploadProgressUnsubscribesByLocalId.get(localId)?.();
     const unsubscribe = this.client.uploadManager.state.subscribeWithSelector(
-      (s) => ({ upload: s.uploads.find((u) => u.id === localId) }),
+      (s) => ({ upload: s.uploads[localId] }),
       ({ upload: nextUpload }) => {
         if (!nextUpload) return;
         this.upsertAttachments([

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -247,12 +247,12 @@ export class AttachmentManager {
         return attachments;
       }
     }
-    return null;
+    return stateAttachments;
   };
 
   updateAttachment = (attachmentToUpdate: LocalAttachment) => {
     const updatedAttachments = this.prepareAttachmentUpdate(attachmentToUpdate);
-    if (updatedAttachments) {
+    if (updatedAttachments && updatedAttachments !== this.attachments) {
       this.state.partialNext({ attachments: updatedAttachments });
     }
   };
@@ -263,16 +263,17 @@ export class AttachmentManager {
     let hasUpdates = false;
     attachmentsToUpsert.forEach((attachment) => {
       const updatedAttachments = this.prepareAttachmentUpdate(attachment);
-      if (updatedAttachments) {
-        attachments = updatedAttachments;
-        hasUpdates = true;
-      } else {
+      if (updatedAttachments === null) {
         const localAttachment = ensureIsLocalAttachment(attachment);
         if (localAttachment) {
           attachments.push(localAttachment);
           hasUpdates = true;
         }
+      } else if (updatedAttachments !== this.attachments) {
+        attachments = updatedAttachments;
+        hasUpdates = true;
       }
+      // else: id exists and merge was a no-op (`prepareAttachmentUpdate` returns current state)
     });
     if (hasUpdates) {
       this.state.partialNext({ attachments });

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -19,7 +19,7 @@ import {
   AttachmentPostUploadMiddlewareExecutor,
   AttachmentPreUploadMiddlewareExecutor,
 } from './middleware/attachmentManager';
-import { StateStore } from '../store';
+import { StateStore, type Unsubscribe } from '../store';
 import { generateUUIDv4 } from '../utils';
 import { DEFAULT_UPLOAD_SIZE_LIMIT_BYTES } from '../constants';
 import type {
@@ -73,6 +73,12 @@ export class AttachmentManager {
     attachmentsById: Record<string, LocalAttachment>;
     attachments: LocalAttachment[];
   };
+
+  /**
+   * Upload manager progress listeners keyed by local attachment id.
+   * Torn down in {@link AttachmentManager.initState} and when attachments are removed.
+   */
+  private uploadProgressUnsubscribesByLocalId = new Map<string, Unsubscribe>();
 
   constructor({ composer, message }: AttachmentManagerOptions) {
     this.composer = composer;
@@ -209,6 +215,10 @@ export class AttachmentManager {
   }
 
   initState = ({ message }: { message?: DraftMessage | LocalMessage } = {}) => {
+    for (const unsubscribe of this.uploadProgressUnsubscribesByLocalId.values()) {
+      unsubscribe();
+    }
+    this.uploadProgressUnsubscribesByLocalId.clear();
     this.state.next(initState({ message }));
   };
 
@@ -270,6 +280,14 @@ export class AttachmentManager {
   };
 
   removeAttachments = (localAttachmentIds: string[]) => {
+    if (!localAttachmentIds.length) return;
+
+    for (const id of localAttachmentIds) {
+      this.uploadProgressUnsubscribesByLocalId.get(id)?.();
+      this.uploadProgressUnsubscribesByLocalId.delete(id);
+      this.client.uploadManager.deleteUploadRecord(id);
+    }
+
     this.state.partialNext({
       attachments: this.attachments.filter(
         (attachment) => !localAttachmentIds.includes(attachment.localMetadata?.id),
@@ -537,37 +555,9 @@ export class AttachmentManager {
       return localAttachment;
     }
 
-    const shouldTrackProgress = this.config.trackUploadProgress;
-    const uploadingAttachment: LocalUploadAttachment = {
-      ...attachment,
-      localMetadata: {
-        ...attachment.localMetadata,
-        uploadState: 'uploading',
-        ...(shouldTrackProgress && { uploadProgress: 0 }),
-      },
-    };
-    this.upsertAttachments([uploadingAttachment]);
-
-    const uploadOptions = shouldTrackProgress
-      ? {
-          onProgress: (percent: number | undefined) => {
-            this.updateAttachment({
-              ...uploadingAttachment,
-              localMetadata: {
-                ...uploadingAttachment.localMetadata,
-                uploadProgress: percent,
-              },
-            });
-          },
-        }
-      : undefined;
-
     let response: MinimumUploadRequestResult;
     try {
-      response = await this.doUploadRequest(
-        localAttachment.localMetadata.file,
-        uploadOptions,
-      );
+      response = await this.upload(attachment);
     } catch (error) {
       const reason = error instanceof Error ? error.message : 'unknown error';
       const failedAttachment: LocalUploadAttachment = {
@@ -655,35 +645,10 @@ export class AttachmentManager {
       return preUpload.state.attachment;
     }
 
-    const shouldTrackProgress = this.config.trackUploadProgress;
-    attachment = {
-      ...attachment,
-      localMetadata: {
-        ...attachment.localMetadata,
-        uploadState: 'uploading',
-        ...(shouldTrackProgress && { uploadProgress: 0 }),
-      },
-    };
-    this.upsertAttachments([attachment]);
-
-    const uploadOptions = shouldTrackProgress
-      ? {
-          onProgress: (percent: number | undefined) => {
-            this.updateAttachment({
-              ...attachment,
-              localMetadata: {
-                ...attachment.localMetadata,
-                uploadProgress: percent,
-              },
-            });
-          },
-        }
-      : undefined;
-
     let response: MinimumUploadRequestResult | undefined;
     let error: Error | undefined;
     try {
-      response = await this.doUploadRequest(file, uploadOptions);
+      response = await this.upload(attachment);
     } catch (err) {
       error = err instanceof Error ? err : undefined;
     }
@@ -725,4 +690,41 @@ export class AttachmentManager {
       iterableFiles.slice(0, this.availableUploadSlots).map(this.uploadFile),
     );
   };
+
+  private upload(attachment: LocalUploadAttachment) {
+    const localId = attachment.localMetadata.id;
+
+    this.uploadProgressUnsubscribesByLocalId.get(localId)?.();
+    const unsubscribe = this.client.uploadManager.state.subscribeWithSelector(
+      (s) => ({ upload: s.uploads.find((u) => u.id === localId) }),
+      ({ upload: nextUpload }) => {
+        if (!nextUpload) return;
+        this.upsertAttachments([
+          {
+            ...attachment,
+            localMetadata: {
+              ...attachment.localMetadata,
+              uploadState: 'uploading',
+              uploadProgress: nextUpload.uploadProgress,
+            },
+          },
+        ]);
+      },
+    );
+
+    this.uploadProgressUnsubscribesByLocalId.set(localId, unsubscribe);
+
+    return this.client.uploadManager
+      .upload({
+        id: localId,
+        channelCid: this.channel.cid,
+        file: attachment.localMetadata.file,
+      })
+      .finally(() => {
+        if (this.uploadProgressUnsubscribesByLocalId.get(localId) === unsubscribe) {
+          unsubscribe();
+          this.uploadProgressUnsubscribesByLocalId.delete(localId);
+        }
+      });
+  }
 }

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -19,7 +19,7 @@ import {
   AttachmentPostUploadMiddlewareExecutor,
   AttachmentPreUploadMiddlewareExecutor,
 } from './middleware/attachmentManager';
-import { StateStore, type Unsubscribe } from '../store';
+import { StateStore } from '../store';
 import { generateUUIDv4 } from '../utils';
 import { DEFAULT_UPLOAD_SIZE_LIMIT_BYTES } from '../constants';
 import type {
@@ -73,12 +73,6 @@ export class AttachmentManager {
     attachmentsById: Record<string, LocalAttachment>;
     attachments: LocalAttachment[];
   };
-
-  /**
-   * Upload manager progress listeners keyed by local attachment id.
-   * Torn down in {@link AttachmentManager.initState} and when attachments are removed.
-   */
-  private uploadProgressUnsubscribesByLocalId = new Map<string, Unsubscribe>();
 
   constructor({ composer, message }: AttachmentManagerOptions) {
     this.composer = composer;
@@ -215,10 +209,6 @@ export class AttachmentManager {
   }
 
   initState = ({ message }: { message?: DraftMessage | LocalMessage } = {}) => {
-    for (const unsubscribe of this.uploadProgressUnsubscribesByLocalId.values()) {
-      unsubscribe();
-    }
-    this.uploadProgressUnsubscribesByLocalId.clear();
     this.state.next(initState({ message }));
   };
 
@@ -284,8 +274,6 @@ export class AttachmentManager {
     if (!localAttachmentIds.length) return;
 
     for (const id of localAttachmentIds) {
-      this.uploadProgressUnsubscribesByLocalId.get(id)?.();
-      this.uploadProgressUnsubscribesByLocalId.delete(id);
       this.client.uploadManager.deleteUploadRecord(id);
     }
 
@@ -695,25 +683,31 @@ export class AttachmentManager {
   private upload(attachment: LocalUploadAttachment) {
     const localId = attachment.localMetadata.id;
 
-    this.uploadProgressUnsubscribesByLocalId.get(localId)?.();
+    this.upsertAttachments([
+      {
+        ...attachment,
+        localMetadata: {
+          ...attachment.localMetadata,
+          uploadState: 'uploading',
+          uploadProgress: this.config.trackUploadProgress ? 0 : undefined,
+        },
+      },
+    ]);
+
     const unsubscribe = this.client.uploadManager.state.subscribeWithSelector(
       (s) => ({ upload: s.uploads[localId] }),
       ({ upload: nextUpload }) => {
         if (!nextUpload) return;
-        this.upsertAttachments([
-          {
-            ...attachment,
-            localMetadata: {
-              ...attachment.localMetadata,
-              uploadState: 'uploading',
-              uploadProgress: nextUpload.uploadProgress,
-            },
+        this.updateAttachment({
+          ...attachment,
+          localMetadata: {
+            ...attachment.localMetadata,
+            uploadState: 'uploading',
+            uploadProgress: nextUpload.uploadProgress,
           },
-        ]);
+        });
       },
     );
-
-    this.uploadProgressUnsubscribesByLocalId.set(localId, unsubscribe);
 
     return this.client.uploadManager
       .upload({
@@ -722,10 +716,7 @@ export class AttachmentManager {
         file: attachment.localMetadata.file,
       })
       .finally(() => {
-        if (this.uploadProgressUnsubscribesByLocalId.get(localId) === unsubscribe) {
-          unsubscribe();
-          this.uploadProgressUnsubscribesByLocalId.delete(localId);
-        }
+        unsubscribe();
       });
   }
 }

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -6,9 +6,14 @@ export type MinimumUploadRequestResult = { file: string; thumb_url?: string } & 
   Record<string, unknown>
 >;
 
-/** Optional second argument to `UploadRequestFn`; integrators may call `onProgress` to report 0–100 or `undefined` when indeterminate. */
+/**
+ * Optional second argument to `UploadRequestFn`.
+ * - Call `onProgress` to report 0–100 or `undefined` when indeterminate.
+ * - Forward `abortSignal` to your upload implementation to cancel the upload if the user deletes the attachment while it's uploading.
+ */
 export type UploadRequestOptions = {
   onProgress?: (percent: number | undefined) => void;
+  abortSignal?: AbortSignal;
 };
 
 export type UploadRequestFn = (

--- a/src/uploadManager.ts
+++ b/src/uploadManager.ts
@@ -8,31 +8,26 @@ export type UploadRecord = {
 };
 
 export type UploadManagerState = {
-  uploads: UploadRecord[];
+  uploads: Record<string, UploadRecord>;
 };
 
-const initState = (): UploadManagerState => ({ uploads: [] });
+const initState = (): UploadManagerState => ({ uploads: {} });
 
-const upsertById = (uploads: UploadRecord[], record: UploadRecord): UploadRecord[] => {
-  const idx = uploads.findIndex((u) => u.id === record.id);
-  if (idx === -1) return [...uploads, record];
-  const current = uploads[idx];
-  if (current === record) return uploads;
-  const next = [...uploads];
-  next[idx] = { ...current, ...record };
-  return next;
-};
+const upsertById = (
+  uploads: Record<string, UploadRecord>,
+  record: UploadRecord,
+): Record<string, UploadRecord> => ({
+  ...uploads,
+  [record.id]: { ...uploads[record.id], ...record },
+});
 
 const updateById = (
-  uploads: UploadRecord[],
+  uploads: Record<string, UploadRecord>,
   record: UploadRecord,
-): UploadRecord[] | null => {
-  const idx = uploads.findIndex((u) => u.id === record.id);
-  if (idx === -1) return null;
-  const current = uploads[idx];
-  const next = [...uploads];
-  next[idx] = { ...current, ...record };
-  return next;
+): Record<string, UploadRecord> | null => {
+  if (!(record.id in uploads)) return null;
+  const current = uploads[record.id];
+  return { ...uploads, [record.id]: { ...current, ...record } };
 };
 
 /**
@@ -61,7 +56,7 @@ export class UploadManager {
     return this.state.getLatestValue().uploads;
   }
 
-  getUpload = (id: string) => this.uploads.find((u) => u.id === id);
+  getUpload = (id: string) => this.uploads[id];
 
   /**
    * Clears all upload records.
@@ -77,9 +72,10 @@ export class UploadManager {
    */
   deleteUploadRecord = (id: string) => {
     this.state.next((current) => {
-      const nextUploads = current.uploads.filter((u) => u.id !== id);
-      if (nextUploads.length === current.uploads.length) return current;
-      return { ...current, uploads: nextUploads };
+      if (!(id in current.uploads)) return current;
+      const uploads = { ...current.uploads };
+      delete uploads[id];
+      return { ...current, uploads };
     });
     this.inFlightUploads.delete(id);
   };

--- a/src/uploadManager.ts
+++ b/src/uploadManager.ts
@@ -1,0 +1,163 @@
+import type { StreamChat } from './client';
+import { StateStore } from './store';
+import type { AttachmentManager } from '.';
+
+export type UploadRecord = {
+  id: string;
+  uploadProgress?: number;
+};
+
+export type UploadManagerState = {
+  uploads: UploadRecord[];
+};
+
+const initState = (): UploadManagerState => ({ uploads: [] });
+
+const upsertById = (uploads: UploadRecord[], record: UploadRecord): UploadRecord[] => {
+  const idx = uploads.findIndex((u) => u.id === record.id);
+  if (idx === -1) return [...uploads, record];
+  const current = uploads[idx];
+  if (current === record) return uploads;
+  const next = [...uploads];
+  next[idx] = { ...current, ...record };
+  return next;
+};
+
+const updateById = (
+  uploads: UploadRecord[],
+  record: UploadRecord,
+): UploadRecord[] | null => {
+  const idx = uploads.findIndex((u) => u.id === record.id);
+  if (idx === -1) return null;
+  const current = uploads[idx];
+  const next = [...uploads];
+  next[idx] = { ...current, ...record };
+  return next;
+};
+
+/**
+ * @internal
+ */
+export class UploadManager {
+  readonly state: StateStore<UploadManagerState>;
+
+  private inFlightUploads = new Map<string, ReturnType<typeof this.upload>>();
+
+  constructor(private readonly client: StreamChat) {
+    this.state = new StateStore<UploadManagerState>(initState());
+  }
+
+  private resolveAttachmentManager(channelCid: string) {
+    const colon = channelCid.indexOf(':');
+    if (colon <= 0 || colon === channelCid.length - 1) {
+      throw new Error(`Invalid channelCid: ${channelCid}`);
+    }
+    const channelType = channelCid.slice(0, colon);
+    const channelId = channelCid.slice(colon + 1);
+    return this.client.channel(channelType, channelId).messageComposer.attachmentManager;
+  }
+
+  get uploads() {
+    return this.state.getLatestValue().uploads;
+  }
+
+  getUpload = (id: string) => this.uploads.find((u) => u.id === id);
+
+  /**
+   * Clears all upload records.
+   * Invoked when the user disconnects so a later session does not inherit stale upload state.
+   */
+  reset = () => {
+    this.inFlightUploads.clear();
+    this.state.next(initState());
+  };
+
+  /**
+   * Removes the upload record for `id` if present.
+   */
+  deleteUploadRecord = (id: string) => {
+    this.state.next((current) => {
+      const nextUploads = current.uploads.filter((u) => u.id !== id);
+      if (nextUploads.length === current.uploads.length) return current;
+      return { ...current, uploads: nextUploads };
+    });
+    this.inFlightUploads.delete(id);
+  };
+
+  /**
+   * Starts an upload for `id`, or returns the existing in-flight promise if one is already running.
+   * Uses {@link StreamChat.channel}(`channelCid`) → `messageComposer.attachmentManager.doUploadRequest`.
+   * Resolves with that result; rejects if the upload rejects (the record is removed from state either way).
+   */
+  upload = ({
+    id,
+    channelCid,
+    file,
+  }: {
+    id: string;
+    channelCid: string;
+    file: Parameters<typeof AttachmentManager.prototype.doUploadRequest>[0];
+  }): ReturnType<typeof AttachmentManager.prototype.doUploadRequest> => {
+    const existingPromise = this.inFlightUploads.get(id);
+    if (existingPromise) return existingPromise;
+
+    let resolvePromise!: (
+      value: Awaited<ReturnType<typeof AttachmentManager.prototype.doUploadRequest>>,
+    ) => void;
+    let rejectPromise!: (reason?: unknown) => void;
+    const promise = new Promise<
+      Awaited<ReturnType<typeof AttachmentManager.prototype.doUploadRequest>>
+    >((resolve, reject) => {
+      resolvePromise = resolve;
+      rejectPromise = reject;
+    });
+
+    this.inFlightUploads.set(id, promise);
+
+    void (async () => {
+      const attachmentManager = this.resolveAttachmentManager(channelCid);
+      const trackProgress = attachmentManager.config.trackUploadProgress;
+      try {
+        this.upsertUpload({
+          id,
+          uploadProgress: trackProgress ? 0 : undefined,
+        });
+
+        const onProgress = trackProgress
+          ? (progress?: number) => {
+              this.updateUpload({
+                id,
+                uploadProgress: progress,
+              });
+            }
+          : undefined;
+
+        const response = await attachmentManager.doUploadRequest(
+          file,
+          onProgress ? { onProgress } : undefined,
+        );
+        resolvePromise(response);
+      } catch (error) {
+        rejectPromise(error);
+      } finally {
+        this.deleteUploadRecord(id);
+      }
+    })();
+
+    return promise;
+  };
+
+  private upsertUpload = (record: UploadRecord) => {
+    this.state.partialNext({
+      uploads: upsertById(this.uploads, record),
+    });
+  };
+
+  private updateUpload = (record: UploadRecord) => {
+    this.state.next((current) => {
+      const nextUploads = updateById(current.uploads, record);
+      if (!nextUploads) return current;
+      return { ...current, uploads: nextUploads };
+    });
+  };
+}

--- a/src/uploadManager.ts
+++ b/src/uploadManager.ts
@@ -1,4 +1,5 @@
 import type { StreamChat } from './client';
+import type { UploadRequestOptions } from './messageComposer/configuration/types';
 import { StateStore } from './store';
 import type { AttachmentManager } from '.';
 
@@ -30,13 +31,17 @@ const updateById = (
   return { ...uploads, [record.id]: { ...current, ...record } };
 };
 
+type UploadPromise = ReturnType<typeof AttachmentManager.prototype.doUploadRequest>;
+
+type InFlightUpload = { promise: UploadPromise; abortController: AbortController };
+
 /**
  * @internal
  */
 export class UploadManager {
   readonly state: StateStore<UploadManagerState>;
 
-  private inFlightUploads = new Map<string, ReturnType<typeof this.upload>>();
+  private inFlightUploads = new Map<string, InFlightUpload>();
 
   constructor(private readonly client: StreamChat) {
     this.state = new StateStore<UploadManagerState>(initState());
@@ -61,23 +66,32 @@ export class UploadManager {
   /**
    * Clears all upload records.
    * Invoked when the user disconnects so a later session does not inherit stale upload state.
+   * Aborts every in-flight upload request via its `UploadRequestOptions.abortSignal`.
    */
   reset = () => {
+    for (const { abortController } of this.inFlightUploads.values()) {
+      abortController.abort();
+    }
     this.inFlightUploads.clear();
     this.state.next(initState());
   };
 
   /**
    * Removes the upload record for `id` if present.
+   * If an upload is still in progress, aborts its `UploadRequestOptions.abortSignal`.
    */
   deleteUploadRecord = (id: string) => {
+    const flight = this.inFlightUploads.get(id);
+    if (flight) {
+      this.inFlightUploads.delete(id);
+      flight.abortController.abort();
+    }
     this.state.next((current) => {
       if (!(id in current.uploads)) return current;
       const uploads = { ...current.uploads };
       delete uploads[id];
       return { ...current, uploads };
     });
-    this.inFlightUploads.delete(id);
   };
 
   /**
@@ -94,21 +108,18 @@ export class UploadManager {
     channelCid: string;
     file: Parameters<typeof AttachmentManager.prototype.doUploadRequest>[0];
   }): ReturnType<typeof AttachmentManager.prototype.doUploadRequest> => {
-    const existingPromise = this.inFlightUploads.get(id);
-    if (existingPromise) return existingPromise;
+    const existing = this.inFlightUploads.get(id);
+    if (existing) return existing.promise;
 
-    let resolvePromise!: (
-      value: Awaited<ReturnType<typeof AttachmentManager.prototype.doUploadRequest>>,
-    ) => void;
+    let resolvePromise!: (value: Awaited<UploadPromise>) => void;
     let rejectPromise!: (reason?: unknown) => void;
-    const promise = new Promise<
-      Awaited<ReturnType<typeof AttachmentManager.prototype.doUploadRequest>>
-    >((resolve, reject) => {
+    const promise = new Promise<Awaited<UploadPromise>>((resolve, reject) => {
       resolvePromise = resolve;
       rejectPromise = reject;
     });
 
-    this.inFlightUploads.set(id, promise);
+    const abortController = new AbortController();
+    this.inFlightUploads.set(id, { promise, abortController });
 
     void (async () => {
       const attachmentManager = this.resolveAttachmentManager(channelCid);
@@ -128,14 +139,20 @@ export class UploadManager {
             }
           : undefined;
 
+        const uploadRequestOptions: UploadRequestOptions = {
+          abortSignal: abortController.signal,
+          ...(onProgress ? { onProgress } : {}),
+        };
+
         const response = await attachmentManager.doUploadRequest(
           file,
-          onProgress ? { onProgress } : undefined,
+          uploadRequestOptions,
         );
         resolvePromise(response);
       } catch (error) {
         rejectPromise(error);
       } finally {
+        this.inFlightUploads.delete(id);
         this.deleteUploadRecord(id);
       }
     })();

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -599,6 +599,21 @@ describe('AttachmentManager', () => {
 
       expect(attachmentManager.attachments).toEqual(updatedAttachments);
     });
+
+    it('should do nothing if the attachments are the same', () => {
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+      const attachment = { localMetadata: { id: 'test-id-1' }, type: 'image' };
+      attachmentManager.upsertAttachments([attachment]);
+
+      const spy = vi.fn();
+      attachmentManager.state.subscribe(spy);
+      spy.mockClear();
+      attachmentManager.upsertAttachments([attachment]);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateAttachment', () => {
@@ -649,6 +664,20 @@ describe('AttachmentManager', () => {
       attachmentManager.updateAttachment(updatedAttachment);
 
       expect(attachmentManager.attachments).toEqual(newAttachments);
+    });
+
+    it('should do nothing if the attachment is the same', () => {
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+      const attachment = { localMetadata: { id: 'test-id-1' }, type: 'image' };
+      attachmentManager.upsertAttachments([attachment]);
+
+      const spy = vi.fn();
+      attachmentManager.state.subscribe(spy);
+      spy.mockReset();
+      attachmentManager.updateAttachment(attachment);
+      expect(spy).not.toHaveBeenCalled();
     });
   });
 

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -494,7 +494,7 @@ describe('AttachmentManager', () => {
         ).toBeGreaterThan(0);
       });
 
-      const uploadId = mockClient.uploadManager.uploads[0]?.id;
+      const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
       expect(uploadId).toBeDefined();
 
       expect(upsertSpy).toHaveBeenCalled();
@@ -512,14 +512,13 @@ describe('AttachmentManager', () => {
 
       mockClient.uploadManager.state.partialNext((current) => ({
         ...current,
-        uploads: current.uploads.map((u) =>
-          u.id === uploadId
-            ? {
-                ...u,
-                uploadProgress: 99,
-              }
-            : u,
-        ),
+        uploads: {
+          ...current.uploads,
+          [uploadId!]: {
+            ...current.uploads[uploadId!],
+            uploadProgress: 99,
+          },
+        },
       }));
 
       expect(upsertSpy).not.toHaveBeenCalled();
@@ -736,15 +735,11 @@ describe('AttachmentManager', () => {
 
       await Promise.resolve();
 
-      expect(
-        mockClient.uploadManager.uploads.some((u) => u.id === 'att-with-upload'),
-      ).toBe(true);
+      expect('att-with-upload' in mockClient.uploadManager.uploads).toBe(true);
 
       attachmentManager.removeAttachments(['att-with-upload']);
 
-      expect(
-        mockClient.uploadManager.uploads.some((u) => u.id === 'att-with-upload'),
-      ).toBe(false);
+      expect('att-with-upload' in mockClient.uploadManager.uploads).toBe(false);
       expect(attachmentManager.attachments).toEqual([]);
     });
 
@@ -786,11 +781,7 @@ describe('AttachmentManager', () => {
 
       attachmentManager.removeAttachments(['att-1']);
 
-      expect(
-        mockClient.uploadManager.uploads.some(
-          (u) => u.id === 'other-composer-attachment',
-        ),
-      ).toBe(true);
+      expect('other-composer-attachment' in mockClient.uploadManager.uploads).toBe(true);
     });
 
     it('should unsubscribe upload progress listeners when removing an in-flight upload', async () => {
@@ -816,7 +807,7 @@ describe('AttachmentManager', () => {
         ).toBeGreaterThan(0);
       });
 
-      const uploadId = mockClient.uploadManager.uploads[0]?.id;
+      const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
       expect(uploadId).toBeDefined();
 
       upsertSpy.mockClear();
@@ -832,7 +823,10 @@ describe('AttachmentManager', () => {
 
       mockClient.uploadManager.state.partialNext((current) => ({
         ...current,
-        uploads: [...current.uploads, { id: uploadId!, uploadProgress: 77 }],
+        uploads: {
+          ...current.uploads,
+          [uploadId!]: { id: uploadId!, uploadProgress: 77 },
+        },
       }));
 
       expect(upsertSpy).not.toHaveBeenCalled();

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -472,7 +472,7 @@ describe('AttachmentManager', () => {
       });
     });
 
-    it('should unsubscribe upload progress listeners when re-initializing state', async () => {
+    it('should not apply upload manager progress to composer attachments after re-initializing state', async () => {
       const { messageComposer, mockClient } = setup();
       const { attachmentManager } = messageComposer;
 
@@ -480,35 +480,17 @@ describe('AttachmentManager', () => {
         () => new Promise(() => {}),
       );
 
-      const upsertSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
-
       void attachmentManager.uploadFile(new File([], 'p.png', { type: 'image/png' }));
 
       await vi.waitFor(() => {
-        expect(
-          (
-            attachmentManager as unknown as {
-              uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
-            }
-          ).uploadProgressUnsubscribesByLocalId.size,
-        ).toBeGreaterThan(0);
+        expect(Object.keys(mockClient.uploadManager.uploads).length).toBeGreaterThan(0);
       });
 
       const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
       expect(uploadId).toBeDefined();
 
-      expect(upsertSpy).toHaveBeenCalled();
-
-      upsertSpy.mockClear();
       attachmentManager.initState();
-
-      expect(
-        (
-          attachmentManager as unknown as {
-            uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
-          }
-        ).uploadProgressUnsubscribesByLocalId.size,
-      ).toBe(0);
+      expect(attachmentManager.attachments).toEqual([]);
 
       mockClient.uploadManager.state.partialNext((current) => ({
         ...current,
@@ -521,7 +503,7 @@ describe('AttachmentManager', () => {
         },
       }));
 
-      expect(upsertSpy).not.toHaveBeenCalled();
+      expect(attachmentManager.attachments).toEqual([]);
     });
 
     it('should initialize with message', () => {
@@ -784,7 +766,7 @@ describe('AttachmentManager', () => {
       expect('other-composer-attachment' in mockClient.uploadManager.uploads).toBe(true);
     });
 
-    it('should unsubscribe upload progress listeners when removing an in-flight upload', async () => {
+    it('should not apply upload manager progress to composer attachments after removing an in-flight upload', async () => {
       const {
         messageComposer: { attachmentManager },
         mockClient,
@@ -793,33 +775,18 @@ describe('AttachmentManager', () => {
       vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
         () => new Promise(() => {}),
       );
-      const upsertSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
 
       void attachmentManager.uploadFile(new File([], 'p.png', { type: 'image/png' }));
 
       await vi.waitFor(() => {
-        expect(
-          (
-            attachmentManager as unknown as {
-              uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
-            }
-          ).uploadProgressUnsubscribesByLocalId.size,
-        ).toBeGreaterThan(0);
+        expect(Object.keys(mockClient.uploadManager.uploads).length).toBeGreaterThan(0);
       });
 
       const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
       expect(uploadId).toBeDefined();
 
-      upsertSpy.mockClear();
       attachmentManager.removeAttachments([uploadId!]);
-
-      expect(
-        (
-          attachmentManager as unknown as {
-            uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
-          }
-        ).uploadProgressUnsubscribesByLocalId.size,
-      ).toBe(0);
+      expect(attachmentManager.attachments).toEqual([]);
 
       mockClient.uploadManager.state.partialNext((current) => ({
         ...current,
@@ -829,7 +796,7 @@ describe('AttachmentManager', () => {
         },
       }));
 
-      expect(upsertSpy).not.toHaveBeenCalled();
+      expect(attachmentManager.attachments).toEqual([]);
     });
   });
 
@@ -1493,7 +1460,7 @@ describe('AttachmentManager', () => {
         messageComposer: { attachmentManager },
         mockChannel,
       } = setup();
-      const updateSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
+      const updateSpy = vi.spyOn(attachmentManager, 'updateAttachment');
       const customUploadFn = vi.fn(async (_file, options) => {
         options?.onProgress?.(42);
         return { file: 'custom-upload-url' };
@@ -1521,11 +1488,9 @@ describe('AttachmentManager', () => {
         expect.objectContaining({ onProgress: expect.any(Function) }),
       );
       expect(updateSpy).toHaveBeenCalledWith(
-        expect.arrayContaining([
-          expect.objectContaining({
-            localMetadata: expect.objectContaining({ uploadProgress: 42 }),
-          }),
-        ]),
+        expect.objectContaining({
+          localMetadata: expect.objectContaining({ uploadProgress: 42 }),
+        }),
       );
       expect(mockChannel.sendImage).not.toHaveBeenCalled();
     });

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -9,7 +9,6 @@ import {
   DraftResponse,
   FileReference,
   LocalMessage,
-  MessageComposer,
   StreamChat,
 } from '../../../src';
 import { AppSettings } from '../../../src';
@@ -117,12 +116,14 @@ const setup = ({
     .fn()
     .mockResolvedValue({ file: 'test-image-url', thumb_url: 'thumb_url-image' });
   mockChannel.data = { own_capabilities: ['upload-file'] };
-  const messageComposer = new MessageComposer({
-    client: mockClient,
-    composition,
-    compositionContext: mockChannel,
-    config: { attachments: config },
-  });
+  // Use the channel's messageComposer so client.uploadManager (resolves via channelCid) hits this composer.
+  const messageComposer = mockChannel.messageComposer;
+  if (config) {
+    messageComposer.updateConfig({ attachments: config });
+  }
+  if (composition !== undefined) {
+    messageComposer.initState({ composition });
+  }
   return { mockClient, mockChannel, messageComposer };
 };
 
@@ -466,7 +467,62 @@ describe('AttachmentManager', () => {
 
       attachmentManager.initState();
 
-      expect(attachmentManager.state.getLatestValue()).toEqual({ attachments: [] });
+      expect(attachmentManager.state.getLatestValue()).toEqual({
+        attachments: [],
+      });
+    });
+
+    it('should unsubscribe upload progress listeners when re-initializing state', async () => {
+      const { messageComposer, mockClient } = setup();
+      const { attachmentManager } = messageComposer;
+
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      const upsertSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
+
+      void attachmentManager.uploadFile(new File([], 'p.png', { type: 'image/png' }));
+
+      await vi.waitFor(() => {
+        expect(
+          (
+            attachmentManager as unknown as {
+              uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
+            }
+          ).uploadProgressUnsubscribesByLocalId.size,
+        ).toBeGreaterThan(0);
+      });
+
+      const uploadId = mockClient.uploadManager.uploads[0]?.id;
+      expect(uploadId).toBeDefined();
+
+      expect(upsertSpy).toHaveBeenCalled();
+
+      upsertSpy.mockClear();
+      attachmentManager.initState();
+
+      expect(
+        (
+          attachmentManager as unknown as {
+            uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
+          }
+        ).uploadProgressUnsubscribesByLocalId.size,
+      ).toBe(0);
+
+      mockClient.uploadManager.state.partialNext((current) => ({
+        ...current,
+        uploads: current.uploads.map((u) =>
+          u.id === uploadId
+            ? {
+                ...u,
+                uploadProgress: 99,
+              }
+            : u,
+        ),
+      }));
+
+      expect(upsertSpy).not.toHaveBeenCalled();
     });
 
     it('should initialize with message', () => {
@@ -613,6 +669,144 @@ describe('AttachmentManager', () => {
       expect(attachmentManager.attachments).toEqual([
         { localMetadata: { id: 'test-id-2' } },
       ]);
+    });
+
+    it('should delete matching upload records when removing upload attachments', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        messageComposer,
+        mockClient,
+        mockChannel,
+      } = setup({ config: { trackUploadProgress: false } });
+
+      const previewUri = 'blob:preview-for-remove-test';
+      const file = generateFile({ name: 'x.png', type: 'image/png' });
+      const attachment: LocalUploadAttachment = {
+        type: 'image',
+        mime_type: 'image/png',
+        file_size: file.size,
+        fallback: file.name,
+        localMetadata: {
+          id: 'att-with-upload',
+          file,
+          previewUri,
+          uploadState: 'uploading',
+        },
+      };
+
+      attachmentManager.upsertAttachments([attachment]);
+
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () => new Promise(() => {}),
+      );
+      void mockClient.uploadManager.upload({
+        id: 'att-with-upload',
+        channelCid: mockChannel.cid,
+        file,
+      });
+
+      await Promise.resolve();
+
+      expect(
+        mockClient.uploadManager.uploads.some((u) => u.id === 'att-with-upload'),
+      ).toBe(true);
+
+      attachmentManager.removeAttachments(['att-with-upload']);
+
+      expect(
+        mockClient.uploadManager.uploads.some((u) => u.id === 'att-with-upload'),
+      ).toBe(false);
+      expect(attachmentManager.attachments).toEqual([]);
+    });
+
+    it('should not delete upload records for another local attachment id', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockClient,
+        mockChannel,
+      } = setup({ config: { trackUploadProgress: false } });
+
+      const previewUri = 'blob:other-composer-uri';
+
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () => new Promise(() => {}),
+      );
+      void mockClient.uploadManager.upload({
+        id: 'other-composer-attachment',
+        channelCid: mockChannel.cid,
+        file: new File([], 'other.png'),
+      });
+
+      await Promise.resolve();
+
+      const file = generateFile({ name: 'x.png', type: 'image/png' });
+      attachmentManager.upsertAttachments([
+        {
+          type: 'image',
+          mime_type: 'image/png',
+          file_size: file.size,
+          fallback: file.name,
+          localMetadata: {
+            id: 'att-1',
+            file,
+            previewUri,
+            uploadState: 'uploading',
+          },
+        } as LocalUploadAttachment,
+      ]);
+
+      attachmentManager.removeAttachments(['att-1']);
+
+      expect(
+        mockClient.uploadManager.uploads.some(
+          (u) => u.id === 'other-composer-attachment',
+        ),
+      ).toBe(true);
+    });
+
+    it('should unsubscribe upload progress listeners when removing an in-flight upload', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockClient,
+      } = setup({ config: { trackUploadProgress: true } });
+
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () => new Promise(() => {}),
+      );
+      const upsertSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
+
+      void attachmentManager.uploadFile(new File([], 'p.png', { type: 'image/png' }));
+
+      await vi.waitFor(() => {
+        expect(
+          (
+            attachmentManager as unknown as {
+              uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
+            }
+          ).uploadProgressUnsubscribesByLocalId.size,
+        ).toBeGreaterThan(0);
+      });
+
+      const uploadId = mockClient.uploadManager.uploads[0]?.id;
+      expect(uploadId).toBeDefined();
+
+      upsertSpy.mockClear();
+      attachmentManager.removeAttachments([uploadId!]);
+
+      expect(
+        (
+          attachmentManager as unknown as {
+            uploadProgressUnsubscribesByLocalId: Map<string, unknown>;
+          }
+        ).uploadProgressUnsubscribesByLocalId.size,
+      ).toBe(0);
+
+      mockClient.uploadManager.state.partialNext((current) => ({
+        ...current,
+        uploads: [...current.uploads, { id: uploadId!, uploadProgress: 77 }],
+      }));
+
+      expect(upsertSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -1276,7 +1470,7 @@ describe('AttachmentManager', () => {
         messageComposer: { attachmentManager },
         mockChannel,
       } = setup();
-      const updateSpy = vi.spyOn(attachmentManager, 'updateAttachment');
+      const updateSpy = vi.spyOn(attachmentManager, 'upsertAttachments');
       const customUploadFn = vi.fn(async (_file, options) => {
         options?.onProgress?.(42);
         return { file: 'custom-upload-url' };
@@ -1304,9 +1498,11 @@ describe('AttachmentManager', () => {
         expect.objectContaining({ onProgress: expect.any(Function) }),
       );
       expect(updateSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          localMetadata: expect.objectContaining({ uploadProgress: 42 }),
-        }),
+        expect.arrayContaining([
+          expect.objectContaining({
+            localMetadata: expect.objectContaining({ uploadProgress: 42 }),
+          }),
+        ]),
       );
       expect(mockChannel.sendImage).not.toHaveBeenCalled();
     });

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -1382,7 +1382,7 @@ describe('AttachmentManager', () => {
       expect(attachmentManager.config.trackUploadProgress).toBe(true);
     });
 
-    it('when false, default upload does not pass progress options to channel', async () => {
+    it('when false, default upload passes abort signal without onUploadProgress to channel', async () => {
       const {
         messageComposer: { attachmentManager },
         mockChannel,
@@ -1398,7 +1398,7 @@ describe('AttachmentManager', () => {
         undefined,
         undefined,
         undefined,
-        undefined,
+        { signal: expect.any(AbortSignal) },
       );
     });
 
@@ -1440,7 +1440,7 @@ describe('AttachmentManager', () => {
       expect(att.localMetadata.uploadProgress).toBe(0);
     });
 
-    it('when false, custom doUploadRequest is called without options', async () => {
+    it('when false, custom doUploadRequest receives abortSignal only', async () => {
       const {
         messageComposer: { attachmentManager },
         mockChannel,
@@ -1451,7 +1451,9 @@ describe('AttachmentManager', () => {
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
       await attachmentManager.uploadFiles([file]);
 
-      expect(customUploadFn).toHaveBeenCalledWith(file, undefined);
+      expect(customUploadFn).toHaveBeenCalledWith(file, {
+        abortSignal: expect.any(AbortSignal),
+      });
       expect(mockChannel.sendImage).not.toHaveBeenCalled();
     });
 
@@ -1485,13 +1487,70 @@ describe('AttachmentManager', () => {
 
       expect(customUploadFn).toHaveBeenCalledWith(
         file,
-        expect.objectContaining({ onProgress: expect.any(Function) }),
+        expect.objectContaining({
+          onProgress: expect.any(Function),
+          abortSignal: expect.any(AbortSignal),
+        }),
       );
       expect(updateSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           localMetadata: expect.objectContaining({ uploadProgress: 42 }),
         }),
       );
+      expect(mockChannel.sendImage).not.toHaveBeenCalled();
+    });
+
+    it('aborts default upload axios signal when attachment is removed during upload', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockChannel,
+      } = setup();
+      mockChannel.sendImage.mockImplementation(() => new Promise(() => {}));
+
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
+      const local = await attachmentManager.fileToLocalUploadAttachment(file);
+      void attachmentManager.uploadAttachment(local);
+
+      await vi.waitFor(() => {
+        expect(mockChannel.sendImage).toHaveBeenCalled();
+      });
+
+      const axiosOpts = mockChannel.sendImage.mock.calls[0][4] as {
+        signal?: AbortSignal;
+      };
+      expect(axiosOpts?.signal).toBeInstanceOf(AbortSignal);
+      expect(axiosOpts!.signal!.aborted).toBe(false);
+
+      attachmentManager.removeAttachments([local.localMetadata.id!]);
+
+      expect(axiosOpts!.signal!.aborted).toBe(true);
+    });
+
+    it('aborts custom upload abortSignal when attachment is removed during upload', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockChannel,
+      } = setup();
+      let capturedSignal: AbortSignal | undefined;
+      const customUploadFn = vi.fn().mockImplementation((_file, opts) => {
+        capturedSignal = opts?.abortSignal;
+        return new Promise(() => {});
+      });
+      attachmentManager.setCustomUploadFn(customUploadFn);
+
+      const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
+      const local = await attachmentManager.fileToLocalUploadAttachment(file);
+      void attachmentManager.uploadAttachment(local);
+
+      await vi.waitFor(() => {
+        expect(customUploadFn).toHaveBeenCalled();
+      });
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal!.aborted).toBe(false);
+
+      attachmentManager.removeAttachments([local.localMetadata.id!]);
+
+      expect(capturedSignal!.aborted).toBe(true);
       expect(mockChannel.sendImage).not.toHaveBeenCalled();
     });
 
@@ -1659,6 +1718,27 @@ describe('AttachmentManager', () => {
         undefined,
         undefined,
         undefined,
+      );
+    });
+
+    it('passes axios signal when abortSignal is provided without onProgress', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockChannel,
+      } = setup();
+      const controller = new AbortController();
+      const file = new File([''], 'photo.jpg', { type: 'image/jpeg' });
+
+      await attachmentManager.doDefaultUploadRequest(file, {
+        abortSignal: controller.signal,
+      });
+
+      expect(mockChannel.sendImage).toHaveBeenCalledWith(
+        file,
+        undefined,
+        undefined,
+        undefined,
+        { signal: controller.signal },
       );
     });
 

--- a/test/unit/MessageComposer/uploadManager.test.ts
+++ b/test/unit/MessageComposer/uploadManager.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StreamChat, UploadRecord } from '../../../src';
+import { UploadManager } from '../../../src';
+
+const TEST_CID = 'channelType:channelId';
+
+const createManager = (
+  doUploadRequest: (...args: unknown[]) => unknown = vi.fn().mockResolvedValue(undefined),
+  trackUploadProgress = true,
+) => {
+  const attachmentManager = {
+    doUploadRequest,
+    config: { trackUploadProgress },
+  };
+  const client = {
+    channel: vi.fn().mockReturnValue({
+      messageComposer: { attachmentManager },
+    }),
+  } as unknown as StreamChat;
+  const manager = new UploadManager(client);
+  return { manager, client, doUploadRequest };
+};
+
+describe('UploadManager', () => {
+  it('upload upserts uploading record and calls doUploadRequest with onProgress', async () => {
+    const { manager, doUploadRequest } = createManager();
+    const file = new File([], 'a.txt');
+
+    const promise = manager.upload({
+      id: 'local-a',
+      channelCid: TEST_CID,
+      file,
+    });
+
+    expect(manager.uploads).toEqual([
+      {
+        id: 'local-a',
+        uploadProgress: 0,
+      },
+    ]);
+    await promise;
+
+    expect(manager.getUpload('local-a')).toBeUndefined();
+    expect(doUploadRequest).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining({ onProgress: expect.any(Function) }),
+    );
+  });
+
+  it('stores id on upload record', async () => {
+    const { manager, doUploadRequest } = createManager();
+    const file = new File([], 'a.txt');
+
+    await manager.upload({ id: 'm1', channelCid: TEST_CID, file });
+
+    const snapshots: unknown[] = [];
+    const { manager: manager2, doUploadRequest: doUploadRequest2 } = createManager();
+    const unsub = manager2.state.subscribe((next) => snapshots.push(next.uploads));
+    await manager2.upload({
+      id: 'm1',
+      channelCid: TEST_CID,
+      file: new File([], 'b.txt'),
+    });
+    unsub();
+
+    expect(
+      snapshots.some((u: unknown) => {
+        const row = (u as UploadRecord[])?.[0];
+        return row?.id === 'm1' && row.uploadProgress === 0;
+      }),
+    ).toBe(true);
+    expect(snapshots.some((u: unknown) => (u as UploadRecord[]).length === 0)).toBe(true);
+    expect(doUploadRequest).toHaveBeenCalled();
+    expect(doUploadRequest2).toHaveBeenCalled();
+  });
+
+  it('updates uploadProgress when onProgress is invoked (including undefined)', async () => {
+    const { manager, doUploadRequest } = createManager();
+    let onProgress!: (p?: number) => void;
+    doUploadRequest.mockImplementation(
+      async (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+        onProgress = opts!.onProgress!;
+      },
+    );
+
+    const start = manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+    onProgress(33);
+    expect(manager.getUpload('u1')?.uploadProgress).toBe(33);
+    onProgress(undefined);
+    expect(manager.getUpload('u1')?.uploadProgress).toBeUndefined();
+    await start;
+  });
+
+  it('on failure, removes record and rejects the promise', async () => {
+    const err = new Error('boom');
+    const { manager, doUploadRequest } = createManager(vi.fn().mockRejectedValue(err));
+
+    await expect(
+      manager.upload({
+        id: 'u1',
+        channelCid: TEST_CID,
+        file: new File([], 'x'),
+      }),
+    ).rejects.toBe(err);
+
+    expect(manager.getUpload('u1')).toBeUndefined();
+  });
+
+  it('reset clears all records', async () => {
+    const err = new Error('fail');
+    const { manager, doUploadRequest } = createManager(
+      vi.fn().mockRejectedValueOnce(err).mockResolvedValueOnce(undefined),
+    );
+
+    await expect(
+      manager.upload({ id: 'm1', channelCid: TEST_CID, file: new File([], 'a') }),
+    ).rejects.toBe(err);
+    manager.reset();
+
+    expect(manager.uploads).toEqual([]);
+    expect(doUploadRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes upload: concurrent calls share one promise and a single doUploadRequest run', async () => {
+    const { manager, doUploadRequest } = createManager();
+    let resolve!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolve = r;
+    });
+    doUploadRequest.mockImplementation(async () => gate);
+
+    const file = new File([], 'x');
+    const first = manager.upload({ id: 'same', channelCid: TEST_CID, file });
+    const second = manager.upload({ id: 'same', channelCid: TEST_CID, file });
+
+    expect(first).toBe(second);
+    expect(doUploadRequest).toHaveBeenCalledTimes(1);
+
+    resolve();
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+  });
+
+  it('different ids allow concurrent uploads', async () => {
+    const { manager, doUploadRequest } = createManager();
+    let resolveA!: () => void;
+    let resolveB!: () => void;
+    const gateA = new Promise<void>((r) => {
+      resolveA = r;
+    });
+    const gateB = new Promise<void>((r) => {
+      resolveB = r;
+    });
+    const gates = [gateA, gateB];
+    let i = 0;
+    doUploadRequest.mockImplementation(async () => gates[i++]);
+
+    const file = new File([], 'x');
+    const p1 = manager.upload({ id: 'm1', channelCid: TEST_CID, file });
+    const p2 = manager.upload({ id: 'm2', channelCid: TEST_CID, file });
+
+    expect(manager.getUpload('m1')).toEqual({ id: 'm1', uploadProgress: 0 });
+    expect(manager.getUpload('m2')).toEqual({ id: 'm2', uploadProgress: 0 });
+
+    const p1Again = manager.upload({ id: 'm1', channelCid: TEST_CID, file });
+    expect(p1Again).toBe(p1);
+    expect(doUploadRequest).toHaveBeenCalledTimes(2);
+
+    resolveA();
+    resolveB();
+    await Promise.all([p1, p2]);
+  });
+
+  it('on success, response is returned and upload record is removed', async () => {
+    const response = { file: 'https://cdn.example/uploaded' };
+    const { manager, doUploadRequest } = createManager(
+      vi.fn().mockResolvedValue(response),
+    );
+
+    const result = await manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+
+    expect(result).toBe(response);
+    expect(manager.getUpload('u1')).toBeUndefined();
+    expect(doUploadRequest).toHaveBeenCalled();
+  });
+
+  it('omits onProgress when attachment manager config trackUploadProgress is false', async () => {
+    const { manager, doUploadRequest } = createManager(
+      vi.fn().mockResolvedValue(undefined),
+      false,
+    );
+    const file = new File([], 'x');
+    await manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file,
+    });
+    expect(doUploadRequest).toHaveBeenCalledWith(file, undefined);
+  });
+
+  describe('deleteUploadRecord', () => {
+    it('removes matching in-flight record and leaves others', async () => {
+      const { manager, doUploadRequest } = createManager(
+        vi.fn().mockImplementation(() => new Promise(() => {})),
+      );
+      const file = new File([], 'x');
+
+      void manager.upload({ id: 'm1', channelCid: TEST_CID, file });
+      void manager.upload({ id: 'm2', channelCid: TEST_CID, file });
+
+      await Promise.resolve();
+
+      expect(manager.getUpload('m1')).toBeDefined();
+      expect(manager.getUpload('m2')).toBeDefined();
+
+      manager.deleteUploadRecord('m1');
+
+      expect(manager.getUpload('m1')).toBeUndefined();
+      expect(manager.getUpload('m2')).toBeDefined();
+      expect(doUploadRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('is a no-op when id does not match any record', () => {
+      const { manager, doUploadRequest } = createManager(
+        vi.fn().mockImplementation(() => new Promise(() => {})),
+      );
+      void manager.upload({ id: 'm1', channelCid: TEST_CID, file: new File([], 'x') });
+
+      manager.deleteUploadRecord('other');
+
+      expect(manager.getUpload('m1')).toEqual({ id: 'm1', uploadProgress: 0 });
+      expect(doUploadRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-insert the record when onProgress fires after deleteUploadRecord', async () => {
+      let onProgress!: (p?: number) => void;
+      const { manager, doUploadRequest } = createManager(
+        vi
+          .fn()
+          .mockImplementation(
+            (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+              onProgress = opts!.onProgress!;
+              return new Promise(() => {});
+            },
+          ),
+      );
+
+      void manager.upload({
+        id: 'removed-mid-flight',
+        channelCid: TEST_CID,
+        file: new File([], 'x'),
+      });
+
+      await Promise.resolve();
+      expect(manager.getUpload('removed-mid-flight')).toBeDefined();
+
+      manager.deleteUploadRecord('removed-mid-flight');
+      expect(manager.getUpload('removed-mid-flight')).toBeUndefined();
+
+      onProgress(50);
+      expect(manager.getUpload('removed-mid-flight')).toBeUndefined();
+      expect(doUploadRequest).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/test/unit/MessageComposer/uploadManager.test.ts
+++ b/test/unit/MessageComposer/uploadManager.test.ts
@@ -43,7 +43,10 @@ describe('UploadManager', () => {
     expect(manager.getUpload('local-a')).toBeUndefined();
     expect(doUploadRequest).toHaveBeenCalledWith(
       file,
-      expect.objectContaining({ onProgress: expect.any(Function) }),
+      expect.objectContaining({
+        onProgress: expect.any(Function),
+        abortSignal: expect.any(AbortSignal),
+      }),
     );
   });
 
@@ -195,7 +198,7 @@ describe('UploadManager', () => {
     expect(doUploadRequest).toHaveBeenCalled();
   });
 
-  it('omits onProgress when attachment manager config trackUploadProgress is false', async () => {
+  it('passes abortSignal without onProgress when trackUploadProgress is false', async () => {
     const { manager, doUploadRequest } = createManager(
       vi.fn().mockResolvedValue(undefined),
       false,
@@ -206,7 +209,9 @@ describe('UploadManager', () => {
       channelCid: TEST_CID,
       file,
     });
-    expect(doUploadRequest).toHaveBeenCalledWith(file, undefined);
+    expect(doUploadRequest).toHaveBeenCalledWith(file, {
+      abortSignal: expect.any(AbortSignal),
+    });
   });
 
   describe('deleteUploadRecord', () => {
@@ -243,13 +248,98 @@ describe('UploadManager', () => {
       expect(doUploadRequest).toHaveBeenCalledTimes(1);
     });
 
+    it('aborts abortSignal when deleteUploadRecord is called during upload', async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const { manager, doUploadRequest } = createManager(
+        vi
+          .fn()
+          .mockImplementation((_file: unknown, opts?: { abortSignal?: AbortSignal }) => {
+            capturedSignal = opts?.abortSignal;
+            return new Promise(() => {});
+          }),
+      );
+
+      void manager.upload({ id: 'm1', channelCid: TEST_CID, file: new File([], 'x') });
+      await Promise.resolve();
+      expect(capturedSignal).toBeDefined();
+      expect(capturedSignal?.aborted).toBe(false);
+
+      manager.deleteUploadRecord('m1');
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(doUploadRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it('aborts all in-flight abortSignals when reset is called', async () => {
+      const signals: AbortSignal[] = [];
+      const { manager, doUploadRequest } = createManager(
+        vi
+          .fn()
+          .mockImplementation((_file: unknown, opts?: { abortSignal?: AbortSignal }) => {
+            if (opts?.abortSignal) signals.push(opts.abortSignal);
+            return new Promise(() => {});
+          }),
+      );
+
+      void manager.upload({ id: 'a', channelCid: TEST_CID, file: new File([], 'x') });
+      void manager.upload({ id: 'b', channelCid: TEST_CID, file: new File([], 'y') });
+      await Promise.resolve();
+      expect(signals).toHaveLength(2);
+      expect(signals.every((s) => !s.aborted)).toBe(true);
+
+      manager.reset();
+      expect(signals.every((s) => s.aborted)).toBe(true);
+      expect(manager.uploads).toEqual({});
+      expect(doUploadRequest).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects upload promise after delete when doUploadRequest honors abortSignal', async () => {
+      const { manager, doUploadRequest } = createManager(
+        vi
+          .fn()
+          .mockImplementation((_file: unknown, opts?: { abortSignal?: AbortSignal }) => {
+            const { abortSignal } = opts ?? {};
+            return new Promise((resolve, reject) => {
+              if (!abortSignal) {
+                reject(new Error('missing signal'));
+                return;
+              }
+              if (abortSignal.aborted) {
+                reject(new DOMException('The user aborted a request.', 'AbortError'));
+                return;
+              }
+              abortSignal.addEventListener(
+                'abort',
+                () =>
+                  reject(new DOMException('The user aborted a request.', 'AbortError')),
+                { once: true },
+              );
+            });
+          }),
+      );
+
+      const uploadPromise = manager.upload({
+        id: 'u-abort',
+        channelCid: TEST_CID,
+        file: new File([], 'x'),
+      });
+      await Promise.resolve();
+
+      manager.deleteUploadRecord('u-abort');
+
+      await expect(uploadPromise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(doUploadRequest).toHaveBeenCalledTimes(1);
+    });
+
     it('does not re-insert the record when onProgress fires after deleteUploadRecord', async () => {
       let onProgress!: (p?: number) => void;
       const { manager, doUploadRequest } = createManager(
         vi
           .fn()
           .mockImplementation(
-            (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+            (
+              _file: unknown,
+              opts?: { onProgress?: (n?: number) => void; abortSignal?: AbortSignal },
+            ) => {
               onProgress = opts!.onProgress!;
               return new Promise(() => {});
             },

--- a/test/unit/MessageComposer/uploadManager.test.ts
+++ b/test/unit/MessageComposer/uploadManager.test.ts
@@ -32,12 +32,12 @@ describe('UploadManager', () => {
       file,
     });
 
-    expect(manager.uploads).toEqual([
-      {
+    expect(manager.uploads).toEqual({
+      'local-a': {
         id: 'local-a',
         uploadProgress: 0,
       },
-    ]);
+    });
     await promise;
 
     expect(manager.getUpload('local-a')).toBeUndefined();
@@ -55,7 +55,7 @@ describe('UploadManager', () => {
 
     const snapshots: unknown[] = [];
     const { manager: manager2, doUploadRequest: doUploadRequest2 } = createManager();
-    const unsub = manager2.state.subscribe((next) => snapshots.push(next.uploads));
+    const unsub = manager2.state.subscribe((next) => snapshots.push({ ...next.uploads }));
     await manager2.upload({
       id: 'm1',
       channelCid: TEST_CID,
@@ -65,11 +65,15 @@ describe('UploadManager', () => {
 
     expect(
       snapshots.some((u: unknown) => {
-        const row = (u as UploadRecord[])?.[0];
+        const row = (u as Record<string, UploadRecord>)['m1'];
         return row?.id === 'm1' && row.uploadProgress === 0;
       }),
     ).toBe(true);
-    expect(snapshots.some((u: unknown) => (u as UploadRecord[]).length === 0)).toBe(true);
+    expect(
+      snapshots.some(
+        (u: unknown) => Object.keys(u as Record<string, UploadRecord>).length === 0,
+      ),
+    ).toBe(true);
     expect(doUploadRequest).toHaveBeenCalled();
     expect(doUploadRequest2).toHaveBeenCalled();
   });
@@ -121,7 +125,7 @@ describe('UploadManager', () => {
     ).rejects.toBe(err);
     manager.reset();
 
-    expect(manager.uploads).toEqual([]);
+    expect(manager.uploads).toEqual({});
     expect(doUploadRequest).toHaveBeenCalledTimes(1);
   });
 

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -345,6 +345,26 @@ describe('Client disconnectUser', () => {
 		await expect(client.disconnectUser()).rejects.toThrow();
 		expect(client.tokenManager.reset.called).to.be.true;
 	});
+
+	it('should clear upload manager records', async () => {
+		const client = new StreamChat('', '');
+		client.uploadManager.state.next(() => ({
+			uploads: [
+				{
+					id: 'upload-x',
+					uploadProgress: 0,
+				},
+			],
+		}));
+		const { resolve, promise } = Promise.withResolvers();
+		client.wsConnection = { disconnect: () => promise };
+		client.wsFallback = null;
+		const disconnectPromise = client.disconnectUser();
+		expect(client.uploadManager.uploads).to.have.length(0);
+		resolve();
+		await disconnectPromise;
+		expect(client.uploadManager.uploads).to.deep.equal([]);
+	});
 });
 
 describe('Detect node environment', () => {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -349,21 +349,21 @@ describe('Client disconnectUser', () => {
 	it('should clear upload manager records', async () => {
 		const client = new StreamChat('', '');
 		client.uploadManager.state.next(() => ({
-			uploads: [
-				{
+			uploads: {
+				'upload-x': {
 					id: 'upload-x',
 					uploadProgress: 0,
 				},
-			],
+			},
 		}));
 		const { resolve, promise } = Promise.withResolvers();
 		client.wsConnection = { disconnect: () => promise };
 		client.wsFallback = null;
 		const disconnectPromise = client.disconnectUser();
-		expect(client.uploadManager.uploads).to.have.length(0);
+		expect(Object.keys(client.uploadManager.uploads)).to.have.length(0);
 		resolve();
 		await disconnectPromise;
-		expect(client.uploadManager.uploads).to.deep.equal([]);
+		expect(client.uploadManager.uploads).to.deep.equal({});
 	});
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,14 +1603,14 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.2.tgz#6c307390136cf7a2278d09cec63b136dfc6e6da7"
-  integrity sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==
+axios@^1.15.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.1.tgz#075420b785da8adbdf545785b69f90c926b28542"
+  integrity sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==
   dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2771,10 +2771,10 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
-follow-redirects@^1.15.6:
-  version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.15.11:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 for-each@^0.3.3:
   version "0.3.5"
@@ -2795,6 +2795,17 @@ form-data@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
   integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -5021,10 +5032,10 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
 
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -5620,16 +5631,7 @@ string-argv@0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5695,14 +5697,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6315,16 +6310,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

RN PR for reference: https://github.com/GetStream/stream-chat-react-native/pull/3527

React Native allows hitting the send button before attachment uploads are completed. This means they need a way to track attachment upload status outside of `AttachmentManager`.

To solve this we have an `UploadManager` (can be accessed via `client.uploadManager`) that uses the `AttachmentManager` of a given channel to do attachment upload, and has a state to track `uploadProgress` for attachments.

Attachments are tracked by `id` in `UploadManager`.

Long-term solution: we talked with @isekovanic that `messageComposer` should have support for this feature, but that is a bigger task, not the scope of this PR.

## Changelog

-
