### PR TITLE
chore(dev): add burst simulator Chrome extension

### DIFF
--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -1,0 +1,63 @@
+# Stream Chat Burst Simulator (Chrome extension)
+
+Dev-only Chrome extension that dispatches synthetic `message.new` and `reaction.new` events at `window.streamChannel` for stress / perf testing the chat UI.
+
+Not part of the npm package. Not shipped to users.
+
+## What it does
+
+On click, it injects [`simulator.js`](./simulator.js) into the active tab's main world (where `window.streamChannel` lives) and calls `window.__streamSimulateBurst(config)`. The simulator:
+
+- builds a pool of fake users
+- generates `message.new` events with varied text (3–50 words, occasional emojis / fake URLs / line breaks) so the renderer has real layout work to do
+- generates `reaction.new` events targeting the sliding window of recently-generated messages
+- paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
+- returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
+
+## Prerequisites
+
+The page under test must expose the channel as `window.streamChannel` (a `Channel` instance from `stream-chat`). The simulator calls `channel.getClient().dispatchEvent(...)`.
+
+## Load it
+
+1. Open `chrome://extensions`.
+2. Toggle **Developer mode** on.
+3. Click **Load unpacked** → select this `dev/burst-simulator-extension/` folder.
+4. Pin the extension to the toolbar.
+
+After editing any file, click the refresh icon for the extension on `chrome://extensions`. No build step.
+
+## Use it
+
+1. Open a page where `window.streamChannel` is set and the channel UI is mounted.
+2. Click the **Burst Simulator** icon.
+3. Configure:
+   - **Count** — total events (default `200`)
+   - **Rate / sec** — pacing; `0` = fire all in one tick (default `50`)
+   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.3`)
+   - **User pool size** — distinct fake users to rotate (default `10`)
+   - **React to last N** — sliding window of recent messages reactions can target (default `20`)
+4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.
+
+## Recommended profiling workflow
+
+1. Open the page, open DevTools → Performance.
+2. Open the extension popup, set your config.
+3. Click Record in DevTools.
+4. Click **Run burst**. Wait for completion.
+5. Stop recording and inspect the flame chart.
+
+For a single all-at-once burst, set **Rate / sec** to `0` — every event lands in one frame, captured as one long task.
+
+## Files
+
+- `manifest.json` — MV3 manifest, `scripting` + `activeTab` only
+- `popup.html` / `popup.css` / `popup.js` — popup UI and `executeScript` wiring
+- `simulator.js` — core simulator, runs in the page's main world
+
+## Limitations (v1)
+
+- No mid-run cancel — if a long run is wrong, reload the tab.
+- `message.new` and `reaction.new` only — no typing, edits, deletes, threads, attachments, or mentions.
+- Reactions only target burst-generated messages (not pre-existing channel state).
+- Single-channel only (whatever is on `window.streamChannel`).

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -38,8 +38,8 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
 2. Click the **Burst Simulator** icon.
 3. Configure:
    - **Count** — total events (default `1000`)
-   - **Rate / sec** — pacing; `0` = fire all in one tick (default `50`)
-   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.5`)
+   - **Rate / sec** — pacing; `0` = fire all in one tick (default `75`)
+   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.25`)
    - **User pool size** — distinct fake users to rotate (default `10`)
    - **React to last N** — sliding window of recent messages reactions can target (default `20`)
 4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -11,7 +11,7 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 - builds a pool of fake users
 - generates `message.new` events with varied text (3–50 words, occasional emojis / fake URLs / line breaks) so the renderer has real layout work to do
 - generates `reaction.new` events targeting any of the burst-generated messages, picked at random
-- mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too by default. The local parse can be disabled via the **Double parse** toggle for A/B comparisons against fixes that remove the duplicate.
+- mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too.
 - paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
 - returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
 
@@ -37,11 +37,10 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
 1. Open a page where the channel UI is mounted (no manual setup needed — the popup auto-finds the active `Channel`).
 2. Click the **Burst Simulator** icon.
 3. Configure:
-   - **Count** — total events (default `1000`)
-   - **Rate / sec** — pacing; `0` = fire all in one tick (default `75`)
-   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.25`)
+   - **Total events** — synthetic events to dispatch (default `1000`)
+   - **Rate per second** — pacing; `0` = fire all in one tick (default `75`)
+   - **Reactions ratio** — `0`–`1`, fraction of events that are reactions (default `0.25`)
    - **User pool size** — distinct fake users to rotate (default `10`)
-   - **Double parse** — when on (default), the simulator runs `JSON.parse` on each event twice per dispatch, mirroring today's prod path (`connection.onmessage` parses for the health-check shortcut, then `client.handleEvent` parses again). Toggle off to pay only the single parse and A/B against an in-flight fix that removes the duplicate.
 4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.
 
 ## Recommended profiling workflow

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -37,7 +37,7 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
 1. Open a page where the channel UI is mounted (no manual setup needed — the popup auto-finds the active `Channel`).
 2. Click the **Burst Simulator** icon.
 3. Configure:
-   - **Count** — total events (default `200`)
+   - **Count** — total events (default `1000`)
    - **Rate / sec** — pacing; `0` = fire all in one tick (default `50`)
    - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.5`)
    - **User pool size** — distinct fake users to rotate (default `10`)

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -10,7 +10,7 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 
 - builds a pool of fake users
 - generates `message.new` events with varied text (3–50 words, occasional emojis / fake URLs / line breaks) so the renderer has real layout work to do
-- generates `reaction.new` events targeting the sliding window of recently-generated messages
+- generates `reaction.new` events targeting any of the burst-generated messages, picked at random
 - mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too.
 - paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
 - returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
@@ -41,7 +41,6 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
    - **Rate / sec** — pacing; `0` = fire all in one tick (default `75`)
    - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.25`)
    - **User pool size** — distinct fake users to rotate (default `10`)
-   - **React to last N** — sliding window of recent messages reactions can target (default `20`)
 4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.
 
 ## Recommended profiling workflow

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -21,9 +21,9 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 
 The page under test must render the channel UI with React and `stream-chat`. The simulator calls `channel.getClient().handleEvent(...)`.
 
-You don't need to expose `window.streamChannel` yourself — the popup walks the React fiber tree on open, finds the active `Channel` (by duck-typing: any prop whose value has `getClient`, `cid`, `id`, `type`), and binds it to `window.streamChannel` automatically. If multiple Channel-shaped props exist (e.g. a `ChannelList` of previews next to an active `<Channel>`), it picks the one whose owning fiber wraps the largest subtree — typically the active channel.
+You don't need to expose anything yourself — the popup walks the React fiber tree on open, finds the active `Channel` (by duck-typing: any prop whose value has `getClient`, `cid`, `id`, `type` — including the conventional `channel` prop on `<Channel channel={ch}>`), and binds it to `window.streamChannel` automatically. If multiple Channel-shaped props exist (e.g. a `ChannelList` of previews next to an active `<Channel>`), it picks the one whose owning fiber wraps the largest subtree — typically the active channel.
 
-If you've already set `window.streamChannel` manually, the popup honors it and skips the fiber walk.
+If you've already set the channel manually, the popup honors it and skips the fiber walk. Both `window.streamChannel` (canonical) and `window.channel` (alias) are supported, with `window.streamChannel` taking precedence when both are set.
 
 ## Load it
 

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -17,7 +17,11 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 
 ## Prerequisites
 
-The page under test must expose the channel as `window.streamChannel` (a `Channel` instance from `stream-chat`). The simulator calls `channel.getClient().handleEvent(...)`.
+The page under test must render the channel UI with React and `stream-chat`. The simulator calls `channel.getClient().handleEvent(...)`.
+
+You don't need to expose `window.streamChannel` yourself — the popup walks the React fiber tree on open, finds the active `Channel` (by duck-typing: any prop whose value has `getClient`, `cid`, `id`, `type`), and binds it to `window.streamChannel` automatically. If multiple Channel-shaped props exist (e.g. a `ChannelList` of previews next to an active `<Channel>`), it picks the one whose owning fiber wraps the largest subtree — typically the active channel.
+
+If you've already set `window.streamChannel` manually, the popup honors it and skips the fiber walk.
 
 ## Load it
 
@@ -30,7 +34,7 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
 
 ## Use it
 
-1. Open a page where `window.streamChannel` is set and the channel UI is mounted.
+1. Open a page where the channel UI is mounted (no manual setup needed — the popup auto-finds the active `Channel`).
 2. Click the **Burst Simulator** icon.
 3. Configure:
    - **Count** — total events (default `200`)
@@ -61,4 +65,5 @@ For a single all-at-once burst, set **Rate / sec** to `0` — every event lands 
 - No mid-run cancel — if a long run is wrong, reload the tab.
 - `message.new` and `reaction.new` only — no typing, edits, deletes, threads, attachments, or mentions.
 - Reactions only target burst-generated messages (not pre-existing channel state).
-- Single-channel only (whatever is on `window.streamChannel`).
+- Single-channel only (whatever is on `window.streamChannel` — auto-bound or manually set).
+- Auto-detection requires the page to be a React app and the `Channel` to be live in the fiber tree. For non-React hosts, set `window.streamChannel` manually before opening the popup.

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -11,12 +11,13 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 - builds a pool of fake users
 - generates `message.new` events with varied text (3–50 words, occasional emojis / fake URLs / line breaks) so the renderer has real layout work to do
 - generates `reaction.new` events targeting the sliding window of recently-generated messages
+- mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too.
 - paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
 - returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
 
 ## Prerequisites
 
-The page under test must expose the channel as `window.streamChannel` (a `Channel` instance from `stream-chat`). The simulator calls `channel.getClient().dispatchEvent(...)`.
+The page under test must expose the channel as `window.streamChannel` (a `Channel` instance from `stream-chat`). The simulator calls `channel.getClient().handleEvent(...)`.
 
 ## Load it
 

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -13,7 +13,9 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 - generates `reaction.new` events targeting any of the burst-generated messages, picked at random
 - mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too.
 - paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
-- returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
+- streams live progress to the popup status line while a paced run is in flight (`Running · 230 / 1000 · 76 eps · 3s`); the **Fire burst** button morphs into a red **Stop** button so you can abort mid-run, returning a partial `{ dispatched, durationMs, messages, reactions, aborted: true }` result
+- preserves run state across popup open/close: closing the popup mid-run doesn't kill the burst — the simulator keeps running in the page main world. Re-opening the popup re-attaches to the in-flight run (or shows the summary if it finished while the popup was closed)
+- returns `{ dispatched, durationMs, messages, reactions, aborted }` and `console.log`s the same so the result survives the popup closing
 
 ## Prerequisites
 

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -39,7 +39,7 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
 3. Configure:
    - **Count** — total events (default `200`)
    - **Rate / sec** — pacing; `0` = fire all in one tick (default `50`)
-   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.3`)
+   - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.5`)
    - **User pool size** — distinct fake users to rotate (default `10`)
    - **React to last N** — sliding window of recent messages reactions can target (default `20`)
 4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.

--- a/dev/burst-simulator-extension/README.md
+++ b/dev/burst-simulator-extension/README.md
@@ -11,7 +11,7 @@ On click, it injects [`simulator.js`](./simulator.js) into the active tab's main
 - builds a pool of fake users
 - generates `message.new` events with varied text (3–50 words, occasional emojis / fake URLs / line breaks) so the renderer has real layout work to do
 - generates `reaction.new` events targeting any of the burst-generated messages, picked at random
-- mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too.
+- mirrors the real receive path's per-frame parse cost: stringify once, `JSON.parse` it locally (matches `connection.onmessage`'s local parse), then hand the string to `client.handleEvent` (which parses it a second time before dispatching). Production does both parses per WS frame — the simulator does too by default. The local parse can be disabled via the **Double parse** toggle for A/B comparisons against fixes that remove the duplicate.
 - paces dispatch by `ratePerSec`, or fires the whole burst in one `requestAnimationFrame` tick when rate is `0`
 - returns `{ dispatched, durationMs, messages, reactions }` and `console.log`s the same so the result survives the popup closing
 
