### PR TITLE
fix: add command utils to public exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,13 @@ export { type CooldownTimerState } from './CooldownTimer';
 export * from './events';
 export * from './insights';
 export * from './messageComposer';
+export {
+  escapeCommandRegExp,
+  getCompleteCommandInString,
+  getRawCommandName,
+  notifyCommandDisabled,
+  stripCommandFromText,
+} from './messageComposer/middleware/textComposer/commandUtils';
 export * from './messageDelivery';
 export * from './middleware';
 export * from './moderation';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,6 @@ export { type CooldownTimerState } from './CooldownTimer';
 export * from './events';
 export * from './insights';
 export * from './messageComposer';
-export {
-  escapeCommandRegExp,
-  getCompleteCommandInString,
-  getRawCommandName,
-  notifyCommandDisabled,
-  stripCommandFromText,
-} from './messageComposer/middleware/textComposer/commandUtils';
 export * from './messageDelivery';
 export * from './middleware';
 export * from './moderation';

--- a/src/messageComposer/middleware/textComposer/index.ts
+++ b/src/messageComposer/middleware/textComposer/index.ts
@@ -2,6 +2,7 @@ export * from './activeCommandGuard';
 export * from './commands';
 export * from './commandEffects';
 export * from './commandStringExtraction';
+export * from './commandUtils';
 export * from './mentions';
 export * from './validation';
 export * from './TextComposerMiddlewareExecutor';


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR exports our internal `commandUtils` so that they can be used within the SDKs (or elsewhere in integrations) where necessary.

## Changelog

-
