### PR TITLE
fix: update channel state if message becomes shadowed

### DIFF
--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -221,7 +221,8 @@ export class ChannelState {
 
     for (let i = 0; i < messagesToAdd.length; i += 1) {
       const isFromShadowBannedUser = messagesToAdd[i].shadowed;
-      if (isFromShadowBannedUser) {
+      const isMessageUpdate = !addIfDoesNotExist;
+      if (isFromShadowBannedUser && !isMessageUpdate) {
         filteredMessageIds.push(messagesToAdd[i].id);
         continue;
       }

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -221,8 +221,7 @@ export class ChannelState {
 
     for (let i = 0; i < messagesToAdd.length; i += 1) {
       const isFromShadowBannedUser = messagesToAdd[i].shadowed;
-      const isMessageUpdate = !addIfDoesNotExist;
-      if (isFromShadowBannedUser && !isMessageUpdate) {
+      if (isFromShadowBannedUser && addIfDoesNotExist) {
         filteredMessageIds.push(messagesToAdd[i].id);
         continue;
       }

--- a/test/unit/channel_state.test.js
+++ b/test/unit/channel_state.test.js
@@ -45,6 +45,19 @@ describe('ChannelState addMessagesSorted', function () {
 		expect(state.messages).to.be.empty;
 	});
 
+	it('updates an existing message with shadowed: true when applying a message update', () => {
+		state.addMessagesSorted([generateMsg({ id: 'shadow-update-msg' })]);
+
+		expect(state.messages).to.have.length(1);
+		expect(state.messages[0].shadowed).not.to.be.ok;
+
+		state.addMessageSorted({ ...state.messages[0], shadowed: true }, false, false);
+
+		expect(state.messages).to.have.length(1);
+		expect(state.messages[0].id).to.be.equal('shadow-update-msg');
+		expect(state.messages[0].shadowed).to.be.equal(true);
+	});
+
 	it('empty state add multiple messages', async function () {
 		state.addMessagesSorted([
 			generateMsg({ id: '1', date: '2020-01-01T00:00:00.001Z' }),


### PR DESCRIPTION
https://linear.app/stream/issue/REACT-945/handle-shadow-blocked-images-in-react-chat-sdk

If a message changed from `shadowed: false` to `shadowed: true`, the channel state ignored this change, didn't remove the message, nor did it update the message in state. This could happen with async image moderation. 

Fix: allow state update if the message becomes shadowed. This follows existing UX patterns where asynchronously moderated messages (this only happens if someone uses a custom CDN) are not removed from channel state, instead a placeholder is displayed.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
