### PR TITLE
fix: prevent deleteUserMessages crash when hard-deleting a self-quoting message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,7 +479,7 @@ export const deleteUserMessages = ({
           : (toDeletedMessage({ message, hardDelete, deletedAt }) as LocalMessage);
     }
 
-    if (message.quoted_message?.user?.id === user.id) {
+    if (messages[i].quoted_message && message.quoted_message?.user?.id === user.id) {
       messages[i].quoted_message =
         message.quoted_message.type === 'deleted'
           ? message.quoted_message

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -644,6 +644,46 @@ describe('Channel _handleChannelEvent', function () {
 		});
 	});
 
+	// Regression coverage for GetStream/stream-chat-js#1736 at the per-channel event entry point
+	// (channel.ts → _handleChannelEvent → state.deleteUserMessages). Mirrors the global-event
+	// regression suite in client.test.js but exercises the channel-scoped user.messages.deleted
+	// event (one carrying a cid).
+	describe('user.messages.deleted — quoted_message regression (#1736)', () => {
+		const bannedUser = { id: 'banned-user' };
+
+		it('does not throw on channel-scoped hard-delete when channel contains a same-user self-quote', () => {
+			const m1 = generateMsg({
+				created_at: '2020-01-01T00:00:01.000Z',
+				user: bannedUser,
+			});
+			const m2 = generateMsg({
+				created_at: '2020-01-01T00:00:02.000Z',
+				user: bannedUser,
+				quoted_message: m1,
+				quoted_message_id: m1.id,
+			});
+			channel.state.addMessagesSorted([m1, m2]);
+
+			const event = {
+				type: 'user.messages.deleted',
+				cid: channel.cid,
+				channel_type: channel.type,
+				channel_id: channel.id,
+				user: bannedUser,
+				hard_delete: true,
+				created_at: '2025-02-01T14:01:30.000Z',
+			};
+
+			expect(() => channel._handleChannelEvent(event)).not.to.throw();
+
+			const messages = channel.state.messageSets[0].messages;
+			expect(messages.find((m) => m.id === m1.id).type).to.equal('deleted');
+			const quoter = messages.find((m) => m.id === m2.id);
+			expect(quoter.type).to.equal('deleted');
+			expect(quoter.quoted_message).to.equal(undefined);
+		});
+	});
+
 	describe('notification.mark_unread', () => {
 		let initialCountUnread;
 		let initialReadState;

--- a/test/unit/channel_state.test.js
+++ b/test/unit/channel_state.test.js
@@ -1547,6 +1547,152 @@ describe('deleteUserMessages', () => {
 	});
 });
 
+// Regression tests for GetStream/stream-chat-js#1736:
+// deleteUserMessages crashed with "Cannot read property 'cid' of undefined" when
+// hard-deleting a message that quotes another message from the same user. The first
+// branch replaced messages[i] with the stripped hard-delete placeholder (no
+// quoted_message field); the second branch then read messages[i].quoted_message as
+// undefined and passed it into toDeletedMessage, which dereferences message.cid.
+describe('deleteUserMessages — quoted_message regression (#1736)', () => {
+	let state;
+
+	beforeEach(() => {
+		const client = new StreamChat();
+		client.userID = 'userId';
+		const channel = new Channel(client, 'type', 'id', {});
+		client._addChannelConfig({ cid: channel.cid, config: {} });
+		state = new ChannelState(channel);
+	});
+
+	it('does not throw when hard-deleting a message that quotes another message from the same user', () => {
+		const user1 = generateUser();
+		const m1 = generateMsg({ user: user1 });
+		const m2 = generateMsg({
+			user: user1,
+			quoted_message: m1,
+			quoted_message_id: m1.id,
+		});
+
+		state.addMessagesSorted([m1, m2]);
+
+		expect(() => state.deleteUserMessages(user1, true)).not.to.throw();
+
+		expect(state.messages).to.have.length(2);
+		expect(state.messages[0].type).to.be.equal('deleted');
+		expect(state.messages[1].type).to.be.equal('deleted');
+		// Hard-deleted parent retains the stripped shape (no quoted_message field).
+		expect(state.messages[1].text).to.be.equal(undefined);
+		expect(state.messages[1].quoted_message).to.be.equal(undefined);
+	});
+
+	it('does not throw when hard-deleting a thread reply that quotes another same-user reply', () => {
+		const user1 = generateUser();
+		const parent = generateMsg({ user: user1, id: 'parent-id' });
+		const reply1 = generateMsg({
+			user: user1,
+			parent_id: parent.id,
+			date: '2020-01-01T00:00:01.000Z',
+		});
+		const reply2 = generateMsg({
+			user: user1,
+			parent_id: parent.id,
+			date: '2020-01-01T00:00:02.000Z',
+			quoted_message: reply1,
+			quoted_message_id: reply1.id,
+		});
+
+		state.addMessagesSorted([parent, reply1, reply2]);
+		expect(state.threads[parent.id]).to.have.length(2);
+
+		expect(() => state.deleteUserMessages(user1, true)).not.to.throw();
+
+		const thread = state.threads[parent.id];
+		expect(thread).to.have.length(2);
+		expect(thread[0].type).to.be.equal('deleted');
+		expect(thread[1].type).to.be.equal('deleted');
+		expect(thread[1].quoted_message).to.be.equal(undefined);
+	});
+
+	it('does not throw when hard-deleting a pinned message that quotes another same-user pinned message', () => {
+		const user1 = generateUser();
+		const m1 = generateMsg({
+			user: user1,
+			pinned: true,
+			pinned_at: new Date('2022-01-01T00:00:00.001Z'),
+		});
+		const m2 = generateMsg({
+			user: user1,
+			pinned: true,
+			pinned_at: new Date('2022-01-01T00:00:00.002Z'),
+			quoted_message: m1,
+			quoted_message_id: m1.id,
+		});
+
+		state.addMessagesSorted([m1, m2]);
+		state.addPinnedMessages([m1, m2]);
+		expect(state.pinnedMessages).to.have.length(2);
+
+		expect(() => state.deleteUserMessages(user1, true)).not.to.throw();
+
+		expect(state.pinnedMessages).to.have.length(2);
+		state.pinnedMessages.forEach((message) => {
+			expect(message.type).to.be.equal('deleted');
+		});
+		const pinnedQuoter = state.pinnedMessages.find((m) => m.id === m2.id);
+		expect(pinnedQuoter.quoted_message).to.be.equal(undefined);
+	});
+
+	it('soft-deletes a message that quotes another same-user message and marks the quoted_message as deleted', () => {
+		const user1 = generateUser();
+		const m1 = generateMsg({ user: user1 });
+		const m2 = generateMsg({
+			user: user1,
+			quoted_message: m1,
+			quoted_message_id: m1.id,
+		});
+
+		state.addMessagesSorted([m1, m2]);
+
+		expect(() => state.deleteUserMessages(user1, false)).not.to.throw();
+
+		expect(state.messages[0].type).to.be.equal('deleted');
+		expect(state.messages[1].type).to.be.equal('deleted');
+		// Soft-delete preserves message content via the spread path.
+		expect(state.messages[1].text).to.be.equal(m2.text);
+		// quoted_message reference is replaced with a deleted placeholder.
+		expect(state.messages[1].quoted_message).to.not.be.equal(undefined);
+		expect(state.messages[1].quoted_message.id).to.be.equal(m1.id);
+		expect(state.messages[1].quoted_message.type).to.be.equal('deleted');
+	});
+
+	it('continues processing later messages after encountering a self-quote on hard-delete', () => {
+		const user1 = generateUser();
+		const user2 = generateUser();
+		const mA = generateMsg({ user: user2, date: '2020-01-01T00:00:01.000Z' });
+		const m1 = generateMsg({ user: user1, date: '2020-01-01T00:00:02.000Z' });
+		const m2 = generateMsg({
+			user: user1,
+			date: '2020-01-01T00:00:03.000Z',
+			quoted_message: m1,
+			quoted_message_id: m1.id,
+		});
+		const mB = generateMsg({ user: user1, date: '2020-01-01T00:00:04.000Z' });
+		const mC = generateMsg({ user: user2, date: '2020-01-01T00:00:05.000Z' });
+
+		state.addMessagesSorted([mA, m1, m2, mB, mC]);
+
+		expect(() => state.deleteUserMessages(user1, true)).not.to.throw();
+
+		const byId = (id) => state.messages.find((m) => m.id === id);
+		expect(byId(mA.id).type).to.be.equal('regular');
+		expect(byId(m1.id).type).to.be.equal('deleted');
+		expect(byId(m2.id).type).to.be.equal('deleted');
+		// mB sits after the self-quote pair — previously the throw aborted the loop here.
+		expect(byId(mB.id).type).to.be.equal('deleted');
+		expect(byId(mC.id).type).to.be.equal('regular');
+	});
+});
+
 describe('updateUserMessages', () => {
 	let state;
 

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1596,6 +1596,92 @@ describe('user.messages.deleted', () => {
 	});
 });
 
+// Regression coverage for GetStream/stream-chat-js#1736.
+// Hard-deleting a user whose cached messages include a self-quote (a message that
+// quotes another message from the same user) used to throw inside
+// _deleteUserMessages, aborting the entire dispatchEvent chain — downstream
+// listeners and offline-DB writes silently dropped. These tests exercise both
+// event entry points that funnel into _deleteUserMessageReference.
+describe('user.messages.deleted — quoted_message regression (#1736)', () => {
+	let client;
+	const bannedUser = { id: 'banned-user' };
+
+	beforeEach(async () => {
+		client = await getClientWithUser();
+	});
+
+	const setupChannelWithSelfQuote = (type, id) => {
+		const m1 = generateMsg({
+			created_at: '2020-01-01T00:00:01.000Z',
+			user: bannedUser,
+		});
+		const m2 = generateMsg({
+			created_at: '2020-01-01T00:00:02.000Z',
+			user: bannedUser,
+			quoted_message: m1,
+			quoted_message_id: m1.id,
+		});
+		const channel = client.channel(type, id);
+		channel.state.addMessagesSorted([m1, m2]);
+		return { channel, m1, m2 };
+	};
+
+	it('does not throw on user.messages.deleted hard-delete when cached channel contains a same-user self-quote', () => {
+		const { channel, m1, m2 } = setupChannelWithSelfQuote('messaging', 'self-quote-1');
+
+		const event = {
+			type: 'user.messages.deleted',
+			user: bannedUser,
+			hard_delete: true,
+			created_at: '2025-02-01T14:01:30.000Z',
+		};
+
+		expect(() => client._handleClientEvent(event)).not.toThrow();
+
+		const messages = channel.state.messageSets[0].messages;
+		expect(messages).toHaveLength(2);
+		expect(messages.find((m) => m.id === m1.id).type).toBe('deleted');
+		const quoter = messages.find((m) => m.id === m2.id);
+		expect(quoter.type).toBe('deleted');
+		// Hard-delete strips the parent — no quoted_message field remains on it.
+		expect(quoter.quoted_message).toBeUndefined();
+	});
+
+	it('still fires downstream client listeners after the self-quote encounter on hard-delete', () => {
+		setupChannelWithSelfQuote('messaging', 'self-quote-listener');
+
+		const listener = vi.fn();
+		client.on('user.messages.deleted', listener);
+
+		const event = {
+			type: 'user.messages.deleted',
+			user: bannedUser,
+			hard_delete: true,
+			created_at: '2025-02-01T14:01:30.000Z',
+		};
+
+		expect(() => client.dispatchEvent(event)).not.toThrow();
+		expect(listener).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not throw on user.deleted hard-delete when cached channel contains a same-user self-quote', () => {
+		const { channel, m1, m2 } = setupChannelWithSelfQuote('messaging', 'self-quote-2');
+
+		const event = {
+			type: 'user.deleted',
+			user: { ...bannedUser, deleted_at: '2025-02-01T14:01:30.000Z' },
+			hard_delete: true,
+			created_at: '2025-02-01T14:01:30.000Z',
+		};
+
+		expect(() => client._handleClientEvent(event)).not.toThrow();
+
+		const messages = channel.state.messageSets[0].messages;
+		expect(messages.find((m) => m.id === m1.id).type).toBe('deleted');
+		expect(messages.find((m) => m.id === m2.id).type).toBe('deleted');
+	});
+});
+
 describe('dispatchEvent: offlineDb.executeQuerySafely', () => {
 	let client;
 	let executeQuerySafelySpy;


### PR DESCRIPTION
## Description of the changes, What, Why and How?

Closes #1736.

When the backend hard-deletes a user whose cached messages include one that quotes another message from the same user, `deleteUserMessages` was throwing `Cannot read property 'cid' of undefined` mid-loop, which aborted the rest of the `dispatchEvent` chain (silently dropping downstream listeners).

The loop has two branches:

- **A** (`message.user.id === user.id`) replaces `messages[i]` with the stripped hard-delete shape, which intentionally has no `quoted_message` field.
- **B** (`message.quoted_message?.user?.id === user.id`) then reads `messages[i].quoted_message` and hands it to `toDeletedMessage`.

When both fire on the same message (i.e. a self-quote on hard-delete), B was reading an `undefined` quoted_message left behind by A. Fix is a one-line guard so B only runs when the field is still there. Soft-delete and cross-user-quote paths are unaffected, they preserve `messages[i].quoted_message` and continue to work as before.