@@ -41,6 +41,7 @@ After editing any file, click the refresh icon for the extension on `chrome://ex
    - **Rate / sec** — pacing; `0` = fire all in one tick (default `75`)
    - **Reaction ratio** — `0`–`1`, fraction of events that are reactions (default `0.25`)
    - **User pool size** — distinct fake users to rotate (default `10`)
+   - **Double parse** — when on (default), the simulator runs `JSON.parse` on each event twice per dispatch, mirroring today's prod path (`connection.onmessage` parses for the health-check shortcut, then `client.handleEvent` parses again). Toggle off to pay only the single parse and A/B against an in-flight fix that removes the duplicate.
 4. Click **Run burst**. Status line updates when the run completes; result is also `console.log`ged in the page's DevTools console.
 
 ## Recommended profiling workflow

--- a/dev/burst-simulator-extension/manifest.json
+++ b/dev/burst-simulator-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Stream Chat Burst Simulator",
+  "version": "0.1.0",
+  "description": "Dispatch synthetic message.new + reaction.new bursts at window.streamChannel for stress/perf testing.",
+  "permissions": ["scripting", "activeTab"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Burst Simulator"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["simulator.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;"
+  }
+}

--- a/dev/burst-simulator-extension/popup.css
+++ b/dev/burst-simulator-extension/popup.css
@@ -278,6 +278,35 @@ body {
   flex-shrink: 0;
 }
 
+.status__text {
+  flex: 1;
+  min-width: 0;
+}
+
+.status__recheck {
+  flex-shrink: 0;
+  appearance: none;
+  border: 1px solid var(--border-strong);
+  background: transparent;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.status__recheck:hover {
+  color: var(--text);
+  border-color: var(--text-muted);
+}
+
+.status__recheck:active {
+  transform: rotate(90deg);
+}
+
 .status--idle {
   border-left-color: var(--text-faint);
 }

--- a/dev/burst-simulator-extension/popup.css
+++ b/dev/burst-simulator-extension/popup.css
@@ -33,7 +33,7 @@ body {
   color: var(--text);
   background-color: var(--bg);
   background-image:
-    radial-gradient(circle at 10% -10%, rgba(255, 91, 46, 0.10), transparent 45%),
+    radial-gradient(circle at 10% -10%, rgba(255, 91, 46, 0.1), transparent 45%),
     radial-gradient(circle at 110% 110%, rgba(46, 145, 207, 0.06), transparent 45%);
 }
 
@@ -52,7 +52,11 @@ body {
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.035) 1px,
+    transparent 1px
+  );
   background-size: 12px 12px;
   background-position: 0 0;
   mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.4));
@@ -83,7 +87,8 @@ body {
 }
 
 @keyframes indicator-pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     box-shadow: 0 0 8px var(--accent-glow);
   }
@@ -171,7 +176,10 @@ body {
   background: var(--surface-2);
   color: var(--text);
   width: 100%;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background 0.15s ease;
 }
 
 .field input[type='number']::-webkit-outer-spin-button,
@@ -188,6 +196,59 @@ body {
   outline: none;
   border-color: var(--accent);
   background: var(--surface);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+.field--toggle {
+  grid-template-columns: 1fr auto;
+}
+
+.field--toggle input[type='checkbox'] {
+  appearance: none;
+  width: 32px;
+  height: 18px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  position: relative;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.field--toggle input[type='checkbox']::before {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.field--toggle input[type='checkbox']:hover {
+  border-color: var(--border-strong);
+}
+
+.field--toggle input[type='checkbox']:checked {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.field--toggle input[type='checkbox']:checked::before {
+  transform: translateX(14px);
+  background: var(--accent);
+}
+
+.field--toggle input[type='checkbox']:focus-visible {
+  outline: none;
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
@@ -212,8 +273,13 @@ body {
   background: var(--accent);
   cursor: pointer;
   overflow: hidden;
-  transition: transform 0.12s ease, box-shadow 0.2s ease, background 0.15s;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 6px 18px -4px var(--accent-glow);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.2s ease,
+    background 0.15s;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.25),
+    0 6px 18px -4px var(--accent-glow);
 }
 
 .run::after {
@@ -227,7 +293,9 @@ body {
 .run:hover:not(:disabled) {
   background: #ff7350;
   transform: translateY(-1px);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 10px 26px -6px var(--accent-glow);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.3),
+    0 10px 26px -6px var(--accent-glow);
 }
 
 .run:active:not(:disabled) {
@@ -295,7 +363,10 @@ body {
   padding: 2px 6px;
   border-radius: 3px;
   cursor: pointer;
-  transition: color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    transform 0.15s ease;
 }
 
 .status__recheck:hover {
@@ -342,7 +413,8 @@ body {
 }
 
 @keyframes dot-pulse {
-  0%, 100% {
+  0%,
+  100% {
     opacity: 1;
     transform: scale(1);
   }

--- a/dev/burst-simulator-extension/popup.css
+++ b/dev/burst-simulator-extension/popup.css
@@ -1,23 +1,52 @@
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 
-  --bg: #0d0f12;
-  --surface: #14171c;
-  --surface-2: #1c2027;
-  --border: #262b33;
-  --border-strong: #3a414b;
+  /* Surfaces */
+  --bg: #ffffff;
+  --surface-0: #ffffff;
+  --surface-1: #f8fafc; /* slate-50 */
+  --surface-2: #f1f5f9; /* slate-100 */
 
-  --text: #ecf0f5;
-  --text-muted: #7e8893;
-  --text-faint: #525a64;
+  /* Borders / dividers */
+  --border: #e2e8f0; /* slate-200 */
+  --border-strong: #cbd5e1; /* slate-300 */
+  --divider: #e2e8f0;
 
-  --accent: #ff5b2e;
-  --accent-soft: rgba(255, 91, 46, 0.18);
-  --accent-glow: rgba(255, 91, 46, 0.45);
+  /* Text */
+  --text: #0f172a; /* slate-900 */
+  --text-muted: #475569; /* slate-600 */
+  --text-faint: #94a3b8; /* slate-400 */
 
-  --ok: #3ecf8e;
-  --warn: #f7b731;
-  --err: #ff5070;
+  /* Primary / interactive */
+  --primary: #2563eb; /* blue-600 */
+  --primary-hover: #1d4ed8; /* blue-700 */
+  --primary-active: #1e40af; /* blue-800 */
+  --primary-soft: #dbeafe; /* blue-100 */
+  --primary-on: #ffffff;
+
+  /* Semantic — info */
+  --info: #2563eb;
+  --info-soft: #eff6ff; /* blue-50 */
+  --info-border: #bfdbfe; /* blue-200 */
+  --info-strong: #1e3a8a; /* blue-900 */
+
+  /* Semantic — success */
+  --success: #16a34a; /* green-600 */
+  --success-soft: #f0fdf4; /* green-50 */
+  --success-border: #bbf7d0; /* green-200 */
+  --success-strong: #14532d; /* green-900 */
+
+  /* Semantic — warning */
+  --warning: #d97706; /* amber-600 */
+  --warning-soft: #fffbeb; /* amber-50 */
+  --warning-border: #fde68a; /* amber-200 */
+  --warning-strong: #78350f; /* amber-900 */
+
+  /* Semantic — error */
+  --error: #dc2626; /* red-600 */
+  --error-soft: #fef2f2; /* red-50 */
+  --error-border: #fecaca; /* red-200 */
+  --error-strong: #7f1d1d; /* red-900 */
 }
 
 * {
@@ -27,97 +56,48 @@
 body {
   margin: 0;
   width: 320px;
-  font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
-  font-size: 12px;
-  font-feature-settings: 'ss02', 'cv11';
+  font-family:
+    'Geist',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  font-size: 14px;
+  line-height: 20px;
   color: var(--text);
-  background-color: var(--bg);
-  background-image:
-    radial-gradient(circle at 10% -10%, rgba(255, 91, 46, 0.1), transparent 45%),
-    radial-gradient(circle at 110% 110%, rgba(46, 145, 207, 0.06), transparent 45%);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /* ---------- frame ---------- */
 
 .frame {
-  position: relative;
-  padding: 18px 18px 16px 22px;
-  border-left: 3px solid var(--accent);
-  overflow: hidden;
+  padding: 16px;
 }
-
-.frame::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  z-index: 0;
-  background-image: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.035) 1px,
-    transparent 1px
-  );
-  background-size: 12px 12px;
-  background-position: 0 0;
-  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.4));
-}
-
-.frame > * {
-  position: relative;
-  z-index: 1;
-}
-
-/* ---------- header ---------- */
 
 .frame__head {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  gap: 12px;
-  margin-bottom: 18px;
-}
-
-.frame__indicator {
-  width: 10px;
-  height: 10px;
-  border-radius: 2px;
-  background: var(--accent);
-  box-shadow: 0 0 10px var(--accent-glow);
-  animation: indicator-pulse 2.4s ease-in-out infinite;
-}
-
-@keyframes indicator-pulse {
-  0%,
-  100% {
-    opacity: 1;
-    box-shadow: 0 0 8px var(--accent-glow);
-  }
-  50% {
-    opacity: 0.55;
-    box-shadow: 0 0 18px var(--accent-glow);
-  }
+  margin: 0 0 16px;
+  padding: 0 0 16px;
+  border-bottom: 1px solid var(--divider);
 }
 
 .frame__title {
   margin: 0;
-  font-family: 'Major Mono Display', 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 19px;
-  font-weight: 400;
-  letter-spacing: -0.5px;
-  text-transform: lowercase;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
   color: var(--text);
 }
 
-.frame__title span {
-  color: var(--accent);
-  margin: 0 1px;
-}
-
 .frame__subtitle {
-  margin: 2px 0 0;
-  font-size: 10px;
+  margin: 4px 0 0;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
   color: var(--text-muted);
-  letter-spacing: 0.4px;
 }
 
 /* ---------- form ---------- */
@@ -125,61 +105,57 @@ body {
 .form {
   display: flex;
   flex-direction: column;
-  gap: 2px;
 }
 
 .field {
   display: grid;
   grid-template-columns: 1fr 96px;
   align-items: center;
-  gap: 10px;
-  padding: 8px 0;
-  border-bottom: 1px dashed rgba(255, 255, 255, 0.05);
-}
-
-.field:last-of-type {
-  border-bottom: 0;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--divider);
 }
 
 .field label {
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  gap: 2px;
   cursor: pointer;
 }
 
 .field__label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.6px;
-  text-transform: uppercase;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 500;
   color: var(--text);
 }
 
 .field__unit {
-  font-size: 9px;
-  color: var(--text-faint);
-  letter-spacing: 0.5px;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--text-muted);
   text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .field input[type='number'] {
   -moz-appearance: textfield;
   appearance: textfield;
   font: inherit;
-  font-weight: 600;
-  font-size: 13px;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
   text-align: right;
-  padding: 7px 9px;
+  padding: 6px 10px;
   border: 1px solid var(--border);
-  border-radius: 4px;
-  background: var(--surface-2);
+  border-radius: 6px;
+  background: var(--surface-0);
   color: var(--text);
   width: 100%;
   transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    background 0.15s ease;
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
 }
 
 .field input[type='number']::-webkit-outer-spin-button,
@@ -194,128 +170,52 @@ body {
 
 .field input[type='number']:focus {
   outline: none;
-  border-color: var(--accent);
-  background: var(--surface);
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
-
-.field--toggle {
-  grid-template-columns: 1fr auto;
-}
-
-.field--toggle input[type='checkbox'] {
-  appearance: none;
-  width: 32px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--surface-2);
-  border: 1px solid var(--border);
-  position: relative;
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    border-color 0.15s ease;
-  margin: 0;
-  flex-shrink: 0;
-}
-
-.field--toggle input[type='checkbox']::before {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--text-muted);
-  transition:
-    transform 0.15s ease,
-    background 0.15s ease;
-}
-
-.field--toggle input[type='checkbox']:hover {
-  border-color: var(--border-strong);
-}
-
-.field--toggle input[type='checkbox']:checked {
-  background: var(--accent-soft);
-  border-color: var(--accent);
-}
-
-.field--toggle input[type='checkbox']:checked::before {
-  transform: translateX(14px);
-  background: var(--accent);
-}
-
-.field--toggle input[type='checkbox']:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px var(--accent-soft);
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 
 /* ---------- run button ---------- */
 
 .run {
-  position: relative;
-  margin-top: 14px;
+  margin-top: 16px;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  padding: 11px 14px;
+  gap: 6px;
+  padding: 10px 14px;
   font: inherit;
-  font-weight: 700;
-  font-size: 12px;
-  letter-spacing: 1.6px;
-  text-transform: uppercase;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
   border: 0;
-  border-radius: 4px;
-  color: var(--bg);
-  background: var(--accent);
+  border-radius: 6px;
+  color: var(--primary-on);
+  background: var(--primary);
   cursor: pointer;
-  overflow: hidden;
-  transition:
-    transform 0.12s ease,
-    box-shadow 0.2s ease,
-    background 0.15s;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.25),
-    0 6px 18px -4px var(--accent-glow);
-}
-
-.run::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), transparent 55%);
-  pointer-events: none;
+  transition: background 0.12s ease;
 }
 
 .run:hover:not(:disabled) {
-  background: #ff7350;
-  transform: translateY(-1px);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.3),
-    0 10px 26px -6px var(--accent-glow);
+  background: var(--primary-hover);
 }
 
 .run:active:not(:disabled) {
-  transform: translateY(0);
+  background: var(--primary-active);
+}
+
+.run:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--primary-soft);
 }
 
 .run:disabled {
-  background: var(--border-strong);
-  color: var(--text-muted);
-  cursor: progress;
-  box-shadow: none;
-  transform: none;
-}
-
-.run:disabled::after {
-  display: none;
+  background: var(--border);
+  color: var(--text-faint);
+  cursor: not-allowed;
 }
 
 .run__chevron {
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
 }
 
@@ -324,92 +224,67 @@ body {
 .status {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-top: 14px;
+  gap: 8px;
+  margin-top: 12px;
   padding: 10px 12px;
-  border-radius: 4px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-left: 3px solid var(--text-faint);
-  font-size: 11px;
-  letter-spacing: 0.3px;
+  border-radius: 6px;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
   word-break: break-word;
-  line-height: 1.45;
+  background: var(--surface-1);
+  border: 1px solid var(--border);
+  color: var(--text);
 }
 
 .status::before {
   content: '';
-  width: 7px;
-  height: 7px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   background: var(--text-faint);
   flex-shrink: 0;
 }
 
-.status__text {
-  flex: 1;
-  min-width: 0;
-}
-
-.status__recheck {
-  flex-shrink: 0;
-  appearance: none;
-  border: 1px solid var(--border-strong);
-  background: transparent;
-  color: var(--text-muted);
-  font: inherit;
-  font-size: 13px;
-  line-height: 1;
-  padding: 2px 6px;
-  border-radius: 3px;
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease,
-    transform 0.15s ease;
-}
-
-.status__recheck:hover {
-  color: var(--text);
-  border-color: var(--text-muted);
-}
-
-.status__recheck:active {
-  transform: rotate(90deg);
-}
-
 .status--idle {
-  border-left-color: var(--text-faint);
+  background: var(--surface-1);
+  border-color: var(--border);
+  color: var(--text-muted);
 }
+
 .status--idle::before {
-  background: var(--text-muted);
+  background: var(--text-faint);
 }
 
 .status--running {
-  border-left-color: var(--warn);
-  color: var(--warn);
+  background: var(--info-soft);
+  border-color: var(--info-border);
+  color: var(--info-strong);
 }
+
 .status--running::before {
-  background: var(--warn);
-  animation: dot-pulse 0.8s ease-in-out infinite;
+  background: var(--info);
+  animation: dot-pulse 0.9s ease-in-out infinite;
 }
 
 .status--ok {
-  border-left-color: var(--ok);
-  color: var(--ok);
+  background: var(--success-soft);
+  border-color: var(--success-border);
+  color: var(--success-strong);
 }
+
 .status--ok::before {
-  background: var(--ok);
-  box-shadow: 0 0 10px rgba(62, 207, 142, 0.55);
+  background: var(--success);
 }
 
 .status--error {
-  border-left-color: var(--err);
-  color: var(--err);
+  background: var(--error-soft);
+  border-color: var(--error-border);
+  color: var(--error-strong);
 }
+
 .status--error::before {
-  background: var(--err);
-  box-shadow: 0 0 10px rgba(255, 80, 112, 0.6);
+  background: var(--error);
 }
 
 @keyframes dot-pulse {
@@ -420,26 +295,59 @@ body {
   }
   50% {
     opacity: 0.45;
-    transform: scale(0.65);
+    transform: scale(0.7);
   }
+}
+
+.status__text {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+}
+
+.status__recheck {
+  flex-shrink: 0;
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface-0);
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition:
+    color 0.12s ease,
+    border-color 0.12s ease,
+    transform 0.15s ease;
+}
+
+.status__recheck:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+
+.status__recheck:active {
+  transform: rotate(90deg);
 }
 
 /* ---------- footer hint ---------- */
 
 .hint {
   margin: 12px 0 0;
-  font-size: 10px;
-  color: var(--text-faint);
-  line-height: 1.55;
-  letter-spacing: 0.3px;
+  font-size: 12px;
+  line-height: 16px;
+  font-weight: 400;
+  color: var(--text-muted);
 }
 
 .hint code {
-  display: inline-block;
-  color: var(--text-muted);
+  font-family: 'Geist Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12px;
+  letter-spacing: -0.03em;
+  color: var(--text);
   background: var(--surface-2);
-  padding: 1px 5px;
-  border-radius: 2px;
-  font-size: 10px;
-  border: 1px solid var(--border);
+  padding: 1px 6px;
+  border-radius: 3px;
 }

--- a/dev/burst-simulator-extension/popup.css
+++ b/dev/burst-simulator-extension/popup.css
@@ -1,0 +1,344 @@
+:root {
+  color-scheme: dark;
+
+  --bg: #0d0f12;
+  --surface: #14171c;
+  --surface-2: #1c2027;
+  --border: #262b33;
+  --border-strong: #3a414b;
+
+  --text: #ecf0f5;
+  --text-muted: #7e8893;
+  --text-faint: #525a64;
+
+  --accent: #ff5b2e;
+  --accent-soft: rgba(255, 91, 46, 0.18);
+  --accent-glow: rgba(255, 91, 46, 0.45);
+
+  --ok: #3ecf8e;
+  --warn: #f7b731;
+  --err: #ff5070;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  width: 320px;
+  font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  font-size: 12px;
+  font-feature-settings: 'ss02', 'cv11';
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(circle at 10% -10%, rgba(255, 91, 46, 0.10), transparent 45%),
+    radial-gradient(circle at 110% 110%, rgba(46, 145, 207, 0.06), transparent 45%);
+}
+
+/* ---------- frame ---------- */
+
+.frame {
+  position: relative;
+  padding: 18px 18px 16px 22px;
+  border-left: 3px solid var(--accent);
+  overflow: hidden;
+}
+
+.frame::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image: radial-gradient(circle, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+  background-size: 12px 12px;
+  background-position: 0 0;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.4));
+}
+
+.frame > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ---------- header ---------- */
+
+.frame__head {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.frame__indicator {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  background: var(--accent);
+  box-shadow: 0 0 10px var(--accent-glow);
+  animation: indicator-pulse 2.4s ease-in-out infinite;
+}
+
+@keyframes indicator-pulse {
+  0%, 100% {
+    opacity: 1;
+    box-shadow: 0 0 8px var(--accent-glow);
+  }
+  50% {
+    opacity: 0.55;
+    box-shadow: 0 0 18px var(--accent-glow);
+  }
+}
+
+.frame__title {
+  margin: 0;
+  font-family: 'Major Mono Display', 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 19px;
+  font-weight: 400;
+  letter-spacing: -0.5px;
+  text-transform: lowercase;
+  color: var(--text);
+}
+
+.frame__title span {
+  color: var(--accent);
+  margin: 0 1px;
+}
+
+.frame__subtitle {
+  margin: 2px 0 0;
+  font-size: 10px;
+  color: var(--text-muted);
+  letter-spacing: 0.4px;
+}
+
+/* ---------- form ---------- */
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.field {
+  display: grid;
+  grid-template-columns: 1fr 96px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed rgba(255, 255, 255, 0.05);
+}
+
+.field:last-of-type {
+  border-bottom: 0;
+}
+
+.field label {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  cursor: pointer;
+}
+
+.field__label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.field__unit {
+  font-size: 9px;
+  color: var(--text-faint);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.field input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+  font: inherit;
+  font-weight: 600;
+  font-size: 13px;
+  text-align: right;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface-2);
+  color: var(--text);
+  width: 100%;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.field input[type='number']::-webkit-outer-spin-button,
+.field input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.field input[type='number']:hover {
+  border-color: var(--border-strong);
+}
+
+.field input[type='number']:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--surface);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+/* ---------- run button ---------- */
+
+.run {
+  position: relative;
+  margin-top: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 11px 14px;
+  font: inherit;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  border: 0;
+  border-radius: 4px;
+  color: var(--bg);
+  background: var(--accent);
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.12s ease, box-shadow 0.2s ease, background 0.15s;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 6px 18px -4px var(--accent-glow);
+}
+
+.run::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.18), transparent 55%);
+  pointer-events: none;
+}
+
+.run:hover:not(:disabled) {
+  background: #ff7350;
+  transform: translateY(-1px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3), 0 10px 26px -6px var(--accent-glow);
+}
+
+.run:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.run:disabled {
+  background: var(--border-strong);
+  color: var(--text-muted);
+  cursor: progress;
+  box-shadow: none;
+  transform: none;
+}
+
+.run:disabled::after {
+  display: none;
+}
+
+.run__chevron {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* ---------- status ---------- */
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 14px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--text-faint);
+  font-size: 11px;
+  letter-spacing: 0.3px;
+  word-break: break-word;
+  line-height: 1.45;
+}
+
+.status::before {
+  content: '';
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  flex-shrink: 0;
+}
+
+.status--idle {
+  border-left-color: var(--text-faint);
+}
+.status--idle::before {
+  background: var(--text-muted);
+}
+
+.status--running {
+  border-left-color: var(--warn);
+  color: var(--warn);
+}
+.status--running::before {
+  background: var(--warn);
+  animation: dot-pulse 0.8s ease-in-out infinite;
+}
+
+.status--ok {
+  border-left-color: var(--ok);
+  color: var(--ok);
+}
+.status--ok::before {
+  background: var(--ok);
+  box-shadow: 0 0 10px rgba(62, 207, 142, 0.55);
+}
+
+.status--error {
+  border-left-color: var(--err);
+  color: var(--err);
+}
+.status--error::before {
+  background: var(--err);
+  box-shadow: 0 0 10px rgba(255, 80, 112, 0.6);
+}
+
+@keyframes dot-pulse {
+  0%, 100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.45;
+    transform: scale(0.65);
+  }
+}
+
+/* ---------- footer hint ---------- */
+
+.hint {
+  margin: 12px 0 0;
+  font-size: 10px;
+  color: var(--text-faint);
+  line-height: 1.55;
+  letter-spacing: 0.3px;
+}
+
+.hint code {
+  display: inline-block;
+  color: var(--text-muted);
+  background: var(--surface-2);
+  padding: 1px 5px;
+  border-radius: 2px;
+  font-size: 10px;
+  border: 1px solid var(--border);
+}

--- a/dev/burst-simulator-extension/popup.css
+++ b/dev/burst-simulator-extension/popup.css
@@ -214,6 +214,22 @@ body {
   cursor: not-allowed;
 }
 
+.run--stop {
+  background: var(--error);
+}
+
+.run--stop:hover:not(:disabled) {
+  background: #b91c1c; /* red-700 */
+}
+
+.run--stop:active:not(:disabled) {
+  background: #991b1b; /* red-800 */
+}
+
+.run--stop:focus-visible {
+  box-shadow: 0 0 0 3px var(--error-soft);
+}
+
 .run__chevron {
   font-size: 12px;
   line-height: 1;

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -36,7 +36,7 @@
             <span class="field__label">rate</span>
             <span class="field__unit">/ sec — 0 = burst</span>
           </label>
-          <input id="f-rate" type="number" name="ratePerSec" value="50" min="0" step="1" />
+          <input id="f-rate" type="number" name="ratePerSec" value="75" min="0" step="1" />
         </div>
 
         <div class="field">
@@ -44,7 +44,7 @@
             <span class="field__label">reactions</span>
             <span class="field__unit">ratio (0–1)</span>
           </label>
-          <input id="f-react" type="number" name="reactionRatio" value="0.5" min="0" max="1" step="0.05" />
+          <input id="f-react" type="number" name="reactionRatio" value="0.25" min="0" max="1" step="0.05" />
         </div>
 
         <div class="field">

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -77,6 +77,14 @@
           />
         </div>
 
+        <div class="field field--toggle">
+          <label for="f-double-parse">
+            <span class="field__label">double parse</span>
+            <span class="field__unit">mirror prod onmessage</span>
+          </label>
+          <input id="f-double-parse" type="checkbox" name="doubleParse" checked />
+        </div>
+
         <button type="submit" id="run" class="run">
           <span class="run__chevron" aria-hidden="true">▸</span>
           <span class="run__label">Fire burst</span>

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -2,12 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <!-- preview-refresh: 2 -->
     <title>Burst Simulator</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Major+Mono+Display&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=Geist+Mono:wght@400;500&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="popup.css" />
@@ -15,26 +14,23 @@
   <body>
     <div class="frame">
       <header class="frame__head">
-        <div class="frame__indicator" aria-hidden="true"></div>
-        <div class="frame__titles">
-          <h1 class="frame__title">burst<span>:</span>simulator</h1>
-          <p class="frame__subtitle">// stream-chat channel pressure test</p>
-        </div>
+        <h1 class="frame__title">Burst Simulator</h1>
+        <p class="frame__subtitle">Stream chat channel pressure test</p>
       </header>
 
       <form id="burst-form" class="form">
         <div class="field">
           <label for="f-count">
-            <span class="field__label">count</span>
-            <span class="field__unit">events</span>
+            <span class="field__label">total events</span>
+            <span class="field__unit">to dispatch</span>
           </label>
           <input id="f-count" type="number" name="count" value="1000" min="0" step="1" />
         </div>
 
         <div class="field">
           <label for="f-rate">
-            <span class="field__label">rate</span>
-            <span class="field__unit">/ sec — 0 = burst</span>
+            <span class="field__label">rate per second</span>
+            <span class="field__unit">0 = burst</span>
           </label>
           <input
             id="f-rate"
@@ -48,8 +44,8 @@
 
         <div class="field">
           <label for="f-react">
-            <span class="field__label">reactions</span>
-            <span class="field__unit">ratio (0–1)</span>
+            <span class="field__label">reactions ratio</span>
+            <span class="field__unit">0 – 1</span>
           </label>
           <input
             id="f-react"
@@ -64,8 +60,8 @@
 
         <div class="field">
           <label for="f-pool">
-            <span class="field__label">users</span>
-            <span class="field__unit">pool size</span>
+            <span class="field__label">user pool size</span>
+            <span class="field__unit">distinct users</span>
           </label>
           <input
             id="f-pool"
@@ -75,14 +71,6 @@
             min="1"
             step="1"
           />
-        </div>
-
-        <div class="field field--toggle">
-          <label for="f-double-parse">
-            <span class="field__label">double parse</span>
-            <span class="field__unit">mirror prod onmessage</span>
-          </label>
-          <input id="f-double-parse" type="checkbox" name="doubleParse" checked />
         </div>
 
         <button type="submit" id="run" class="run">

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <!-- preview-refresh: 1 -->
+    <title>Burst Simulator</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Major+Mono+Display&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <div class="frame">
+      <header class="frame__head">
+        <div class="frame__indicator" aria-hidden="true"></div>
+        <div class="frame__titles">
+          <h1 class="frame__title">burst<span>:</span>simulator</h1>
+          <p class="frame__subtitle">// stream-chat channel pressure test</p>
+        </div>
+      </header>
+
+      <form id="burst-form" class="form">
+        <div class="field">
+          <label for="f-count">
+            <span class="field__label">count</span>
+            <span class="field__unit">events</span>
+          </label>
+          <input id="f-count" type="number" name="count" value="200" min="0" step="1" />
+        </div>
+
+        <div class="field">
+          <label for="f-rate">
+            <span class="field__label">rate</span>
+            <span class="field__unit">/ sec — 0 = burst</span>
+          </label>
+          <input id="f-rate" type="number" name="ratePerSec" value="50" min="0" step="1" />
+        </div>
+
+        <div class="field">
+          <label for="f-react">
+            <span class="field__label">reactions</span>
+            <span class="field__unit">ratio (0–1)</span>
+          </label>
+          <input id="f-react" type="number" name="reactionRatio" value="0.3" min="0" max="1" step="0.05" />
+        </div>
+
+        <div class="field">
+          <label for="f-pool">
+            <span class="field__label">users</span>
+            <span class="field__unit">pool size</span>
+          </label>
+          <input id="f-pool" type="number" name="userPoolSize" value="10" min="1" step="1" />
+        </div>
+
+        <div class="field">
+          <label for="f-window">
+            <span class="field__label">window</span>
+            <span class="field__unit">last n msgs</span>
+          </label>
+          <input id="f-window" type="number" name="reactToLastN" value="20" min="1" step="1" />
+        </div>
+
+        <button type="submit" id="run" class="run">
+          <span class="run__chevron" aria-hidden="true">▸</span>
+          <span class="run__label">Fire burst</span>
+        </button>
+      </form>
+
+      <footer class="status status--idle" id="status">Idle</footer>
+
+      <p class="hint">
+        target → <code>window.streamChannel</code><br />
+        result is also logged to the page console
+      </p>
+    </div>
+
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -44,7 +44,7 @@
             <span class="field__label">reactions</span>
             <span class="field__unit">ratio (0–1)</span>
           </label>
-          <input id="f-react" type="number" name="reactionRatio" value="0.3" min="0" max="1" step="0.05" />
+          <input id="f-react" type="number" name="reactionRatio" value="0.5" min="0" max="1" step="0.05" />
         </div>
 
         <div class="field">

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -28,7 +28,7 @@
             <span class="field__label">count</span>
             <span class="field__unit">events</span>
           </label>
-          <input id="f-count" type="number" name="count" value="200" min="0" step="1" />
+          <input id="f-count" type="number" name="count" value="1000" min="0" step="1" />
         </div>
 
         <div class="field">

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -85,7 +85,7 @@
           type="button"
           id="recheck"
           class="status__recheck"
-          title="Re-check window.streamChannel"
+          title="Re-check channel detection"
           hidden
         >
           ↻
@@ -93,8 +93,8 @@
       </footer>
 
       <p class="hint">
-        target → <code>window.streamChannel</code><br />
-        result is also logged to the page console
+        auto-detected from the React tree<br />
+        (override via <code>window.streamChannel</code> or <code>window.channel</code>)
       </p>
     </div>
 

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <!-- preview-refresh: 1 -->
+    <!-- preview-refresh: 2 -->
     <title>Burst Simulator</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -69,7 +69,16 @@
         </button>
       </form>
 
-      <footer class="status status--idle" id="status">Idle</footer>
+      <footer class="status status--idle" id="status-wrap">
+        <span class="status__text" id="status">Detecting…</span>
+        <button
+          type="button"
+          id="recheck"
+          class="status__recheck"
+          title="Re-check window.streamChannel"
+          hidden
+        >↻</button>
+      </footer>
 
       <p class="hint">
         target → <code>window.streamChannel</code><br />

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -93,8 +93,8 @@
       </footer>
 
       <p class="hint">
-        auto-detected from the React tree<br />
-        (override via <code>window.streamChannel</code> or <code>window.channel</code>)
+        StreamChannel is auto-detected from the React component tree, or taken from
+        <code>window.channel</code> or <code>window.streamChannel</code>.
       </p>
     </div>
 

--- a/dev/burst-simulator-extension/popup.html
+++ b/dev/burst-simulator-extension/popup.html
@@ -36,7 +36,14 @@
             <span class="field__label">rate</span>
             <span class="field__unit">/ sec — 0 = burst</span>
           </label>
-          <input id="f-rate" type="number" name="ratePerSec" value="75" min="0" step="1" />
+          <input
+            id="f-rate"
+            type="number"
+            name="ratePerSec"
+            value="75"
+            min="0"
+            step="1"
+          />
         </div>
 
         <div class="field">
@@ -44,7 +51,15 @@
             <span class="field__label">reactions</span>
             <span class="field__unit">ratio (0–1)</span>
           </label>
-          <input id="f-react" type="number" name="reactionRatio" value="0.25" min="0" max="1" step="0.05" />
+          <input
+            id="f-react"
+            type="number"
+            name="reactionRatio"
+            value="0.25"
+            min="0"
+            max="1"
+            step="0.05"
+          />
         </div>
 
         <div class="field">
@@ -52,15 +67,14 @@
             <span class="field__label">users</span>
             <span class="field__unit">pool size</span>
           </label>
-          <input id="f-pool" type="number" name="userPoolSize" value="10" min="1" step="1" />
-        </div>
-
-        <div class="field">
-          <label for="f-window">
-            <span class="field__label">window</span>
-            <span class="field__unit">last n msgs</span>
-          </label>
-          <input id="f-window" type="number" name="reactToLastN" value="20" min="1" step="1" />
+          <input
+            id="f-pool"
+            type="number"
+            name="userPoolSize"
+            value="10"
+            min="1"
+            step="1"
+          />
         </div>
 
         <button type="submit" id="run" class="run">
@@ -77,7 +91,9 @@
           class="status__recheck"
           title="Re-check window.streamChannel"
           hidden
-        >↻</button>
+        >
+          ↻
+        </button>
       </footer>
 
       <p class="hint">

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -17,6 +17,7 @@ const readConfig = () => {
 		ratePerSec: Number(data.get('ratePerSec')),
 		reactionRatio: Number(data.get('reactionRatio')),
 		userPoolSize: Number(data.get('userPoolSize')),
+		doubleParse: data.get('doubleParse') === 'on',
 	};
 };
 

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -1,5 +1,7 @@
 const form = document.getElementById('burst-form');
 const button = document.getElementById('run');
+const buttonLabel = button.querySelector('.run__label');
+const buttonGlyph = button.querySelector('.run__chevron');
 const statusWrap = document.getElementById('status-wrap');
 const statusText = document.getElementById('status');
 const recheckBtn = document.getElementById('recheck');
@@ -8,6 +10,129 @@ const setStatus = (text, kind, { showRecheck = false } = {}) => {
 	statusText.textContent = text;
 	statusWrap.className = `status status--${kind}`;
 	recheckBtn.hidden = !showRecheck;
+};
+
+let runState = 'idle'; // 'idle' | 'running'
+let pollTimer = null;
+let pollSamples = []; // [{ at, dispatched }]
+let runningTabId = null;
+let isOwnRun = false; // true if THIS popup session started the run
+
+const formatResult = (r) => {
+	const prefix = r.aborted ? 'Stopped at' : 'Dispatched';
+	return `${prefix} ${r.dispatched} in ${r.durationMs}ms — ${r.messages} messages, ${r.reactions} reactions`;
+};
+
+const readPageStatus = async (tabId) => {
+	try {
+		const [injection] = await chrome.scripting.executeScript({
+			target: { tabId },
+			world: 'MAIN',
+			func: () => {
+				const sim = window.__streamSimulateBurst;
+				if (!sim) return null;
+				return {
+					state: sim.state || null,
+					lastResult: sim.lastResult || null,
+				};
+			},
+		});
+		return injection?.result || null;
+	} catch (e) {
+		return null;
+	}
+};
+
+const setRunButton = (state) => {
+	runState = state;
+	if (state === 'running') {
+		button.classList.add('run--stop');
+		buttonGlyph.textContent = '■';
+		buttonLabel.textContent = 'Stop';
+	} else {
+		button.classList.remove('run--stop');
+		buttonGlyph.textContent = '▸';
+		buttonLabel.textContent = 'Fire burst';
+	}
+};
+
+const stopPolling = () => {
+	if (pollTimer) {
+		clearInterval(pollTimer);
+		pollTimer = null;
+	}
+	pollSamples = [];
+};
+
+const startPolling = (tabId) => {
+	stopPolling();
+	const localTimer = setInterval(async () => {
+		try {
+			const status = await readPageStatus(tabId);
+			// Bail if polling was stopped while we were awaiting executeScript —
+			// avoids clobbering the post-run summary with a stale "Running" line.
+			if (pollTimer !== localTimer) return;
+
+			const state = status?.state;
+			if (!state) return;
+
+			if (state.phase === 'done') {
+				stopPolling();
+				// For resumed runs there's no awaiting handler that will pick up
+				// the result — we have to surface the summary ourselves. For
+				// own runs the form-submit handler is awaiting and will do it,
+				// so leave the status alone here.
+				if (!isOwnRun) {
+					const r = status.lastResult;
+					if (r) {
+						setStatus(formatResult(r), 'ok', { showRecheck: true });
+					}
+					setRunButton('idle');
+					runningTabId = null;
+				}
+				return;
+			}
+
+			const now = performance.now();
+			pollSamples.push({ at: now, dispatched: state.dispatched });
+			while (pollSamples.length > 5) pollSamples.shift();
+
+			let eps = 0;
+			if (pollSamples.length >= 2) {
+				const first = pollSamples[0];
+				const last = pollSamples[pollSamples.length - 1];
+				const dtMs = last.at - first.at;
+				const dDispatched = last.dispatched - first.dispatched;
+				eps = dtMs > 0 ? Math.round((dDispatched / dtMs) * 1000) : 0;
+			}
+
+			const elapsedSec = Math.max(0, Math.floor((Date.now() - state.startWallMs) / 1000));
+			setStatus(
+				`Running · ${state.dispatched} / ${state.target} · ${eps} eps · ${elapsedSec}s`,
+				'running',
+				{ showRecheck: false },
+			);
+		} catch (e) {
+			// Tab navigated away or permission revoked — stop quietly.
+			if (pollTimer === localTimer) stopPolling();
+		}
+	}, 300);
+	pollTimer = localTimer;
+};
+
+const requestAbort = async () => {
+	if (!runningTabId) return;
+	try {
+		await chrome.scripting.executeScript({
+			target: { tabId: runningTabId },
+			world: 'MAIN',
+			func: () => {
+				if (window.__streamSimulateBurst) window.__streamSimulateBurst.abort = true;
+			},
+		});
+	} catch (e) {
+		// best-effort
+	}
 };
 
 const readConfig = () => {
@@ -211,6 +336,26 @@ const formatSuccess = (r) => {
 	return `Ready · ${r.cid} · ${detail}${tail}`;
 };
 
+const maybeResumeRun = async (tabId) => {
+	const status = await readPageStatus(tabId);
+	if (!status) return;
+
+	if (status.state?.phase === 'running') {
+		// A previous popup session (or the same one before close) kicked off
+		// this burst; re-attach to it as a watcher.
+		runningTabId = tabId;
+		isOwnRun = false;
+		setRunButton('running');
+		recheckBtn.hidden = true;
+		setStatus('Re-attached to run…', 'running');
+		startPolling(tabId);
+	} else if (status.lastResult) {
+		// Last run finished while the popup was closed (or before this open).
+		// Show its summary instead of the channel-detection text.
+		setStatus(formatResult(status.lastResult), 'ok', { showRecheck: true });
+	}
+};
+
 const detectChannel = async () => {
 	button.disabled = true;
 	setStatus('Scanning React tree…', 'running');
@@ -228,6 +373,9 @@ const detectChannel = async () => {
 		if (result?.ok) {
 			setStatus(formatSuccess(result), 'ok', { showRecheck: true });
 			button.disabled = false;
+			// If a burst is already running on this tab, or just finished,
+			// surface that instead of leaving the channel-detection text up.
+			await maybeResumeRun(tab.id);
 		} else {
 			setStatus(REASON_TEXT[result?.reason] || 'channel detection failed', 'error', {
 				showRecheck: true,
@@ -249,20 +397,37 @@ recheckBtn.addEventListener('click', () => {
 form.addEventListener('submit', async (e) => {
 	e.preventDefault();
 
+	if (runState === 'running') {
+		// Second click while a run is in flight → request abort. The simulator
+		// resolves on its next tick with `aborted: true`, and the in-flight
+		// `await` below picks up the partial result and reports it.
+		await requestAbort();
+		return;
+	}
+
 	const config = readConfig();
-	button.disabled = true;
 	recheckBtn.hidden = true;
 	setStatus('Running…', 'running');
+	setRunButton('running');
+	isOwnRun = true;
+
+	const isPaced = config.ratePerSec > 0 && Number.isFinite(config.ratePerSec);
 
 	try {
 		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 		if (!tab?.id) throw new Error('No active tab.');
+		runningTabId = tab.id;
 
 		await chrome.scripting.executeScript({
 			target: { tabId: tab.id },
 			world: 'MAIN',
 			files: ['simulator.js'],
 		});
+
+		// In burst-all mode the entire batch runs in one rAF tick, so polling
+		// would never get a chance to read fresh state. Skip the live readout
+		// and let the post-run summary handle it.
+		if (isPaced) startPolling(tab.id);
 
 		const [injection] = await chrome.scripting.executeScript({
 			target: { tabId: tab.id },
@@ -277,6 +442,8 @@ form.addEventListener('submit', async (e) => {
 			args: [config],
 		});
 
+		stopPolling();
+
 		const payload = injection?.result;
 		if (!payload?.ok) {
 			setStatus(`Error: ${payload?.error || 'unknown failure'}`, 'error', {
@@ -284,8 +451,9 @@ form.addEventListener('submit', async (e) => {
 			});
 		} else {
 			const r = payload.result;
+			const prefix = r.aborted ? 'Stopped at' : 'Dispatched';
 			setStatus(
-				`Dispatched ${r.dispatched} in ${r.durationMs}ms — ${r.messages} messages, ${r.reactions} reactions`,
+				`${prefix} ${r.dispatched} in ${r.durationMs}ms — ${r.messages} messages, ${r.reactions} reactions`,
 				'ok',
 				{ showRecheck: true },
 			);
@@ -293,7 +461,10 @@ form.addEventListener('submit', async (e) => {
 	} catch (err) {
 		setStatus(`Error: ${err?.message || String(err)}`, 'error', { showRecheck: true });
 	} finally {
-		button.disabled = false;
+		stopPolling();
+		setRunButton('idle');
+		runningTabId = null;
+		isOwnRun = false;
 	}
 });
 

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -148,7 +148,7 @@ const readConfig = () => {
 // Runs in the page's main world. Walks the React fiber tree to find a
 // Channel-shaped object, binds it to window.streamChannel, and returns
 // metadata about how it was found. Honors a pre-existing window.streamChannel
-// (for users who set it manually).
+// or window.channel (for users who set one manually).
 const findChannelFn = () => {
 	const isChannelLike = (v) => {
 		if (!v || typeof v !== 'object') return false;
@@ -170,19 +170,29 @@ const findChannelFn = () => {
 		}
 	};
 
-	// Honor a manually-set window.streamChannel.
-	if (window.streamChannel) {
-		if (!isChannelLike(window.streamChannel)) {
+	// Honor a manually-set channel global. window.streamChannel takes
+	// precedence (legacy/canonical name); window.channel is a fallback
+	// alias so apps that already expose the channel under that name
+	// don't need extra plumbing.
+	const presetName = window.streamChannel
+		? 'streamChannel'
+		: window.channel
+			? 'channel'
+			: null;
+	if (presetName) {
+		const preset = window[presetName];
+		if (!isChannelLike(preset)) {
 			return { ok: false, reason: 'preset-not-a-channel' };
 		}
-		const v = validateUsable(window.streamChannel);
+		const v = validateUsable(preset);
 		if (!v.ok) return { ok: false, reason: v.reason };
 		return {
 			ok: true,
 			source: 'preset',
-			cid: window.streamChannel.cid,
-			type: window.streamChannel.type,
-			id: window.streamChannel.id,
+			presetName,
+			cid: preset.cid,
+			type: preset.type,
+			id: preset.id,
 		};
 	}
 
@@ -320,7 +330,8 @@ const findChannelFn = () => {
 };
 
 const REASON_TEXT = {
-	'preset-not-a-channel': 'window.streamChannel is set, but is not a Channel instance',
+	'preset-not-a-channel':
+		'window.streamChannel / window.channel is set but is not a Channel instance',
 	'no-handle-event': 'channel.getClient().handleEvent is unavailable',
 	'getclient-threw': 'channel.getClient() threw',
 	'no-react-root': 'No React root found on this page',
@@ -329,7 +340,7 @@ const REASON_TEXT = {
 
 const formatSuccess = (r) => {
 	if (r.source === 'preset') {
-		return `Ready · ${r.cid} · already bound`;
+		return `Ready · ${r.cid} · bound to window.${r.presetName}`;
 	}
 	const detail = `auto-bound · ${r.via} '${r.propName}' on <${r.componentName}>`;
 	const tail = r.candidates > 1 ? ` · best of ${r.candidates}` : '';

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -1,10 +1,13 @@
 const form = document.getElementById('burst-form');
 const button = document.getElementById('run');
-const status = document.getElementById('status');
+const statusWrap = document.getElementById('status-wrap');
+const statusText = document.getElementById('status');
+const recheckBtn = document.getElementById('recheck');
 
-const setStatus = (text, kind) => {
-	status.textContent = text;
-	status.className = `status status--${kind}`;
+const setStatus = (text, kind, { showRecheck = false } = {}) => {
+	statusText.textContent = text;
+	statusWrap.className = `status status--${kind}`;
+	recheckBtn.hidden = !showRecheck;
 };
 
 const readConfig = () => {
@@ -18,11 +21,72 @@ const readConfig = () => {
 	};
 };
 
+const detectFn = () => {
+	const ch = window.streamChannel;
+	if (!ch) return { found: false, reason: 'undefined' };
+	if (typeof ch.getClient !== 'function')
+		return { found: false, reason: 'not-a-channel' };
+	try {
+		const client = ch.getClient();
+		if (!client || typeof client.handleEvent !== 'function') {
+			return { found: false, reason: 'no-handle-event' };
+		}
+	} catch (e) {
+		return { found: false, reason: 'getclient-threw' };
+	}
+	return { found: true, cid: ch.cid, type: ch.type, id: ch.id };
+};
+
+const REASON_TEXT = {
+	undefined: 'window.streamChannel is not set on this page',
+	'not-a-channel': 'window.streamChannel is set, but is not a Channel instance',
+	'no-handle-event': 'channel.getClient().handleEvent is unavailable',
+	'getclient-threw': 'channel.getClient() threw',
+};
+
+const detectChannel = async () => {
+	button.disabled = true;
+	setStatus('Detecting…', 'running');
+	try {
+		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+		if (!tab?.id) throw new Error('No active tab.');
+
+		const [injection] = await chrome.scripting.executeScript({
+			target: { tabId: tab.id },
+			world: 'MAIN',
+			func: detectFn,
+		});
+
+		const result = injection?.result;
+		if (result?.found) {
+			setStatus(`Ready · ${result.cid}`, 'ok', { showRecheck: true });
+			button.disabled = false;
+		} else {
+			setStatus(
+				REASON_TEXT[result?.reason] || 'window.streamChannel not detected',
+				'error',
+				{ showRecheck: true },
+			);
+			button.disabled = true;
+		}
+	} catch (err) {
+		setStatus(`Detection failed: ${err?.message || String(err)}`, 'error', {
+			showRecheck: true,
+		});
+		button.disabled = true;
+	}
+};
+
+recheckBtn.addEventListener('click', () => {
+	detectChannel();
+});
+
 form.addEventListener('submit', async (e) => {
 	e.preventDefault();
 
 	const config = readConfig();
 	button.disabled = true;
+	recheckBtn.hidden = true;
 	setStatus('Running…', 'running');
 
 	try {
@@ -50,17 +114,22 @@ form.addEventListener('submit', async (e) => {
 
 		const payload = injection?.result;
 		if (!payload?.ok) {
-			setStatus(`Error: ${payload?.error || 'unknown failure'}`, 'error');
+			setStatus(`Error: ${payload?.error || 'unknown failure'}`, 'error', {
+				showRecheck: true,
+			});
 		} else {
 			const r = payload.result;
 			setStatus(
 				`Dispatched ${r.dispatched} in ${r.durationMs}ms — ${r.messages} messages, ${r.reactions} reactions`,
 				'ok',
+				{ showRecheck: true },
 			);
 		}
 	} catch (err) {
-		setStatus(`Error: ${err?.message || String(err)}`, 'error');
+		setStatus(`Error: ${err?.message || String(err)}`, 'error', { showRecheck: true });
 	} finally {
 		button.disabled = false;
 	}
 });
+
+detectChannel();

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -21,32 +21,200 @@ const readConfig = () => {
 	};
 };
 
-const detectFn = () => {
-	const ch = window.streamChannel;
-	if (!ch) return { found: false, reason: 'undefined' };
-	if (typeof ch.getClient !== 'function')
-		return { found: false, reason: 'not-a-channel' };
-	try {
-		const client = ch.getClient();
-		if (!client || typeof client.handleEvent !== 'function') {
-			return { found: false, reason: 'no-handle-event' };
+// Runs in the page's main world. Walks the React fiber tree to find a
+// Channel-shaped object, binds it to window.streamChannel, and returns
+// metadata about how it was found. Honors a pre-existing window.streamChannel
+// (for users who set it manually).
+const findChannelFn = () => {
+	const isChannelLike = (v) => {
+		if (!v || typeof v !== 'object') return false;
+		if (typeof v.getClient !== 'function') return false;
+		if (typeof v.cid !== 'string' || !v.cid.includes(':')) return false;
+		if (typeof v.id !== 'string' || typeof v.type !== 'string') return false;
+		return true;
+	};
+
+	const validateUsable = (ch) => {
+		try {
+			const client = ch.getClient();
+			if (!client || typeof client.handleEvent !== 'function') {
+				return { ok: false, reason: 'no-handle-event' };
+			}
+			return { ok: true };
+		} catch (e) {
+			return { ok: false, reason: 'getclient-threw' };
 		}
-	} catch (e) {
-		return { found: false, reason: 'getclient-threw' };
+	};
+
+	// Honor a manually-set window.streamChannel.
+	if (window.streamChannel) {
+		if (!isChannelLike(window.streamChannel)) {
+			return { ok: false, reason: 'preset-not-a-channel' };
+		}
+		const v = validateUsable(window.streamChannel);
+		if (!v.ok) return { ok: false, reason: v.reason };
+		return {
+			ok: true,
+			source: 'preset',
+			cid: window.streamChannel.cid,
+			type: window.streamChannel.type,
+			id: window.streamChannel.id,
+		};
 	}
-	return { found: true, cid: ch.cid, type: ch.type, id: ch.id };
+
+	// Locate React fiber roots — property name varies between React versions.
+	const valueToRootFiber = (v) => {
+		if (!v || typeof v !== 'object') return null;
+		if (v.current && v.current.tag !== undefined) return v.current; // FiberRoot
+		if (v._internalRoot && v._internalRoot.current) return v._internalRoot.current;
+		if (v.tag !== undefined && 'memoizedProps' in v) return v; // already a HostRoot fiber
+		return null;
+	};
+
+	const roots = [];
+	const visited = new WeakSet();
+	const scan = (el) => {
+		if (!el || visited.has(el)) return;
+		visited.add(el);
+		for (const k of Object.keys(el)) {
+			if (k.startsWith('__reactContainer$') || k === '_reactRootContainer') {
+				const r = valueToRootFiber(el[k]);
+				if (r) roots.push(r);
+			}
+		}
+		const children = el.children;
+		if (children) {
+			for (let i = 0; i < children.length; i++) scan(children[i]);
+		}
+	};
+	if (document.body) scan(document.body);
+
+	if (roots.length === 0) {
+		return { ok: false, reason: 'no-react-root' };
+	}
+
+	// Walk each tree, collect every fiber whose memoizedProps reference a
+	// Channel-like object — directly or via a Provider's `value` wrapper.
+	const candidates = [];
+	for (const root of roots) {
+		const stack = [root];
+		while (stack.length) {
+			const fiber = stack.pop();
+			if (!fiber) continue;
+
+			const props = fiber.memoizedProps;
+			if (props && typeof props === 'object') {
+				for (const k in props) {
+					const v = props[k];
+					if (isChannelLike(v)) {
+						candidates.push({ channel: v, fiber, propName: k, via: 'prop' });
+						continue;
+					}
+					// Stream Chat React puts the channel inside a Provider value
+					// object (e.g. ChannelStateContext.Provider value={{ channel, ... }}).
+					if (k === 'value' && v && typeof v === 'object') {
+						for (const k2 in v) {
+							if (isChannelLike(v[k2])) {
+								candidates.push({
+									channel: v[k2],
+									fiber,
+									propName: `value.${k2}`,
+									via: 'context',
+								});
+							}
+						}
+					}
+				}
+			}
+
+			if (fiber.sibling) stack.push(fiber.sibling);
+			if (fiber.child) stack.push(fiber.child);
+		}
+	}
+
+	if (candidates.length === 0) {
+		return { ok: false, reason: 'no-channel-in-tree' };
+	}
+
+	// Tiebreak: when multiple distinct Channels exist (e.g. a ChannelList of
+	// previews + the active <Channel>), pick the one whose owning fiber wraps
+	// the largest subtree. The active channel typically wraps the entire
+	// message list while previews are near-leaves.
+	const countDescendants = (fiber) => {
+		if (!fiber || !fiber.child) return 0;
+		let count = 0;
+		const s = [fiber.child];
+		while (s.length) {
+			const f = s.pop();
+			if (!f) continue;
+			count++;
+			if (f.sibling) s.push(f.sibling);
+			if (f.child) s.push(f.child);
+		}
+		return count;
+	};
+
+	// Dedupe by channel identity, keeping the highest descendant count seen.
+	const byChannel = new Map();
+	for (const c of candidates) {
+		const d = countDescendants(c.fiber);
+		const existing = byChannel.get(c.channel);
+		if (!existing || d > existing.descendants) {
+			byChannel.set(c.channel, { ...c, descendants: d });
+		}
+	}
+	const ranked = Array.from(byChannel.values()).sort(
+		(a, b) => b.descendants - a.descendants,
+	);
+
+	const best = ranked[0];
+	const usable = validateUsable(best.channel);
+	if (!usable.ok) return { ok: false, reason: usable.reason };
+
+	window.streamChannel = best.channel;
+
+	const fiberType = best.fiber && best.fiber.type;
+	const componentName =
+		(fiberType &&
+			typeof fiberType === 'function' &&
+			(fiberType.displayName || fiberType.name)) ||
+		(typeof fiberType === 'string' ? fiberType : null) ||
+		'Anonymous';
+
+	return {
+		ok: true,
+		source: 'fiber',
+		cid: best.channel.cid,
+		type: best.channel.type,
+		id: best.channel.id,
+		propName: best.propName,
+		via: best.via,
+		componentName,
+		descendants: best.descendants,
+		candidates: ranked.length,
+	};
 };
 
 const REASON_TEXT = {
-	undefined: 'window.streamChannel is not set on this page',
-	'not-a-channel': 'window.streamChannel is set, but is not a Channel instance',
+	'preset-not-a-channel': 'window.streamChannel is set, but is not a Channel instance',
 	'no-handle-event': 'channel.getClient().handleEvent is unavailable',
 	'getclient-threw': 'channel.getClient() threw',
+	'no-react-root': 'No React root found on this page',
+	'no-channel-in-tree': 'No Channel-shaped prop found in the React tree',
+};
+
+const formatSuccess = (r) => {
+	if (r.source === 'preset') {
+		return `Ready · ${r.cid} · already bound`;
+	}
+	const detail = `auto-bound · ${r.via} '${r.propName}' on <${r.componentName}>`;
+	const tail = r.candidates > 1 ? ` · best of ${r.candidates}` : '';
+	return `Ready · ${r.cid} · ${detail}${tail}`;
 };
 
 const detectChannel = async () => {
 	button.disabled = true;
-	setStatus('Detecting…', 'running');
+	setStatus('Scanning React tree…', 'running');
 	try {
 		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 		if (!tab?.id) throw new Error('No active tab.');
@@ -54,19 +222,17 @@ const detectChannel = async () => {
 		const [injection] = await chrome.scripting.executeScript({
 			target: { tabId: tab.id },
 			world: 'MAIN',
-			func: detectFn,
+			func: findChannelFn,
 		});
 
 		const result = injection?.result;
-		if (result?.found) {
-			setStatus(`Ready · ${result.cid}`, 'ok', { showRecheck: true });
+		if (result?.ok) {
+			setStatus(formatSuccess(result), 'ok', { showRecheck: true });
 			button.disabled = false;
 		} else {
-			setStatus(
-				REASON_TEXT[result?.reason] || 'window.streamChannel not detected',
-				'error',
-				{ showRecheck: true },
-			);
+			setStatus(REASON_TEXT[result?.reason] || 'channel detection failed', 'error', {
+				showRecheck: true,
+			});
 			button.disabled = true;
 		}
 	} catch (err) {

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -17,7 +17,6 @@ const readConfig = () => {
 		ratePerSec: Number(data.get('ratePerSec')),
 		reactionRatio: Number(data.get('reactionRatio')),
 		userPoolSize: Number(data.get('userPoolSize')),
-		doubleParse: data.get('doubleParse') === 'on',
 	};
 };
 

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -1,0 +1,66 @@
+const form = document.getElementById('burst-form');
+const button = document.getElementById('run');
+const status = document.getElementById('status');
+
+const setStatus = (text, kind) => {
+	status.textContent = text;
+	status.className = `status status--${kind}`;
+};
+
+const readConfig = () => {
+	const data = new FormData(form);
+	return {
+		count: Number(data.get('count')),
+		ratePerSec: Number(data.get('ratePerSec')),
+		reactionRatio: Number(data.get('reactionRatio')),
+		userPoolSize: Number(data.get('userPoolSize')),
+		reactToLastN: Number(data.get('reactToLastN')),
+	};
+};
+
+form.addEventListener('submit', async (e) => {
+	e.preventDefault();
+
+	const config = readConfig();
+	button.disabled = true;
+	setStatus('Running…', 'running');
+
+	try {
+		const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+		if (!tab?.id) throw new Error('No active tab.');
+
+		await chrome.scripting.executeScript({
+			target: { tabId: tab.id },
+			world: 'MAIN',
+			files: ['simulator.js'],
+		});
+
+		const [injection] = await chrome.scripting.executeScript({
+			target: { tabId: tab.id },
+			world: 'MAIN',
+			func: async (cfg) => {
+				try {
+					return { ok: true, result: await window.__streamSimulateBurst(cfg) };
+				} catch (err) {
+					return { ok: false, error: err && err.message ? err.message : String(err) };
+				}
+			},
+			args: [config],
+		});
+
+		const payload = injection?.result;
+		if (!payload?.ok) {
+			setStatus(`Error: ${payload?.error || 'unknown failure'}`, 'error');
+		} else {
+			const r = payload.result;
+			setStatus(
+				`Dispatched ${r.dispatched} in ${r.durationMs}ms — ${r.messages} messages, ${r.reactions} reactions`,
+				'ok',
+			);
+		}
+	} catch (err) {
+		setStatus(`Error: ${err?.message || String(err)}`, 'error');
+	} finally {
+		button.disabled = false;
+	}
+});

--- a/dev/burst-simulator-extension/popup.js
+++ b/dev/burst-simulator-extension/popup.js
@@ -17,7 +17,6 @@ const readConfig = () => {
 		ratePerSec: Number(data.get('ratePerSec')),
 		reactionRatio: Number(data.get('reactionRatio')),
 		userPoolSize: Number(data.get('userPoolSize')),
-		reactToLastN: Number(data.get('reactToLastN')),
 	};
 };
 

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -502,10 +502,9 @@
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
 		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.25)));
 		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
-		const reactToLastN = Math.max(1, Number(config.reactToLastN ?? 20) | 0);
 
 		const users = buildUserPool(userPoolSize);
-		const recentMessages = [];
+		const messagesPool = [];
 		const counters = { dispatched: 0, messages: 0, reactions: 0 };
 		const start = performance.now();
 
@@ -515,17 +514,16 @@
 		// Both parses happen per frame in production — pay both here too.
 		const dispatchOne = () => {
 			const user = pick(users);
-			const wantReaction = Math.random() < reactionRatio && recentMessages.length > 0;
+			const wantReaction = Math.random() < reactionRatio && messagesPool.length > 0;
 			let event;
 			if (wantReaction) {
-				const target = pick(recentMessages);
+				const target = pick(messagesPool);
 				event = buildReactionNewEvent(channel, target, user);
 				counters.reactions++;
 			} else {
 				const message = buildMessage(channel, user);
 				event = buildMessageNewEvent(channel, message);
-				recentMessages.push(message);
-				if (recentMessages.length > reactToLastN) recentMessages.shift();
+				messagesPool.push(message);
 				counters.messages++;
 			}
 			const jsonString = JSON.stringify(event);

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -487,10 +487,13 @@
 	};
 
 	async function simulateBurst(config = {}) {
-		const channel =
-			config.channel || (typeof window !== 'undefined' ? window.streamChannel : null);
+		const fromWindow =
+			typeof window !== 'undefined' ? (window.streamChannel ?? window.channel) : null;
+		const channel = config.channel || fromWindow;
 		if (!channel || typeof channel.getClient !== 'function') {
-			throw new Error('window.streamChannel is not set or is not a Channel instance');
+			throw new Error(
+				'No Channel instance available — set window.streamChannel or window.channel, or pass { channel } in config',
+			);
 		}
 		const client = channel.getClient();
 		if (!client || typeof client.handleEvent !== 'function') {

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -259,8 +259,22 @@
 		'example',
 	];
 
-	const EMOJIS = ['😀', '🔥', '👀', '🎉', '💀', '✨', '❤️', '🤔', '👍', '😅'];
-	const REACTION_TYPES = ['like', 'love', 'haha', 'wow', 'sad', 'angry'];
+	// Each entry pairs the rendered emoji with its base unicode codepoint
+	// (lowercase hex, no variation selector) — Stream Chat reactions are
+	// keyed as `emoji-<codepoint>` (e.g. 'emoji-1f4af' for 💯).
+	const EMOJIS = [
+		{ char: '😀', code: '1f600' },
+		{ char: '🔥', code: '1f525' },
+		{ char: '👀', code: '1f440' },
+		{ char: '🎉', code: '1f389' },
+		{ char: '💀', code: '1f480' },
+		{ char: '✨', code: '2728' },
+		{ char: '❤️', code: '2764' },
+		{ char: '🤔', code: '1f914' },
+		{ char: '👍', code: '1f44d' },
+		{ char: '😅', code: '1f605' },
+		{ char: '💯', code: '1f4af' },
+	];
 
 	const uuid = () => {
 		if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -305,7 +319,7 @@
 			const numEmojis = 1 + Math.floor(Math.random() * 3);
 			for (let i = 0; i < numEmojis; i++) {
 				const pos = Math.floor(Math.random() * (words.length + 1));
-				words.splice(pos, 0, pick(EMOJIS));
+				words.splice(pos, 0, pick(EMOJIS).char);
 			}
 		}
 
@@ -374,6 +388,7 @@
 			own_reactions: [],
 			reaction_counts: {},
 			reaction_scores: {},
+			reaction_groups: {},
 			reply_count: 0,
 			deleted_reply_count: 0,
 			cid: channel.cid,
@@ -407,22 +422,66 @@
 
 	const buildReactionNewEvent = (channel, message, user) => {
 		const now = new Date().toISOString();
+		const emoji = pick(EMOJIS);
+		const reactionType = `emoji-${emoji.code}`;
+
+		const reaction = {
+			type: reactionType,
+			message_id: message.id,
+			user_id: user.id,
+			user,
+			score: 1,
+			created_at: now,
+			updated_at: now,
+		};
+
+		// channel_state.addReaction (src/channel_state.ts) replaces the
+		// in-state message with a copy of event.message after running
+		// formatMessage on it. Whatever denormalized reaction state lives
+		// on event.message is therefore what the UI ends up rendering —
+		// the backend always pre-applies the reaction before delivering
+		// the event, so we mirror that here.
+		message.latest_reactions = [...(message.latest_reactions ?? []), reaction];
+		const counts = message.reaction_counts ?? {};
+		const scores = message.reaction_scores ?? {};
+		const groups = message.reaction_groups ?? {};
+		const existingGroup = groups[reactionType];
+		message.reaction_counts = {
+			...counts,
+			[reactionType]: (counts[reactionType] ?? 0) + 1,
+		};
+		message.reaction_scores = {
+			...scores,
+			[reactionType]: (scores[reactionType] ?? 0) + 1,
+		};
+		message.reaction_groups = {
+			...groups,
+			[reactionType]: existingGroup
+				? {
+						count: existingGroup.count + 1,
+						sum_scores: existingGroup.sum_scores + 1,
+						first_reaction_at: existingGroup.first_reaction_at,
+						last_reaction_at: now,
+						latest_reactions_by: existingGroup.latest_reactions_by ?? [],
+					}
+				: {
+						count: 1,
+						sum_scores: 1,
+						first_reaction_at: now,
+						last_reaction_at: now,
+						latest_reactions_by: [],
+					},
+		};
+
 		return {
 			type: 'reaction.new',
 			created_at: now,
 			cid: channel.cid,
 			channel_type: channel.type,
 			channel_id: channel.id,
+			message_id: message.id,
 			message,
-			reaction: {
-				type: pick(REACTION_TYPES),
-				message_id: message.id,
-				user_id: user.id,
-				user,
-				score: 1,
-				created_at: now,
-				updated_at: now,
-			},
+			reaction,
 			user,
 		};
 	};

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -502,6 +502,7 @@
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
 		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.25)));
 		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
+		const doubleParse = config.doubleParse !== false; // default true
 
 		const users = buildUserPool(userPoolSize);
 		const messagesPool = [];
@@ -511,7 +512,9 @@
 		// Mirror the real receive path: src/connection.ts onmessage parses
 		// the frame locally (health-check / error shortcut), then
 		// src/client.ts handleEvent parses it again before dispatching.
-		// Both parses happen per frame in production — pay both here too.
+		// `doubleParse: true` (default) pays both parses per frame, matching
+		// today's prod code; set false to pay only handleEvent's parse, to
+		// A/B against an in-flight fix that removes the duplicate.
 		const dispatchOne = () => {
 			const user = pick(users);
 			const wantReaction = Math.random() < reactionRatio && messagesPool.length > 0;
@@ -527,8 +530,10 @@
 				counters.messages++;
 			}
 			const jsonString = JSON.stringify(event);
-			JSON.parse(jsonString); // mirrors onmessage's local parse
-			client.handleEvent({ data: jsonString }); // parses again, then dispatches
+			if (doubleParse) {
+				JSON.parse(jsonString); // mirrors onmessage's local parse
+			}
+			client.handleEvent({ data: jsonString }); // parses, then dispatches
 			counters.dispatched++;
 		};
 
@@ -564,6 +569,7 @@
 			durationMs: Math.round(performance.now() - start),
 			messages: counters.messages,
 			reactions: counters.reactions,
+			doubleParse,
 		};
 		console.log('[burst-simulator] result', result);
 		return result;

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -1,0 +1,508 @@
+(() => {
+	const NAMES = [
+		'Alex',
+		'Sam',
+		'Jordan',
+		'Taylor',
+		'Casey',
+		'Morgan',
+		'Riley',
+		'Quinn',
+		'Avery',
+		'Hayden',
+		'Reese',
+		'Skyler',
+		'Drew',
+		'Parker',
+		'Sage',
+		'River',
+		'Phoenix',
+		'Rowan',
+		'Cameron',
+		'Logan',
+	];
+
+	const WORDS = [
+		'the',
+		'of',
+		'and',
+		'a',
+		'to',
+		'in',
+		'is',
+		'you',
+		'that',
+		'it',
+		'he',
+		'was',
+		'for',
+		'on',
+		'are',
+		'as',
+		'with',
+		'his',
+		'they',
+		'at',
+		'be',
+		'this',
+		'have',
+		'from',
+		'or',
+		'one',
+		'had',
+		'by',
+		'word',
+		'but',
+		'not',
+		'what',
+		'all',
+		'were',
+		'we',
+		'when',
+		'your',
+		'can',
+		'said',
+		'there',
+		'use',
+		'an',
+		'each',
+		'which',
+		'she',
+		'do',
+		'how',
+		'their',
+		'if',
+		'will',
+		'up',
+		'other',
+		'about',
+		'out',
+		'many',
+		'then',
+		'them',
+		'these',
+		'so',
+		'some',
+		'her',
+		'would',
+		'make',
+		'like',
+		'him',
+		'into',
+		'time',
+		'has',
+		'look',
+		'two',
+		'more',
+		'write',
+		'go',
+		'see',
+		'number',
+		'no',
+		'way',
+		'could',
+		'people',
+		'my',
+		'than',
+		'first',
+		'water',
+		'been',
+		'call',
+		'who',
+		'its',
+		'now',
+		'find',
+		'long',
+		'down',
+		'day',
+		'did',
+		'get',
+		'come',
+		'made',
+		'may',
+		'part',
+		'over',
+		'new',
+		'sound',
+		'take',
+		'only',
+		'little',
+		'work',
+		'know',
+		'place',
+		'year',
+		'live',
+		'me',
+		'back',
+		'give',
+		'most',
+		'very',
+		'after',
+		'thing',
+		'our',
+		'just',
+		'name',
+		'good',
+		'man',
+		'think',
+		'say',
+		'great',
+		'where',
+		'help',
+		'through',
+		'much',
+		'before',
+		'line',
+		'right',
+		'too',
+		'means',
+		'old',
+		'any',
+		'same',
+		'tell',
+		'boy',
+		'follow',
+		'came',
+		'want',
+		'show',
+		'also',
+		'around',
+		'form',
+		'three',
+		'small',
+		'set',
+		'put',
+		'end',
+		'does',
+		'another',
+		'well',
+		'large',
+		'must',
+		'big',
+		'even',
+		'such',
+		'because',
+		'turn',
+		'here',
+		'why',
+		'ask',
+		'went',
+		'men',
+		'read',
+		'need',
+		'land',
+		'different',
+		'home',
+		'us',
+		'move',
+		'try',
+		'kind',
+		'hand',
+		'picture',
+		'again',
+		'change',
+		'off',
+		'play',
+		'spell',
+		'air',
+		'away',
+		'animal',
+		'house',
+		'point',
+		'page',
+		'letter',
+		'mother',
+		'answer',
+		'found',
+		'study',
+		'still',
+		'learn',
+		'should',
+		'world',
+		'high',
+		'every',
+		'near',
+		'add',
+		'food',
+		'between',
+		'own',
+		'below',
+		'country',
+		'plant',
+		'last',
+		'school',
+		'father',
+		'keep',
+		'tree',
+		'never',
+		'start',
+		'city',
+		'earth',
+		'eye',
+		'light',
+		'thought',
+		'head',
+		'under',
+		'story',
+		'saw',
+		'left',
+		'few',
+		'while',
+		'along',
+		'might',
+		'close',
+		'something',
+		'seem',
+		'next',
+		'hard',
+		'open',
+		'example',
+	];
+
+	const EMOJIS = ['😀', '🔥', '👀', '🎉', '💀', '✨', '❤️', '🤔', '👍', '😅'];
+	const REACTION_TYPES = ['like', 'love', 'haha', 'wow', 'sad', 'angry'];
+
+	const uuid = () => {
+		if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+			return crypto.randomUUID();
+		}
+		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+			const r = (Math.random() * 16) | 0;
+			const v = c === 'x' ? r : (r & 0x3) | 0x8;
+			return v.toString(16);
+		});
+	};
+
+	const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+	const randomHex = (len) => {
+		let s = '';
+		for (let i = 0; i < len; i++) s += Math.floor(Math.random() * 16).toString(16);
+		return s;
+	};
+
+	const sampleWordCount = () => {
+		const r = Math.random();
+		if (r < 0.85) return 3 + Math.floor(Math.random() * 13);
+		if (r < 0.97) return 16 + Math.floor(Math.random() * 15);
+		return 31 + Math.floor(Math.random() * 20);
+	};
+
+	const escapeHtml = (s) =>
+		s
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+
+	const generateText = () => {
+		const n = sampleWordCount();
+		const words = [];
+		for (let i = 0; i < n; i++) words.push(pick(WORDS));
+
+		if (Math.random() < 0.1) {
+			const numEmojis = 1 + Math.floor(Math.random() * 3);
+			for (let i = 0; i < numEmojis; i++) {
+				const pos = Math.floor(Math.random() * (words.length + 1));
+				words.splice(pos, 0, pick(EMOJIS));
+			}
+		}
+
+		if (Math.random() < 0.05) {
+			words.push(`https://example.com/${randomHex(12)}`);
+		}
+
+		let text = words.join(' ');
+
+		if (Math.random() < 0.05) {
+			const breaks = 1 + Math.floor(Math.random() * 2);
+			const splitWords = text.split(' ');
+			for (let i = 0; i < breaks; i++) {
+				const pos = 1 + Math.floor(Math.random() * Math.max(1, splitWords.length - 1));
+				splitWords[pos] = '\n' + splitWords[pos];
+			}
+			text = splitWords.join(' ');
+		}
+
+		return text;
+	};
+
+	const buildHtml = (text) => `<p>${escapeHtml(text).replace(/\n/g, '<br/>')}</p>\n`;
+
+	const buildUserPool = (size) => {
+		const now = new Date().toISOString();
+		const users = [];
+		for (let i = 0; i < size; i++) {
+			const id = `sim_user_${i}`;
+			const baseName = NAMES[i % NAMES.length];
+			const name =
+				i < NAMES.length ? baseName : `${baseName}_${Math.floor(i / NAMES.length)}`;
+			users.push({
+				id,
+				name,
+				image: `https://i.pravatar.cc/150?u=${encodeURIComponent(id)}`,
+				language: '',
+				role: 'user',
+				teams: [],
+				created_at: now,
+				updated_at: now,
+				last_active: now,
+				banned: false,
+				online: true,
+				blocked_user_ids: [],
+				shadow_banned: false,
+				invisible: false,
+				custom: {},
+			});
+		}
+		return users;
+	};
+
+	const buildMessage = (channel, user) => {
+		const now = new Date().toISOString();
+		const text = generateText();
+		return {
+			id: uuid(),
+			text,
+			html: buildHtml(text),
+			type: 'regular',
+			user,
+			member: { channel_role: 'channel_member', notifications_muted: false },
+			attachments: [],
+			latest_reactions: [],
+			own_reactions: [],
+			reaction_counts: {},
+			reaction_scores: {},
+			reply_count: 0,
+			deleted_reply_count: 0,
+			cid: channel.cid,
+			created_at: now,
+			updated_at: now,
+			shadowed: false,
+			mentioned_users: [],
+			mentioned_channel: false,
+			mentioned_here: false,
+			silent: false,
+			pinned: false,
+			pinned_at: null,
+			pinned_by: null,
+			pin_expires: null,
+			restricted_visibility: [],
+			notify_all_members: false,
+		};
+	};
+
+	const buildMessageNewEvent = (channel, message) => ({
+		type: 'message.new',
+		created_at: new Date().toISOString(),
+		cid: channel.cid,
+		channel_type: channel.type,
+		channel_id: channel.id,
+		message_id: message.id,
+		message,
+		user: message.user,
+		watcher_count: 1,
+	});
+
+	const buildReactionNewEvent = (channel, message, user) => {
+		const now = new Date().toISOString();
+		return {
+			type: 'reaction.new',
+			created_at: now,
+			cid: channel.cid,
+			channel_type: channel.type,
+			channel_id: channel.id,
+			message,
+			reaction: {
+				type: pick(REACTION_TYPES),
+				message_id: message.id,
+				user_id: user.id,
+				user,
+				score: 1,
+				created_at: now,
+				updated_at: now,
+			},
+			user,
+		};
+	};
+
+	async function simulateBurst(config = {}) {
+		const channel =
+			config.channel || (typeof window !== 'undefined' ? window.streamChannel : null);
+		if (!channel || typeof channel.getClient !== 'function') {
+			throw new Error('window.streamChannel is not set or is not a Channel instance');
+		}
+		const client = channel.getClient();
+		if (!client || typeof client.dispatchEvent !== 'function') {
+			throw new Error('channel.getClient().dispatchEvent is unavailable');
+		}
+
+		const count = Math.max(0, Number(config.count ?? 200) | 0);
+		const ratePerSecRaw = config.ratePerSec ?? 50;
+		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
+		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.3)));
+		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
+		const reactToLastN = Math.max(1, Number(config.reactToLastN ?? 20) | 0);
+
+		const users = buildUserPool(userPoolSize);
+		const recentMessages = [];
+		const counters = { dispatched: 0, messages: 0, reactions: 0 };
+		const start = performance.now();
+
+		const dispatchOne = () => {
+			const user = pick(users);
+			const wantReaction = Math.random() < reactionRatio && recentMessages.length > 0;
+			if (wantReaction) {
+				const target = pick(recentMessages);
+				client.dispatchEvent(buildReactionNewEvent(channel, target, user));
+				counters.reactions++;
+			} else {
+				const message = buildMessage(channel, user);
+				client.dispatchEvent(buildMessageNewEvent(channel, message));
+				recentMessages.push(message);
+				if (recentMessages.length > reactToLastN) recentMessages.shift();
+				counters.messages++;
+			}
+			counters.dispatched++;
+		};
+
+		const burstAll =
+			ratePerSec === 0 || ratePerSec === Infinity || !Number.isFinite(ratePerSec);
+
+		if (burstAll) {
+			await new Promise((resolve) =>
+				requestAnimationFrame(() => {
+					for (let i = 0; i < count; i++) dispatchOne();
+					resolve();
+				}),
+			);
+		} else {
+			const interval = 1000 / ratePerSec;
+			await new Promise((resolve) => {
+				let i = 0;
+				const tick = () => {
+					if (i >= count) {
+						resolve();
+						return;
+					}
+					dispatchOne();
+					i++;
+					setTimeout(tick, interval);
+				};
+				tick();
+			});
+		}
+
+		const result = {
+			dispatched: counters.dispatched,
+			durationMs: Math.round(performance.now() - start),
+			messages: counters.messages,
+			reactions: counters.reactions,
+		};
+		console.log('[burst-simulator] result', result);
+		return result;
+	}
+
+	window.__streamSimulateBurst = simulateBurst;
+})();

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -434,8 +434,8 @@
 			throw new Error('window.streamChannel is not set or is not a Channel instance');
 		}
 		const client = channel.getClient();
