### PR TITLE
fix(types): restore config_overrides on PartialUpdateChannel

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2939,9 +2939,13 @@ export type Mute = {
   user: UserResponse;
 };
 
+export type PartialUpdateChannelFields = Partial<ChannelResponse> & {
+  config_overrides?: Partial<ChannelConfigFields>;
+};
+
 export type PartialUpdateChannel = {
-  set?: Partial<ChannelResponse>;
-  unset?: Array<keyof ChannelResponse>;
+  set?: PartialUpdateChannelFields;
+  unset?: Array<keyof PartialUpdateChannelFields>;
 };
 
 export type PartialUpdateMember = {


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Closes [#1695](https://github.com/GetStream/stream-chat-js/issues/1695).

**What.** Re-adds typed support for `config_overrides` on `channel.updatePartial({ set: { config_overrides: { ... } } })` and `channel.updatePartial({ unset: ['config_overrides'] })`. Matches the example shown in the public docs ([Channel-level Settings → Examples](https://getstream.io/chat/docs/javascript/channel-level_settings/#examples)), which TypeScript started rejecting in v9.x.

**Why.** This is a TypeScript regression only — the wire protocol has always supported it. The canonical [`GetStream/protocol/openapi/chat-openapi.yaml`](https://github.com/GetStream/protocol/blob/main/openapi/chat-openapi.yaml) defines the partial-update body (`ChannelDataUpdate`) with `config_overrides: ChannelConfig`. The v8 → v9 type cleanup narrowed `PartialUpdateChannel.set` to `Partial<ChannelResponse>`, and `ChannelResponse` exposes only the *resolved* `config` returned by the server — not the *override delta* the client sends — so the field silently fell off the public type surface.

**How.** Pure type widening in `src/types.ts`, no runtime change:

```ts
export type PartialUpdateChannelFields = Partial<ChannelResponse> & {
  config_overrides?: Partial<ChannelConfigFields>;
};

export type PartialUpdateChannel = {
  set?: PartialUpdateChannelFields;
  unset?: Array<keyof PartialUpdateChannelFields>;
};
```

Notes:
- `Partial<ChannelConfigFields>` (already exported from this file) gives users autocomplete on the real settable fields — `typing_events`, `reactions`, `replies`, `quotes`, `uploads`, `url_enrichment`, `max_message_length`, `blocklist_behavior`, `push_level`, `commands`, etc. — instead of an opaque `Record<string, unknown>` escape hatch.
- Pulling the settable shape into the named `PartialUpdateChannelFields` lets `keyof` flow `'config_overrides'` automatically into `unset`, so users can also clear the overrides via `unset: ['config_overrides']`.
- Strict widening — every previously valid call still type-checks. No consumer breakage.

## Verification

- [x] `yarn types` (project `tsc --noEmit`) — clean
- [x] Documented call from issue compiles: `channel.updatePartial({ set: { config_overrides: { typing_events: false, max_message_length: 200 } } })`
- [x] `unset: ['config_overrides']` compiles
- [x] Negative case correctly rejected — an unknown field inside `config_overrides` errors with `TS2353 — does not exist in type 'Partial<ChannelConfigFields>'` (so the type isn't accidentally permissive)
- [x] `yarn test-unit` — 2800 passed, 1 skipped, 0 failed

## Changelog

- Restore `config_overrides` typing on `channel.updatePartial`, fixing the documented `set: { config_overrides: { ... } }` and `unset: ['config_overrides']` calls.