### PR TITLE
chore(ci): update github actions and source node version from .nvmrc

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,24 +3,25 @@ description: Sets up Node and installs dependencies
 
 inputs:
   node-version:
-    description: 'Specify Node version'
+    description: 'Override Node version (defaults to .nvmrc)'
     required: false
-    default: '24'
+    default: ''
 
 runs:
   using: 'composite'
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
+        node-version-file: '.nvmrc'
 
     - name: Set NODE_VERSION env
       shell: bash
       run: echo "NODE_VERSION=$(node --version)" >> $GITHUB_ENV
 
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ./node_modules
         key: ${{ runner.os }}-${{ env.NODE_VERSION }}-modules-${{ hashFiles('./yarn.lock') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,7 +8,7 @@ jobs:
   pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       HUSKY: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-node
 
@@ -31,11 +31,11 @@ jobs:
           done
 
       - name: Notify Slack if failed
-        uses: voxmedia/github-action-slack-notify-build@v1
         if: failure()
+        uses: slackapi/slack-github-action@v3
         with:
-          channel_id: C02RPDF7T63
-          color: danger
-          status: FAILED
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_NOTIFICATIONS_BOT_TOKEN }}
+          payload: |
+            channel: "C02RPDF7T63"
+            text: "Scheduled tests FAILED on ${{ github.repository }}@${{ github.ref_name }} — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|view run>"

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: preactjs/compressed-size-action@v2
         env:

--- a/.github/workflows/type.yml
+++ b/.github/workflows/type.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-node
 


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` (v3/v4 → v6), `actions/setup-node` (v4 → v6), `actions/cache` (v4 → v5) — all latest majors, all on the Node 24 runtime.
- Replace deprecated `voxmedia/github-action-slack-notify-build@v1` (repo archived May 2024, pinned to EOL Node 16) with `slackapi/slack-github-action@v3` using `chat.postMessage`. Same channel (`C02RPDF7T63`) and same secret (`SLACK_NOTIFICATIONS_BOT_TOKEN`); the failure message now includes a clickable link to the failed run.
- The `setup-node` composite now reads the Node version from `.nvmrc` (currently `24`), so bumping Node is a one-line change. The `node-version` input is kept as an optional override (e.g. for matrix testing).

## Test plan
- [ ] `lint`, `pr-check`, `type`, `unit`, `size` workflows pass on this PR
- [ ] Confirm the Slack app behind `SLACK_NOTIFICATIONS_BOT_TOKEN` has `chat:write` scope and is a member of `C02RPDF7T63` (true under the old action, so this should be a no-op)
- [ ] Optional: trigger `Scheduled tests` via workflow_dispatch with a forced failure to verify the new Slack notification path