-		if (!client || typeof client.dispatchEvent !== 'function') {
-			throw new Error('channel.getClient().dispatchEvent is unavailable');
+		if (!client || typeof client.handleEvent !== 'function') {
+			throw new Error('channel.getClient().handleEvent is unavailable');
 		}
 
 		const count = Math.max(0, Number(config.count ?? 200) | 0);
@@ -450,20 +450,28 @@
 		const counters = { dispatched: 0, messages: 0, reactions: 0 };
 		const start = performance.now();
 
+		// Mirror the real receive path: src/connection.ts onmessage parses
+		// the frame locally (health-check / error shortcut), then
+		// src/client.ts handleEvent parses it again before dispatching.
+		// Both parses happen per frame in production — pay both here too.
 		const dispatchOne = () => {
 			const user = pick(users);
 			const wantReaction = Math.random() < reactionRatio && recentMessages.length > 0;
+			let event;
 			if (wantReaction) {
 				const target = pick(recentMessages);
-				client.dispatchEvent(buildReactionNewEvent(channel, target, user));
+				event = buildReactionNewEvent(channel, target, user);
 				counters.reactions++;
 			} else {
 				const message = buildMessage(channel, user);
-				client.dispatchEvent(buildMessageNewEvent(channel, message));
+				event = buildMessageNewEvent(channel, message);
 				recentMessages.push(message);
 				if (recentMessages.length > reactToLastN) recentMessages.shift();
 				counters.messages++;
 			}
+			const jsonString = JSON.stringify(event);
+			JSON.parse(jsonString); // mirrors onmessage's local parse
+			client.handleEvent({ data: jsonString }); // parses again, then dispatches
 			counters.dispatched++;
 		};
 

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -497,7 +497,7 @@
 			throw new Error('channel.getClient().handleEvent is unavailable');
 		}
 
