### PR TITLE
fix: revert RN SDK name update

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -4388,13 +4388,7 @@ export type PromoteChannelParams = {
  * is used to resolve the user agent.
  */
 export type SdkIdentifier = {
-  name:
-    | 'react'
-    | 'react-native-ios'
-    | 'react-native-android'
-    | 'expo-ios'
-    | 'expo-android'
-    | 'angular';
+  name: 'react' | 'react-native' | 'expo' | 'angular';
   version: string;
 };
 


### PR DESCRIPTION
Reverts GetStream/stream-chat-js#1724

This has been handled on our backend in the meantime. Unfortunately have to revert this.