### PR TITLE
perf: parse WebSocket events once at the transport boundary

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -4,7 +4,6 @@
 import type { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import axios from 'axios';
 import https from 'https';
-import type WebSocket from 'isomorphic-ws';
 
 import { Channel } from './channel';
 import { ClientState } from './client_state';
@@ -1379,13 +1378,6 @@ export class StreamChat {
     this.offlineDb?.executeQuerySafely((db) => db.handleEvent({ event }), {
       method: `handleEvent;${event.type}`,
     });
-  };
-
-  handleEvent = (messageEvent: WebSocket.MessageEvent) => {
-    // dispatch the event to the channel listeners
-    const jsonString = messageEvent.data as string;
-    const event = JSON.parse(jsonString) as Event;
-    this.dispatchEvent(event);
   };
 
   /**

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -477,12 +477,13 @@ export class StableWSConnection {
     if (this.wsID !== wsID) return;
 
     this._log('onmessage() - onmessage callback', { event, wsID });
-    const data = typeof event.data === 'string' ? JSON.parse(event.data) : null;
+    if (typeof event.data !== 'string') return;
+    const data = JSON.parse(event.data);
 
     // we wait till the first message before we consider the connection open..
     // the reason for this is that auth errors and similar errors trigger a ws.onopen and immediately
     // after that a ws.onclose..
-    if (!this.isResolved && data) {
+    if (!this.isResolved) {
       this.isResolved = true;
       if (data.error) {
         this.rejectPromise?.(this._errorFromWSEvent(data, false));
@@ -496,11 +497,11 @@ export class StableWSConnection {
     // trigger the event..
     this.lastEvent = new Date();
 
-    if (data && data.type === 'health.check') {
+    if (data.type === 'health.check') {
       this.scheduleNextPing();
     }
 
-    this.client.handleEvent(event);
+    this.client.dispatchEvent(data);
     this.scheduleConnectionCheck();
   };
 

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -131,6 +131,20 @@ describe('connection', function () {
 			expect(c.resolvePromise.calledOnce).to.be.true;
 			expect(c.rejectPromise.notCalled).to.be.true;
 		});
+
+		it('onmessage parses event.data once and dispatches the parsed payload', () => {
+			const client = newStreamChat();
+			client.dispatchEvent = sinon.spy();
+			const c = new StableWSConnection({ client });
+			c.isResolved = true;
+			c.scheduleConnectionCheck = () => null;
+
+			const payload = { type: 'message.new', cid: 'messaging:foo' };
+			c.onmessage(c.wsID, { data: JSON.stringify(payload) });
+
+			expect(client.dispatchEvent.calledOnce).to.be.true;
+			expect(client.dispatchEvent.firstCall.args[0]).to.deep.equal(payload);
+		});
 	});
 
 	describe('isConnecting flag', () => {

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -26,7 +26,6 @@ describe('connection', function () {
 		client.clientID = 'clientID';
 		client.insightMetrics = new InsightMetrics();
 		client.dispatchEvent = () => null;
-		client.handleEvent = () => null;
 		client.recoverState = () => null;
 		return client;
 	};


### PR DESCRIPTION
## Summary

- `StableWSConnection.onmessage` already parses each inbound frame to read `data.error`, `data.type === 'health.check'`, and to resolve the connection-open promise. It then handed the raw `WebSocket.MessageEvent` to `StreamChat.handleEvent`, which parsed the same string a second time before dispatching. This PR threads the already-parsed event into `dispatchEvent` and removes `handleEvent`.
- Tightens `onmessage` to bail early on non-string payloads — the previous code already treated non-string frames as a no-op for its local logic, but `handleEvent` would have unconditionally `JSON.parse(undefined)` and thrown. Aligns the contract with what the WS actually sends.
- Removes the now-unused `WebSocket` type import in `client.ts` and the matching `client.handleEvent = () => null` stub from `test/unit/connection.test.js`.

## Why now

`StreamChat.handleEvent` existed as a thin parse-and-forward wrapper because `StableWSConnection` used to be decoupled from the client through `messageCallback` / `eventCallback` constructor injection — the transport layer received raw `WebSocket.MessageEvent`s and the client owned the parse. PR #822 (Nov 2021, "refactor: simplify StableWSConnection constructor params") removed that abstraction and gave `StableWSConnection` a direct reference to its `client`. From that point `handleEvent` lost its rationale; it has been a redundant parse step ever since. Subsequent passes near this code (`f55157af` "cleanup", `08ce31c4` "feat: move event handling to single abstraction") consolidated other things but left this wrapper in place.

After this change, the WS path mirrors the longpoll fallback (`connection_fallback.ts`), which already calls `client.dispatchEvent(event)` directly with parsed events.

## Behavioral notes

- The offline DB pipeline is unaffected — `offlineDb.handleEvent({ event })` is invoked from inside `dispatchEvent` (added in `08ce31c4`), not from `StreamChat.handleEvent`. Both the live event path and the `OfflineDBSyncManager.syncAndExecutePendingTasks` replay path remain unchanged.
- `StreamChat.handleEvent` is on the public type surface but takes a `WebSocket.MessageEvent` — a transport-layer object no realistic external consumer would hold or construct. Removal is treated as an internal cleanup.

## Test plan

- [x] `yarn types` — passes
- [x] `yarn test-unit` — 2799 passed, 1 skipped, 0 failed (full suite)
- [x] Lint clean on touched files
- [ ] Reviewer manually verifies: a `health.check` frame still triggers `scheduleNextPing`; a frame with `data.error` still rejects the connection-open promise; a regular event still reaches client/channel listeners and the offline DB