-		const count = Math.max(0, Number(config.count ?? 200) | 0);
+		const count = Math.max(0, Number(config.count ?? 1000) | 0);
 		const ratePerSecRaw = config.ratePerSec ?? 50;
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
 		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.5)));

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -498,9 +498,9 @@
 		}
 
 		const count = Math.max(0, Number(config.count ?? 1000) | 0);
-		const ratePerSecRaw = config.ratePerSec ?? 50;
+		const ratePerSecRaw = config.ratePerSec ?? 75;
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
-		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.5)));
+		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.25)));
 		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
 		const reactToLastN = Math.max(1, Number(config.reactToLastN ?? 20) | 0);
 

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -500,7 +500,7 @@
 		const count = Math.max(0, Number(config.count ?? 200) | 0);
 		const ratePerSecRaw = config.ratePerSec ?? 50;
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
-		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.3)));
+		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.5)));
 		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
 		const reactToLastN = Math.max(1, Number(config.reactToLastN ?? 20) | 0);
 

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -507,6 +507,28 @@
 		const messagesPool = [];
 		const counters = { dispatched: 0, messages: 0, reactions: 0 };
 		const start = performance.now();
+		const startWall = Date.now();
+
+		// Reset run-scoped flags on the function object so popup.js can poll
+		// state and signal an abort across the executeScript world boundary.
+		// `phase` is kept around after the run ends so a popup reopened later
+		// can tell whether a run is still in flight or just finished.
+		simulateBurst.abort = false;
+		simulateBurst.state = {
+			phase: 'running',
+			dispatched: 0,
+			messages: 0,
+			reactions: 0,
+			target: count,
+			startMs: start,
+			startWallMs: startWall,
+		};
+
+		const updateState = () => {
+			simulateBurst.state.dispatched = counters.dispatched;
+			simulateBurst.state.messages = counters.messages;
+			simulateBurst.state.reactions = counters.reactions;
+		};
 
 		// Mirror the real receive path: src/connection.ts onmessage parses
 		// the frame locally (health-check / error shortcut), then
