### PR TITLE
fix: omit canceling uploads on initState in attachmentManager

### DIFF
--- a/src/messageComposer/MessageComposerEffectHandlers.ts
+++ b/src/messageComposer/MessageComposerEffectHandlers.ts
@@ -34,7 +34,9 @@ const applyCommandActivationEffect: MessageComposerEffectHandler<
     selection: { start: 0, end: 0 },
     text: '',
   });
+  const attachmentsToCancel = composer.attachmentManager.attachments;
   composer.attachmentManager.initState();
+  composer.attachmentManager.cancelAttachmentUploads(attachmentsToCancel);
   composer.linkPreviewsManager.initState();
   composer.locationComposer.initState();
   composer.pollComposer.initState();

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -210,7 +210,7 @@ export class AttachmentManager {
     );
   }
 
-  private cancelAttachmentUploads = (attachments: LocalAttachment[]) => {
+  cancelAttachmentUploads = (attachments: LocalAttachment[] = this.attachments) => {
     for (const { localMetadata } of attachments) {
       this.client.uploadManager.deleteUploadRecord(localMetadata.id);
     }
@@ -232,7 +232,6 @@ export class AttachmentManager {
   };
 
   initState = ({ message }: { message?: DraftMessage | LocalMessage } = {}) => {
-    this.cancelAttachmentUploads(this.attachments);
     this.state.next(initState({ message }));
   };
 

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -472,7 +472,7 @@ describe('AttachmentManager', () => {
       });
     });
 
-    it('should not apply upload manager progress to composer attachments after re-initializing state', async () => {
+    it('should not cancel uploads or apply upload manager progress to composer attachments after re-initializing state', async () => {
       const { messageComposer, mockClient } = setup();
       const { attachmentManager } = messageComposer;
 
@@ -489,9 +489,15 @@ describe('AttachmentManager', () => {
       const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
       expect(uploadId).toBeDefined();
 
+      const deleteUploadRecordSpy = vi.spyOn(
+        mockClient.uploadManager,
+        'deleteUploadRecord',
+      );
+
       attachmentManager.initState();
       expect(attachmentManager.attachments).toEqual([]);
-      expect(uploadId! in mockClient.uploadManager.uploads).toBe(false);
+      expect(deleteUploadRecordSpy).not.toHaveBeenCalled();
+      expect(uploadId! in mockClient.uploadManager.uploads).toBe(true);
 
       mockClient.uploadManager.state.partialNext((current) => ({
         ...current,

--- a/test/unit/MessageComposer/textComposer.test.ts
+++ b/test/unit/MessageComposer/textComposer.test.ts
@@ -380,7 +380,7 @@ describe('TextComposer', () => {
       expectChildComposerStateToBeCleared(messageComposer);
     });
 
-    it('resets attachments and link previews through initState when setting a command directly', () => {
+    it('resets attachments and link previews while canceling uploads when setting a command directly', () => {
       const {
         messageComposer,
         messageComposer: { textComposer },
@@ -393,6 +393,10 @@ describe('TextComposer', () => {
       const attachmentClearSpy = vi.spyOn(
         messageComposer.attachmentManager,
         'clearAttachments',
+      );
+      const attachmentCancelUploadsSpy = vi.spyOn(
+        messageComposer.attachmentManager,
+        'cancelAttachmentUploads',
       );
       const linkPreviewsInitStateSpy = vi.spyOn(
         messageComposer.linkPreviewsManager,
@@ -423,6 +427,11 @@ describe('TextComposer', () => {
 
       expect(attachmentInitStateSpy).toHaveBeenCalledTimes(1);
       expect(attachmentClearSpy).not.toHaveBeenCalled();
+      expect(attachmentCancelUploadsSpy).toHaveBeenCalledWith([
+        expect.objectContaining({
+          localMetadata: expect.objectContaining({ id: 'attachment-1' }),
+        }),
+      ]);
       expect(deleteUploadRecordSpy).toHaveBeenCalledWith('attachment-1');
       expect(linkPreviewsInitStateSpy).toHaveBeenCalledTimes(1);
       expect(linkPreviewsCancelSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR addresses an unfortunate oversight I made when implementing the advanced command flow. On RN, we allow for attachments to optionally be sent before they've been uploaded (asynchronously) and finish the upload within the message list. Canceling uploads can often mess the state up in a way where the attachment is indeed uploading in the background, however the record has been evicted from our `UploadManager` and so no progress is registered.

This change makes sure that we preserve the cancellation behaviour for the advanced command flow while not corrupting `initState` directly.

## Changelog

-
