### PR TITLE
chore: add predefined filter support for offline mode

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -231,13 +231,14 @@ export class ChannelManager extends WithSubscriptions {
     });
     const {
       channels,
-      pagination: { filters, sort },
+      pagination: { filters, options, sort },
     } = this.state.getLatestValue();
     this.client.offlineDb?.executeQuerySafely(
       (db) =>
         db.upsertCidsForQuery({
           cids: channels.map((channel) => channel.cid),
           filters,
+          options,
           sort,
         }),
       { method: 'upsertCidsForQuery' },
@@ -304,6 +305,7 @@ export class ChannelManager extends WithSubscriptions {
           db.upsertCidsForQuery({
             cids: channels.map((channel) => channel.cid),
             filters: pagination.filters,
+            options,
             sort: pagination.sort,
           }),
         { method: 'upsertCidsForQuery' },
@@ -381,6 +383,7 @@ export class ChannelManager extends WithSubscriptions {
           const channelsFromDB = await this.client.offlineDb.getChannelsForQuery({
             userId: this.client.user.id,
             filters,
+            options,
             sort,
           });
 

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -3,6 +3,7 @@ import type {
   ChannelAPIResponse,
   ChannelFilters,
   ChannelMemberResponse,
+  ChannelOptions,
   ChannelResponse,
   ChannelSort,
   DraftResponse,
@@ -41,6 +42,8 @@ export type DBUpsertCidsForQueryType = {
   cids: string[];
   /** Optional filters for the channels. */
   filters?: ChannelFilters;
+  /** Optional full query options for the channels. */
+  options?: ChannelOptions;
   /** Whether to immediately execute the operation. */
   execute?: boolean;
   /** Optional sorting applied to the channels. */
@@ -177,6 +180,8 @@ export type DBGetChannelsForQueryType = {
   userId: string;
   /** Optional filters for channels. */
   filters?: ChannelFilters;
+  /** Optional full query options for channels. */
+  options?: ChannelOptions;
   /** Optional sorting for the channels. */
   sort?: ChannelSort;
 };

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -272,6 +272,48 @@ describe('ChannelManager', () => {
         expect(newChannels.map((c) => c.id)).to.deep.equal(prevChannels.map((c) => c.id));
         expect(newChannels).to.equal(prevChannels);
       });
+
+      it('passes full predefined-filter query options when upserting CIDs', async () => {
+        client.setOfflineDBApi(new MockOfflineDB({ client }));
+        await client.offlineDb!.init(client.userID as string);
+        client.offlineDb!.state.partialNext({
+          initialized: true,
+          userId: client.userID,
+        });
+        (
+          client.offlineDb!.upsertCidsForQuery as unknown as MockInstance
+        ).mockResolvedValue([]);
+
+        const { channels, pagination } = channelManager.state.getLatestValue();
+        const options = {
+          predefined_filter: 'user_messaging',
+          filter_values: { user_id: 'user123' },
+          sort_values: { sort_field: 'last_message_at' },
+          limit: 10,
+          offset: 20,
+          presence: true,
+          state: true,
+          watch: true,
+        };
+
+        channelManager.state.partialNext({
+          pagination: {
+            ...pagination,
+            filters: { team: 'blue' },
+            options,
+            sort: { last_message_at: -1 },
+          },
+        });
+
+        channelManager.setChannels(channels);
+
+        expect(client.offlineDb!.upsertCidsForQuery).toHaveBeenCalledExactlyOnceWith({
+          cids: channels.map((channel) => channel.cid),
+          filters: { team: 'blue' },
+          options,
+          sort: { last_message_at: -1 },
+        });
+      });
     });
   });
 
@@ -533,6 +575,7 @@ describe('ChannelManager', () => {
           expect(client.offlineDb!.getChannelsForQuery).toHaveBeenCalledExactlyOnceWith({
             userId: client.userID,
             filters: { filterA: true },
+            options: {},
             sort: { asc: 1 },
           });
 
@@ -546,6 +589,24 @@ describe('ChannelManager', () => {
           expect(stateChangeSpy.calledOnceWithExactly(channels));
           expect(executeChannelsQuerySpy.called).to.be.false;
           expect(scheduleSyncStatusCallbackSpy.called).to.be.true;
+        });
+
+        it('passes full predefined-filter query options when hydrating channels from DB', async () => {
+          const options = {
+            predefined_filter: 'user_messaging',
+            filter_values: { user_id: 'dan' },
+            sort_values: { sort_field: 'last_message_at' },
+            limit: 20,
+          };
+
+          await channelManager.queryChannels({}, [], options);
+
+          expect(client.offlineDb!.getChannelsForQuery).toHaveBeenCalledExactlyOnceWith({
+            userId: client.userID,
+            filters: {},
+            options,
+            sort: [],
+          });
         });
 
         it('does NOT hydrate from DB if already initialized', async () => {
@@ -751,6 +812,52 @@ describe('ChannelManager', () => {
             },
           });
           expect(channels.length).to.equal(10);
+        });
+
+        it('passes full predefined-filter query options when upserting CIDs after query', async () => {
+          client.setOfflineDBApi(new MockOfflineDB({ client }));
+          await client.offlineDb!.init(client.userID as string);
+          client.offlineDb!.state.partialNext({
+            initialized: true,
+            userId: client.userID,
+          });
+          (
+            client.offlineDb!.upsertCidsForQuery as unknown as MockInstance
+          ).mockResolvedValue([]);
+
+          const queryOptions = {
+            predefined_filter: 'user_messaging',
+            filter_values: { user_id: 'user123' },
+            sort_values: { sort_field: 'last_message_at' },
+            limit: 10,
+            offset: 0,
+            presence: true,
+            state: true,
+            watch: true,
+          };
+          const { pagination } = channelManager.state.getLatestValue();
+          channelManager.state.partialNext({
+            pagination: {
+              ...pagination,
+              filters: { filterA: true },
+              options: queryOptions,
+              sort: { asc: 1 },
+            },
+          });
+
+          await channelManager['executeChannelsQuery']({
+            filters: { filterA: true },
+            sort: { asc: 1 },
+            options: queryOptions,
+            stateOptions: {},
+          });
+
+          expect(client.offlineDb!.upsertCidsForQuery).toHaveBeenCalledExactlyOnceWith({
+            cids: mockChannelPages[0].map((channel) => channel.cid),
+            filters: { filterA: true },
+            options: queryOptions,
+            sort: { asc: 1 },
+          });
         });
 
         it('should properly update hasNext and offset after executeChannelsQuery if the first returned page is less than the limit', async () => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR adds support for `predefined_filters` to our `OfflineDB` handling and extends the types accordingly. 

## Changelog

-