@@ -530,15 +552,22 @@
 			JSON.parse(jsonString); // mirrors onmessage's local parse
 			client.handleEvent({ data: jsonString }); // parses again, then dispatches
 			counters.dispatched++;
+			updateState();
 		};
 
 		const burstAll =
 			ratePerSec === 0 || ratePerSec === Infinity || !Number.isFinite(ratePerSec);
 
 		if (burstAll) {
+			// In burst-all mode the entire batch runs inside one rAF callback,
+			// so the abort flag effectively can't toggle mid-run — we still
+			// check it at the boundary in case it was set before the rAF fired.
 			await new Promise((resolve) =>
 				requestAnimationFrame(() => {
-					for (let i = 0; i < count; i++) dispatchOne();
+					for (let i = 0; i < count; i++) {
+						if (simulateBurst.abort) break;
+						dispatchOne();
+					}
 					resolve();
 				}),
 			);
@@ -547,7 +576,7 @@
 			await new Promise((resolve) => {
 				let i = 0;
 				const tick = () => {
-					if (i >= count) {
+					if (i >= count || simulateBurst.abort) {
 						resolve();
 						return;
 					}
@@ -559,12 +588,29 @@
 			});
 		}
 
+		const aborted = simulateBurst.abort === true;
 		const result = {
 			dispatched: counters.dispatched,
 			durationMs: Math.round(performance.now() - start),
 			messages: counters.messages,
 			reactions: counters.reactions,
+			aborted,
 		};
+
+		// Mark the run as finished and stash the result. We keep `state`
+		// around (with phase='done') and `lastResult` populated so a popup
+		// reopened later can recover the summary instead of starting from a
+		// blank slate.
+		simulateBurst.state = {
+			...simulateBurst.state,
+			phase: 'done',
+			dispatched: counters.dispatched,
+			messages: counters.messages,
+			reactions: counters.reactions,
+		};
+		simulateBurst.lastResult = result;
+		simulateBurst.abort = false;
+
 		console.log('[burst-simulator] result', result);
 		return result;
 	}

--- a/dev/burst-simulator-extension/simulator.js
+++ b/dev/burst-simulator-extension/simulator.js
@@ -502,7 +502,6 @@
 		const ratePerSec = ratePerSecRaw === Infinity ? Infinity : Number(ratePerSecRaw);
 		const reactionRatio = Math.max(0, Math.min(1, Number(config.reactionRatio ?? 0.25)));
 		const userPoolSize = Math.max(1, Number(config.userPoolSize ?? 10) | 0);
-		const doubleParse = config.doubleParse !== false; // default true
 
 		const users = buildUserPool(userPoolSize);
 		const messagesPool = [];
@@ -512,9 +511,7 @@
 		// Mirror the real receive path: src/connection.ts onmessage parses
 		// the frame locally (health-check / error shortcut), then
 		// src/client.ts handleEvent parses it again before dispatching.
-		// `doubleParse: true` (default) pays both parses per frame, matching
-		// today's prod code; set false to pay only handleEvent's parse, to
-		// A/B against an in-flight fix that removes the duplicate.
+		// Both parses happen per frame in production — pay both here too.
 		const dispatchOne = () => {
 			const user = pick(users);
 			const wantReaction = Math.random() < reactionRatio && messagesPool.length > 0;
@@ -530,10 +527,8 @@
 				counters.messages++;
 			}
 			const jsonString = JSON.stringify(event);
-			if (doubleParse) {
-				JSON.parse(jsonString); // mirrors onmessage's local parse
-			}
-			client.handleEvent({ data: jsonString }); // parses, then dispatches
+			JSON.parse(jsonString); // mirrors onmessage's local parse
+			client.handleEvent({ data: jsonString }); // parses again, then dispatches
 			counters.dispatched++;
 		};
 
