### PR TITLE
fix(types): align with backend response schema

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,13 @@ export type AppSettingsAPIResponse = APIResponse & {
         uploads?: boolean;
         url_enrichment?: boolean;
         user_message_reminders?: boolean;
+        push_level?:
+          | 'all'
+          | 'all_mentions'
+          | 'direct_mentions'
+          | 'mentions'
+          | 'none'
+          | '';
       }
     >;
     reminders_interval: number;
@@ -154,9 +161,11 @@ export type AppSettingsAPIResponse = APIResponse & {
     max_aggregated_activities_length?: number;
     moderation_bulk_submit_action_enabled?: boolean;
     moderation_dashboard_preferences?: Record<string, unknown> | null;
+    moderation_audio_call_moderation_enabled?: boolean;
     moderation_enabled?: boolean;
     moderation_llm_configurability_enabled?: boolean;
     moderation_multitenant_blocklist_enabled?: boolean;
+    moderation_video_call_moderation_enabled?: boolean;
     moderation_webhook_url?: string;
     multi_tenant_enabled?: boolean;
     name?: string;
@@ -535,8 +544,8 @@ export type LocalMessageBase = Omit<
 };
 
 export type LocalMessage = LocalMessageBase & {
-  error?: ErrorFromResponse<APIErrorResponse>;
-  quoted_message?: LocalMessageBase;
+  error?: ErrorFromResponse<APIErrorResponse> | null;
+  quoted_message?: LocalMessageBase | null;
 };
 
 /**
@@ -744,6 +753,8 @@ export type MessageResponseBase = MessageBase & {
   member?: ChannelMemberResponse;
   mentioned_users?: UserResponse[];
   mentioned_channel?: boolean;
+  mentioned_here?: boolean;
+  mentioned_roles?: string[];
   message_text_updated_at?: string;
   moderation?: ModerationResponse; // present only with Moderation v2
   moderation_details?: ModerationDetailsResponse; // present only with Moderation v1
@@ -770,6 +781,13 @@ export type ReactionGroupResponse = {
   sum_scores: number;
   first_reaction_at?: string;
   last_reaction_at?: string;
+  latest_reactions_by?: ReactionGroupUserResponse[];
+};
+
+export type ReactionGroupUserResponse = {
+  created_at: string;
+  user_id: string;
+  user?: UserResponse;
 };
 
 export type ModerationDetailsResponse = {
@@ -2500,6 +2518,7 @@ export type ChannelConfigFields = {
   uploads?: boolean;
   url_enrichment?: boolean;
   user_message_reminders?: boolean; // Feature flag for user message reminders
+  push_level?: 'all' | 'all_mentions' | 'direct_mentions' | 'mentions' | 'none' | '';
 };
 
 export type ChannelConfigWithInfo = ChannelConfigFields &


### PR DESCRIPTION
## Summary
Fixes the scheduled `Type test` workflow, which has been failing for 4 consecutive Mondays (Apr 6, 13, 20, 27) because the live Stream backend has drifted from the SDK's TypeScript types. Each field added below is cross-referenced against the canonical [`GetStream/protocol/openapi/chat-openapi.yaml`](https://github.com/GetStream/protocol/blob/main/openapi/chat-openapi.yaml).

### Changes to `src/types.ts`

| Type | Field | Source |
|---|---|---|
| `MessageResponseBase` | `mentioned_here?: boolean` | spec: "Whether the message mentioned online users with @here tag" |
| `MessageResponseBase` | `mentioned_roles?: string[]` | spec: list of roles mentioned (admin, channel_moderator, custom roles). **Proactive** — in spec, not yet returned by backend, but will be the next drift the moment it ships |
| `ReactionGroupResponse` | `latest_reactions_by?: ReactionGroupUserResponse[]` | spec: required field, "The most recent users who reacted with this type, ordered by most recent first" |
| **new** `ReactionGroupUserResponse` | `{ created_at: string; user_id: string; user?: UserResponse }` | spec: required = `[user_id, created_at]` |
| `ChannelConfigFields` | `push_level?: 'all' \| 'all_mentions' \| 'direct_mentions' \| 'mentions' \| 'none' \| ''` | spec enum (5 values); `''` added to absorb empty-string responses observed in live `getAppSettings` data |
| `AppSettingsAPIResponse.app.channel_configs` (inline) | same `push_level` | this inline type duplicates `ChannelConfigFields` and didn't share it — same drift, two locations |
| `AppSettingsAPIResponse.app` | `moderation_audio_call_moderation_enabled?: boolean`, `moderation_video_call_moderation_enabled?: boolean` | spec: both `boolean`. Marked optional to match the existing pattern of every other `moderation_*` field on `app` |
| `LocalMessage` | `error?: ... \| null`, `quoted_message?: ... \| null` | live responses return explicit `null` (not just `undefined`) |

### Notes for reviewers

1. **`push_level: ''`** — the OpenAPI enum doesn't include `''`, but the live backend currently returns it for unset channel-type configs (visible in the captured `data.ts` from `getAppSettings`). Tightening the union to spec would re-break the test. Worth flagging upstream as a backend/spec discrepancy, but in the SDK we should match reality.
2. **`moderation_*_call_moderation_enabled`** — the spec lists both as `required` on `App`. I declared them `?:` to stay consistent with every other `moderation_*` field on the SDK's `app` object (all currently optional). Tightening these alone would be an inconsistent half-measure; aligning everything to spec would be a separate sweep PR.
3. **Inline duplication** — `AppSettingsAPIResponse.app.channel_configs` redeclares `ChannelConfigFields` inline rather than reusing the named type. That's why this drift surfaced in two places. A small follow-up to dedupe would prevent the next round of two-edits-for-one-field. Not in scope here.

## Test plan
Verified locally against the live Stream backend:
- [x] `yarn build` — clean
- [x] `yarn test-types` — 0 tsc errors after fixes (all 100+ live API calls return ✅)
- [x] `yarn types` (SDK noEmit type-check) — clean
- [x] `yarn lint` — clean
- [x] `yarn vitest run` — 2767 passed, 1 skipped, 0 failed

The next scheduled `Type test` run on Monday should turn green.