@@ -569,7 +564,6 @@
 			durationMs: Math.round(performance.now() - start),
 			messages: counters.messages,
 			reactions: counters.reactions,
-			doubleParse,
 		};
 		console.log('[burst-simulator] result', result);
 		return result;


### PR DESCRIPTION
## Summary

Adds a Manifest V3 Chrome extension under `dev/burst-simulator-extension/` for stress / perf testing the chat UI by dispatching synthetic `message.new` and `reaction.new` events at a Stream Chat `Channel` instance. Dev-only — not part of the npm package, no build step, load-unpacked.

- **Auto-binds the channel.** Walks the React fiber tree on popup open and finds any prop whose value duck-types as a Channel (`getClient` + `cid` + `id` + `type` — including the conventional `channel` prop on `<Channel channel={ch}>`). When multiple exist (e.g. `ChannelList` previews + active `<Channel>`), picks the one whose owning fiber wraps the largest subtree. Apps that already expose the channel as `window.streamChannel` (canonical) or `window.channel` (alias) get honored as-is, skipping the walk.
- **Realistic event payloads.** Generated messages mirror real `live_stream_chat` events (full `member`, `restricted_visibility`, `reaction_groups`, etc.); reactions use the `emoji-<unicode codepoint>` keying the modern UI expects (e.g. `emoji-1f4af`) and pre-apply `latest_reactions` / `reaction_counts` / `reaction_scores` / `reaction_groups` to `event.message` so `channel_state.addReaction` lands them correctly.
- **Real receive path.** Each event is stringified, `JSON.parse`'d locally (mirroring `connection.onmessage`'s health-check shortcut), then handed to `client.handleEvent` which parses again before dispatching. **Note:** this matches the pre-#1729 prod path; with that PR landed on master, prod now does a single parse — flipping the simulator to single-parse is an obvious follow-up.
- **Live run UX.** While a paced run is in flight, the popup polls in-page state every 300 ms and shows `Running · 230 / 1000 · 76 eps · 3s`. The Run button morphs into a red Stop (■); clicking it flips an in-page abort flag, the simulator resolves on its next tick with `aborted: true`, and the popup reports `Stopped at N in Tms`.
- **State survives popup close.** The simulator preserves `state` (with `phase: 'done'`) and `lastResult` after the run ends. Re-opening the popup mid-run re-attaches as a watcher; re-opening after a run finished surfaces the summary instead of going back to the channel-detection text.
- **Design-system aesthetic.** Geist + Geist Mono, light theme, slate neutrals, blue-600 primary, semantic info / success / warning / error surfaces.

## Test plan

- [ ] `chrome://extensions` → Developer mode on → **Load unpacked** → select `dev/burst-simulator-extension/`; pin the extension
- [ ] Open a page where a Stream Chat `Channel` is rendered; click the extension; status reads `Ready · <cid> · auto-bound · context 'value.channel' on <…>` (or similar)
- [ ] Manual override: in DevTools console, run `window.channel = window.streamChannel; delete window.streamChannel;` then re-open the popup → status reads `Ready · <cid> · bound to window.channel`
- [ ] Run defaults (`count: 1000, rate per second: 75, reactions ratio: 0.25, user pool size: 10`) and confirm:
  - Live status line ticks `Running · X / 1000 · ~75 eps · Ts` during the run
  - ~750 messages + ~250 reactions land in the channel; reactions render with their emoji glyphs (not bare strings)
  - Same target receiving multiple reactions aggregates counts correctly
- [ ] Click **Stop** mid-run; status reports `Stopped at N in Tms`
- [ ] Close popup mid-run; re-open; popup re-attaches and continues live progress, then shows the final summary
- [ ] Burst ceiling: `count: 1000, rate per second: 0` while recording in DevTools Performance — confirm one long-task flame, channel state contains 1000 messages, no thrown errors
- [ ] Error paths: open the popup on a tab with no React app; status reads `No React root found on this page`; click ↻ to re-detect