### PR TITLE
feat(MessageComposer): control command sendability

### DIFF
--- a/src/messageComposer/configuration/commands.configuration.ts
+++ b/src/messageComposer/configuration/commands.configuration.ts
@@ -6,7 +6,7 @@ import type {
 import type { DeepPartial } from '../../types.utility';
 import { stripMentionTokens } from '../middleware';
 
-const MENTION_ONLY_COMMANDS = new Set(['mute', 'unmute', 'unban']);
+export const MENTION_ONLY_COMMANDS = new Set(['mute', 'unmute', 'unban']);
 export const defaultCommandSendabilityValidator: CommandSendValidator = ({
   command,
   commandArgsText,

--- a/src/messageComposer/configuration/commands.configuration.ts
+++ b/src/messageComposer/configuration/commands.configuration.ts
@@ -31,17 +31,17 @@ export const defaultCommandSendabilityValidator: CommandSendValidator = ({
   return { command, ready: true };
 };
 export const DEFAULT_COMMANDS_CONFIG: CommandsConfig = {
-  sendValidators: [defaultCommandSendabilityValidator],
+  sendValidator: defaultCommandSendabilityValidator,
 };
 export const applyCommandValidatorOverride = (
   targetConfig: MessageComposerConfig,
   sourceConfig?: DeepPartial<MessageComposerConfig>,
 ) => {
-  const overrideValidators = sourceConfig?.commands?.sendValidators as
-    | CommandSendValidator[]
+  const overrideValidator = sourceConfig?.commands?.sendValidator as
+    | CommandSendValidator
     | undefined;
 
-  if (typeof overrideValidators === 'undefined') {
+  if (typeof overrideValidator === 'undefined') {
     return targetConfig;
   }
 
@@ -49,7 +49,7 @@ export const applyCommandValidatorOverride = (
     ...targetConfig,
     commands: {
       ...targetConfig.commands,
-      sendValidators: overrideValidators,
+      sendValidator: overrideValidator,
     },
   };
 };

--- a/src/messageComposer/configuration/commands.configuration.ts
+++ b/src/messageComposer/configuration/commands.configuration.ts
@@ -15,17 +15,17 @@ export const defaultCommandSendabilityValidator: CommandSendValidator = ({
   if (command.name !== 'ban' && !MENTION_ONLY_COMMANDS.has(command.name ?? '')) return;
 
   if (mentionedUsersInText.length === 0) {
-    return { command, ready: false, reason: 'missing_mention' };
+    return { command, ready: false, reason: 'missing-mention' };
   }
 
   if (command.name !== 'ban') {
     return { command, ready: true };
   }
 
-  const reason = stripMentionTokens(commandArgsText, mentionedUsersInText);
+  const banReason = stripMentionTokens(commandArgsText, mentionedUsersInText);
 
-  if (!reason.length) {
-    return { command, ready: false, reason: 'missing_reason' };
+  if (!banReason.length) {
+    return { command, ready: false, reason: 'missing-ban-reason' };
   }
 
   return { command, ready: true };

--- a/src/messageComposer/configuration/commands.configuration.ts
+++ b/src/messageComposer/configuration/commands.configuration.ts
@@ -1,0 +1,55 @@
+import type {
+  CommandsConfig,
+  CommandSendValidator,
+  MessageComposerConfig,
+} from './types';
+import type { DeepPartial } from '../../types.utility';
+import { stripMentionTokens } from '../middleware';
+
+const MENTION_ONLY_COMMANDS = new Set(['mute', 'unmute', 'unban']);
+export const defaultCommandSendabilityValidator: CommandSendValidator = ({
+  command,
+  commandArgsText,
+  mentionedUsersInText,
+}) => {
+  if (command.name !== 'ban' && !MENTION_ONLY_COMMANDS.has(command.name ?? '')) return;
+
+  if (mentionedUsersInText.length === 0) {
+    return { command, ready: false, reason: 'missing_mention' };
+  }
+
+  if (command.name !== 'ban') {
+    return { command, ready: true };
+  }
+
+  const reason = stripMentionTokens(commandArgsText, mentionedUsersInText);
+
+  if (!reason.length) {
+    return { command, ready: false, reason: 'missing_reason' };
+  }
+
+  return { command, ready: true };
+};
+export const DEFAULT_COMMANDS_CONFIG: CommandsConfig = {
+  sendValidators: [defaultCommandSendabilityValidator],
+};
+export const applyCommandValidatorOverride = (
+  targetConfig: MessageComposerConfig,
+  sourceConfig?: DeepPartial<MessageComposerConfig>,
+) => {
+  const overrideValidators = sourceConfig?.commands?.sendValidators as
+    | CommandSendValidator[]
+    | undefined;
+
+  if (typeof overrideValidators === 'undefined') {
+    return targetConfig;
+  }
+
+  return {
+    ...targetConfig,
+    commands: {
+      ...targetConfig.commands,
+      sendValidators: overrideValidators,
+    },
+  };
+};

--- a/src/messageComposer/configuration/configuration.ts
+++ b/src/messageComposer/configuration/configuration.ts
@@ -2,15 +2,13 @@ import { find } from 'linkifyjs';
 import { API_MAX_FILES_ALLOWED_PER_MESSAGE } from '../../constants';
 import type {
   AttachmentManagerConfig,
-  CommandSendValidator,
-  CommandsConfig,
   LinkPreviewsManagerConfig,
   LocationComposerConfig,
   MessageComposerConfig,
+  TextComposerConfig,
 } from './types';
-import type { TextComposerConfig } from './types';
-import type { UserResponse } from '../../types';
 import { generateUUIDv4 } from '../../utils';
+import { DEFAULT_COMMANDS_CONFIG } from './commands.configuration';
 
 export const DEFAULT_LINK_PREVIEW_MANAGER_CONFIG: LinkPreviewsManagerConfig = {
   debounceURLEnrichmentMs: 1500,
@@ -40,41 +38,6 @@ export const DEFAULT_ATTACHMENT_MANAGER_CONFIG: AttachmentManagerConfig = {
 export const DEFAULT_TEXT_COMPOSER_CONFIG: TextComposerConfig = {
   enabled: true,
   publishTypingEvents: true,
-};
-
-const stripMentionTokens = (text: string, mentionedUsersInText: UserResponse[]) =>
-  mentionedUsersInText.reduce((value, user) => {
-    let next = value.replace(`@${user.id}`, '');
-
-    if (user.name) {
-      next = next.replace(`@${user.name}`, '');
-    }
-
-    return next.trim();
-  }, text.trim());
-
-export const defaultCommandSendabilityValidator: CommandSendValidator = ({
-  command,
-  commandArgsText,
-  mentionedUsersInText,
-}) => {
-  if (command.name !== 'ban') return;
-
-  if (mentionedUsersInText.length === 0) {
-    return { ready: false, reason: 'missing_mention' };
-  }
-
-  const reason = stripMentionTokens(commandArgsText, mentionedUsersInText);
-
-  if (!reason.length) {
-    return { ready: false, reason: 'missing_reason' };
-  }
-
-  return { ready: true };
-};
-
-export const DEFAULT_COMMANDS_CONFIG: CommandsConfig = {
-  validators: [defaultCommandSendabilityValidator],
 };
 
 export const DEFAULT_LOCATION_COMPOSER_CONFIG: LocationComposerConfig = {

--- a/src/messageComposer/configuration/configuration.ts
+++ b/src/messageComposer/configuration/configuration.ts
@@ -2,12 +2,14 @@ import { find } from 'linkifyjs';
 import { API_MAX_FILES_ALLOWED_PER_MESSAGE } from '../../constants';
 import type {
   AttachmentManagerConfig,
+  CommandSendValidator,
   CommandsConfig,
   LinkPreviewsManagerConfig,
   LocationComposerConfig,
   MessageComposerConfig,
 } from './types';
 import type { TextComposerConfig } from './types';
+import type { UserResponse } from '../../types';
 import { generateUUIDv4 } from '../../utils';
 
 export const DEFAULT_LINK_PREVIEW_MANAGER_CONFIG: LinkPreviewsManagerConfig = {
@@ -40,8 +42,39 @@ export const DEFAULT_TEXT_COMPOSER_CONFIG: TextComposerConfig = {
   publishTypingEvents: true,
 };
 
+const stripMentionTokens = (text: string, mentionedUsersInText: UserResponse[]) =>
+  mentionedUsersInText.reduce((value, user) => {
+    let next = value.replace(`@${user.id}`, '');
+
+    if (user.name) {
+      next = next.replace(`@${user.name}`, '');
+    }
+
+    return next.trim();
+  }, text.trim());
+
+export const defaultCommandSendabilityValidator: CommandSendValidator = ({
+  command,
+  commandArgsText,
+  mentionedUsersInText,
+}) => {
+  if (command.name !== 'ban') return;
+
+  if (mentionedUsersInText.length === 0) {
+    return { ready: false, reason: 'missing_mention' };
+  }
+
+  const reason = stripMentionTokens(commandArgsText, mentionedUsersInText);
+
+  if (!reason.length) {
+    return { ready: false, reason: 'missing_reason' };
+  }
+
+  return { ready: true };
+};
+
 export const DEFAULT_COMMANDS_CONFIG: CommandsConfig = {
-  validators: [],
+  validators: [defaultCommandSendabilityValidator],
 };
 
 export const DEFAULT_LOCATION_COMPOSER_CONFIG: LocationComposerConfig = {

--- a/src/messageComposer/configuration/configuration.ts
+++ b/src/messageComposer/configuration/configuration.ts
@@ -2,6 +2,7 @@ import { find } from 'linkifyjs';
 import { API_MAX_FILES_ALLOWED_PER_MESSAGE } from '../../constants';
 import type {
   AttachmentManagerConfig,
+  CommandsConfig,
   LinkPreviewsManagerConfig,
   LocationComposerConfig,
   MessageComposerConfig,
@@ -39,6 +40,10 @@ export const DEFAULT_TEXT_COMPOSER_CONFIG: TextComposerConfig = {
   publishTypingEvents: true,
 };
 
+export const DEFAULT_COMMANDS_CONFIG: CommandsConfig = {
+  validators: [],
+};
+
 export const DEFAULT_LOCATION_COMPOSER_CONFIG: LocationComposerConfig = {
   enabled: true,
   getDeviceId: () => generateUUIDv4(),
@@ -46,6 +51,7 @@ export const DEFAULT_LOCATION_COMPOSER_CONFIG: LocationComposerConfig = {
 
 export const DEFAULT_COMPOSER_CONFIG: MessageComposerConfig = {
   attachments: DEFAULT_ATTACHMENT_MANAGER_CONFIG,
+  commands: DEFAULT_COMMANDS_CONFIG,
   drafts: { enabled: false },
   linkPreviews: DEFAULT_LINK_PREVIEW_MANAGER_CONFIG,
   location: DEFAULT_LOCATION_COMPOSER_CONFIG,

--- a/src/messageComposer/configuration/index.ts
+++ b/src/messageComposer/configuration/index.ts
@@ -1,2 +1,6 @@
 export * from './configuration';
 export * from './types';
+export { applyCommandValidatorOverride } from './commands.configuration';
+export { DEFAULT_COMMANDS_CONFIG } from './commands.configuration';
+export { defaultCommandSendabilityValidator } from './commands.configuration';
+export { MENTION_ONLY_COMMANDS } from './commands.configuration';

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -1,7 +1,8 @@
 import type { LinkPreview } from '../linkPreviewsManager';
 import type { FileUploadFilter } from '../attachmentManager';
 import type { MessageComposer } from '../messageComposer';
-import type { CommandResponse, FileLike, FileReference, UserResponse } from '../../types';
+import type { FileLike, FileReference } from '../types';
+import type { CommandResponse, UserResponse } from '../../types';
 
 export type MinimumUploadRequestResult = { file: string; thumb_url?: string } & Partial<
   Record<string, unknown>

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -1,6 +1,7 @@
 import type { LinkPreview } from '../linkPreviewsManager';
 import type { FileUploadFilter } from '../attachmentManager';
-import type { FileLike, FileReference } from '../types';
+import type { MessageComposer } from '../messageComposer';
+import type { CommandResponse, FileLike, FileReference, UserResponse } from '../../types';
 
 export type MinimumUploadRequestResult = { file: string; thumb_url?: string } & Partial<
   Record<string, unknown>
@@ -36,6 +37,28 @@ export type TextComposerConfig = {
   maxLengthOnEdit?: number;
   /** Prevents sending a message longer than this length */
   maxLengthOnSend?: number;
+};
+
+export type CommandSendability = {
+  ready: boolean;
+  reason?: string & {};
+  metadata?: Record<string, unknown>;
+};
+
+export type CommandSendValidationContext = {
+  command: CommandResponse;
+  composer: MessageComposer;
+  commandArgsText: string;
+  mentionedUsersInText: UserResponse[];
+  rawText: string;
+};
+
+export type CommandSendValidator = (
+  context: CommandSendValidationContext,
+) => CommandSendability | undefined;
+
+export type CommandsConfig = {
+  validators: CommandSendValidator[];
 };
 
 export type AttachmentManagerConfig = {
@@ -86,6 +109,8 @@ export type LocationComposerConfig = {
 export type MessageComposerConfig = {
   /** If true, enables creating drafts on the server */
   drafts: DraftsConfiguration;
+  /** Configuration for command sendability validation */
+  commands: CommandsConfig;
   /** Configuration for the attachment manager */
   attachments: AttachmentManagerConfig;
   /** Configuration for the link previews manager */

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -41,6 +41,7 @@ export type TextComposerConfig = {
 };
 
 export type CommandSendability = {
+  command: CommandResponse;
   ready: boolean;
   reason?: string & {};
   metadata?: Record<string, unknown>;
@@ -59,7 +60,7 @@ export type CommandSendValidator = (
 ) => CommandSendability | undefined;
 
 export type CommandsConfig = {
-  validators: CommandSendValidator[];
+  sendValidators: CommandSendValidator[];
 };
 
 export type AttachmentManagerConfig = {

--- a/src/messageComposer/configuration/types.ts
+++ b/src/messageComposer/configuration/types.ts
@@ -60,7 +60,7 @@ export type CommandSendValidator = (
 ) => CommandSendability | undefined;
 
 export type CommandsConfig = {
-  sendValidators: CommandSendValidator[];
+  sendValidator: CommandSendValidator;
 };
 
 export type AttachmentManagerConfig = {

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -17,6 +17,10 @@ import { formatMessage, generateUUIDv4, isLocalMessage, unformatMessage } from '
 import { mergeWith } from '../utils/mergeWith';
 import { Channel } from '../channel';
 import { Thread } from '../thread';
+import {
+  getRawCommandName,
+  stripCommandFromText,
+} from './middleware/textComposer/commandUtils';
 import type {
   ChannelAPIResponse,
   CommandResponse,
@@ -27,10 +31,15 @@ import type {
   LocalMessageBase,
   MessageResponse,
   MessageResponseBase,
+  UserResponse,
 } from '../types';
 import { WithSubscriptions } from '../utils/WithSubscriptions';
 import type { StreamChat } from '../client';
-import type { MessageComposerConfig } from './configuration/types';
+import type {
+  CommandSendValidationContext,
+  CommandSendability,
+  MessageComposerConfig,
+} from './configuration/types';
 import type {
   CommandSuggestionDisabledReason,
   TextComposerCommandActivationEffect,
@@ -378,6 +387,63 @@ export class MessageComposer extends WithSubscriptions {
   isCommandDisabled = (command: CommandResponse) =>
     !!this.getCommandDisabledReason(command);
 
+  getKnownCommand = (commandName?: string): CommandResponse | undefined => {
+    if (!commandName) return;
+
+    const normalizedCommandName = commandName.toLowerCase();
+    return (this.channel.getConfig()?.commands ?? []).find(
+      (command) => command.name?.toLowerCase() === normalizedCommandName,
+    );
+  };
+
+  getCurrentCommand = (text = this.textComposer.text): CommandResponse | undefined =>
+    this.textComposer.command ?? this.getKnownCommand(getRawCommandName(text));
+
+  getMentionedUsersInText = (
+    text = this.textComposer.text,
+    mentionedUsers = this.textComposer.mentionedUsers,
+  ): UserResponse[] =>
+    Array.from(
+      new Set(
+        mentionedUsers.filter(
+          ({ id, name }) =>
+            text.includes(`@${id}`) || (!!name && text.includes(`@${name}`)),
+        ),
+      ),
+    );
+
+  getCommandSendValidationContext = (
+    command: CommandResponse,
+    text = this.textComposer.text,
+  ): CommandSendValidationContext => ({
+    command,
+    commandArgsText: command.name
+      ? stripCommandFromText(text, command.name).trim()
+      : text.trim(),
+    composer: this,
+    mentionedUsersInText: this.getMentionedUsersInText(text),
+    rawText: text,
+  });
+
+  getCommandSendability = (
+    command: CommandResponse,
+    text = this.textComposer.text,
+  ): CommandSendability => {
+    const validationContext = this.getCommandSendValidationContext(command, text);
+
+    for (const validator of this.config.commands.validators) {
+      const result = validator(validationContext);
+      if (result && !result.ready) {
+        return result;
+      }
+    }
+
+    return { ready: true };
+  };
+
+  isCommandSendable = (command: CommandResponse, text = this.textComposer.text) =>
+    this.getCommandSendability(command, text).ready;
+
   get pollId() {
     return this.state.getLatestValue().pollId;
   }
@@ -387,12 +453,18 @@ export class MessageComposer extends WithSubscriptions {
   }
 
   get hasSendableData() {
-    return !!(
-      (!this.attachmentManager.uploadsInProgressCount &&
-        (!this.textComposer.textIsEmpty ||
-          this.attachmentManager.successfulUploadsCount > 0)) ||
-      this.pollId ||
-      !!this.locationComposer.validLocation
+    const currentCommand = this.getCurrentCommand();
+    const commandIsSendable = !currentCommand || this.isCommandSendable(currentCommand);
+
+    return (
+      commandIsSendable &&
+      !!(
+        (!this.attachmentManager.uploadsInProgressCount &&
+          (!this.textComposer.textIsEmpty ||
+            this.attachmentManager.successfulUploadsCount > 0)) ||
+        this.pollId ||
+        !!this.locationComposer.validLocation
+      )
     );
   }
 

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -36,6 +36,7 @@ import type {
 import { WithSubscriptions } from '../utils/WithSubscriptions';
 import type { StreamChat } from '../client';
 import type {
+  CommandSendValidator,
   CommandSendValidationContext,
   CommandSendability,
   MessageComposerConfig,
@@ -174,6 +175,27 @@ const initState = (
   };
 };
 
+const applyCommandValidatorOverride = (
+  targetConfig: MessageComposerConfig,
+  sourceConfig?: DeepPartial<MessageComposerConfig>,
+) => {
+  const overrideValidators = sourceConfig?.commands?.validators as
+    | CommandSendValidator[]
+    | undefined;
+
+  if (typeof overrideValidators === 'undefined') {
+    return targetConfig;
+  }
+
+  return {
+    ...targetConfig,
+    commands: {
+      ...targetConfig.commands,
+      validators: overrideValidators,
+    },
+  };
+};
+
 export class MessageComposer extends WithSubscriptions {
   readonly channel: Channel;
   readonly state: StateStore<MessageComposerState>;
@@ -232,14 +254,17 @@ export class MessageComposer extends WithSubscriptions {
             : originalVal;
 
     this.configState = new StateStore<MessageComposerConfig>(
-      mergeWith(
-        mergeWith(DEFAULT_COMPOSER_CONFIG, config ?? {}),
-        {
-          location: {
-            enabled: this.channel.getConfig()?.shared_locations,
+      applyCommandValidatorOverride(
+        mergeWith(
+          mergeWith(DEFAULT_COMPOSER_CONFIG, config ?? {}),
+          {
+            location: {
+              enabled: this.channel.getConfig()?.shared_locations,
+            },
           },
-        },
-        mergeChannelConfigCustomizer,
+          mergeChannelConfigCustomizer,
+        ),
+        config,
       ),
     );
 
@@ -498,7 +523,9 @@ export class MessageComposer extends WithSubscriptions {
   }
 
   updateConfig(config: DeepPartial<MessageComposerConfig>) {
-    this.configState.partialNext(mergeWith(this.config, config));
+    this.configState.partialNext(
+      applyCommandValidatorOverride(mergeWith(this.config, config), config),
+    );
   }
 
   refreshId = () => {

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -406,16 +406,16 @@ export class MessageComposer extends WithSubscriptions {
     command: CommandResponse,
     text = this.textComposer.text,
   ): CommandSendability => {
+    const currentMentionedUsers = this.textComposer.mentionedUsers;
+    const mentionedUsersInText = getMentionedUsersInText(text, currentMentionedUsers);
+
     const validationContext = {
       command,
       commandArgsText: command.name
         ? stripCommandFromText(text, command.name).trim()
         : text.trim(),
       composer: this,
-      mentionedUsersInText: getMentionedUsersInText(
-        text,
-        this.textComposer.mentionedUsers,
-      ),
+      mentionedUsersInText,
       rawText: text,
     };
 

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -239,7 +239,16 @@ export class MessageComposer extends WithSubscriptions {
       );
     }
 
-    const mergeChannelConfigCustomizer: MergeWithCustomizer<
+    /**
+     * Customizes config merges for the composer constructor.
+     *
+     * It catches two scalar override cases that should not use the default deep merge:
+     * - client-disabled `enabled` flags stay disabled even if the channel config tries to re-enable them
+     * - scalar channel-config values replace client defaults for matching config keys
+     *
+     * All other values fall back to the normal `mergeWith` behavior.
+     */
+    const mergeMessageComposerConfigCustomizer: MergeWithCustomizer<
       DeepPartial<MessageComposerConfig>
     > = (originalVal, channelConfigVal, key) =>
       typeof originalVal === 'object'
@@ -262,7 +271,7 @@ export class MessageComposer extends WithSubscriptions {
               enabled: this.channel.getConfig()?.shared_locations,
             },
           },
-          mergeChannelConfigCustomizer,
+          mergeMessageComposerConfigCustomizer,
         ),
         config,
       ),

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -5,7 +5,7 @@ import { LocationComposer } from './LocationComposer';
 import { MessageComposerEffectHandlers } from './MessageComposerEffectHandlers';
 import { PollComposer } from './pollComposer';
 import { TextComposer } from './textComposer';
-import { DEFAULT_COMPOSER_CONFIG } from './configuration';
+import { applyCommandValidatorOverride, DEFAULT_COMPOSER_CONFIG } from './configuration';
 import type { MessageComposerMiddlewareValue } from './middleware';
 import {
   MessageComposerMiddlewareExecutor,
@@ -17,10 +17,6 @@ import { formatMessage, generateUUIDv4, isLocalMessage, unformatMessage } from '
 import { mergeWith } from '../utils/mergeWith';
 import { Channel } from '../channel';
 import { Thread } from '../thread';
-import {
-  getRawCommandName,
-  stripCommandFromText,
-} from './middleware/textComposer/commandUtils';
 import type {
   ChannelAPIResponse,
   CommandResponse,
@@ -31,16 +27,10 @@ import type {
   LocalMessageBase,
   MessageResponse,
   MessageResponseBase,
-  UserResponse,
 } from '../types';
 import { WithSubscriptions } from '../utils/WithSubscriptions';
 import type { StreamChat } from '../client';
-import type {
-  CommandSendValidator,
-  CommandSendValidationContext,
-  CommandSendability,
-  MessageComposerConfig,
-} from './configuration/types';
+import type { CommandSendability, MessageComposerConfig } from './configuration/types';
 import type {
   CommandSuggestionDisabledReason,
   TextComposerCommandActivationEffect,
@@ -54,6 +44,10 @@ import type { PollComposerSnapshot } from './pollComposer';
 import type { TextComposerSnapshot } from './textComposer';
 import type { DeepPartial } from '../types.utility';
 import type { MergeWithCustomizer } from '../utils/mergeWith/mergeWithCore';
+import {
+  getMentionedUsersInText,
+  stripCommandFromText,
+} from './middleware/textComposer/commandUtils';
 
 type UnregisterSubscriptions = Unsubscribe;
 
@@ -172,27 +166,6 @@ const initState = (
       : null,
     showReplyInChannel: false,
     editedMessage,
-  };
-};
-
-const applyCommandValidatorOverride = (
-  targetConfig: MessageComposerConfig,
-  sourceConfig?: DeepPartial<MessageComposerConfig>,
-) => {
-  const overrideValidators = sourceConfig?.commands?.validators as
-    | CommandSendValidator[]
-    | undefined;
-
-  if (typeof overrideValidators === 'undefined') {
-    return targetConfig;
-  }
-
-  return {
-    ...targetConfig,
-    commands: {
-      ...targetConfig.commands,
-      validators: overrideValidators,
-    },
   };
 };
 
@@ -403,6 +376,14 @@ export class MessageComposer extends WithSubscriptions {
     return this.state.getLatestValue().quotedMessage;
   }
 
+  get pollId() {
+    return this.state.getLatestValue().pollId;
+  }
+
+  get showReplyInChannel() {
+    return this.state.getLatestValue().showReplyInChannel;
+  }
+
   getCommandDisabledReason = (
     command: CommandResponse,
   ): CommandSuggestionDisabledReason | undefined => {
@@ -421,73 +402,38 @@ export class MessageComposer extends WithSubscriptions {
   isCommandDisabled = (command: CommandResponse) =>
     !!this.getCommandDisabledReason(command);
 
-  getKnownCommand = (commandName?: string): CommandResponse | undefined => {
-    if (!commandName) return;
-
-    const normalizedCommandName = commandName.toLowerCase();
-    return (this.channel.getConfig()?.commands ?? []).find(
-      (command) => command.name?.toLowerCase() === normalizedCommandName,
-    );
-  };
-
-  getCurrentCommand = (text = this.textComposer.text): CommandResponse | undefined =>
-    this.textComposer.command ?? this.getKnownCommand(getRawCommandName(text));
-
-  getMentionedUsersInText = (
-    text = this.textComposer.text,
-    mentionedUsers = this.textComposer.mentionedUsers,
-  ): UserResponse[] =>
-    Array.from(
-      new Set(
-        mentionedUsers.filter(
-          ({ id, name }) =>
-            text.includes(`@${id}`) || (!!name && text.includes(`@${name}`)),
-        ),
-      ),
-    );
-
-  getCommandSendValidationContext = (
-    command: CommandResponse,
-    text = this.textComposer.text,
-  ): CommandSendValidationContext => ({
-    command,
-    commandArgsText: command.name
-      ? stripCommandFromText(text, command.name).trim()
-      : text.trim(),
-    composer: this,
-    mentionedUsersInText: this.getMentionedUsersInText(text),
-    rawText: text,
-  });
-
-  getCommandSendability = (
+  validateCommandSendability = (
     command: CommandResponse,
     text = this.textComposer.text,
   ): CommandSendability => {
-    const validationContext = this.getCommandSendValidationContext(command, text);
+    const validationContext = {
+      command,
+      commandArgsText: command.name
+        ? stripCommandFromText(text, command.name).trim()
+        : text.trim(),
+      composer: this,
+      mentionedUsersInText: getMentionedUsersInText(
+        text,
+        this.textComposer.mentionedUsers,
+      ),
+      rawText: text,
+    };
 
-    for (const validator of this.config.commands.validators) {
+    for (const validator of this.config.commands.sendValidators) {
       const result = validator(validationContext);
       if (result && !result.ready) {
         return result;
       }
     }
 
-    return { ready: true };
+    return { command, ready: true };
   };
 
   isCommandSendable = (command: CommandResponse, text = this.textComposer.text) =>
-    this.getCommandSendability(command, text).ready;
-
-  get pollId() {
-    return this.state.getLatestValue().pollId;
-  }
-
-  get showReplyInChannel() {
-    return this.state.getLatestValue().showReplyInChannel;
-  }
+    this.validateCommandSendability(command, text).ready;
 
   get hasSendableData() {
-    const currentCommand = this.getCurrentCommand();
+    const currentCommand = this.textComposer.command;
     const commandIsSendable = !currentCommand || this.isCommandSendable(currentCommand);
 
     return (
@@ -732,6 +678,7 @@ export class MessageComposer extends WithSubscriptions {
         draft.channel_cid !== this.channel.cid
       )
         return;
+      if (this.editedMessage) return;
       this.initState({ composition: draft });
     }).unsubscribe;
 
@@ -745,6 +692,7 @@ export class MessageComposer extends WithSubscriptions {
       ) {
         return;
       }
+      if (this.editedMessage) return;
 
       this.logDraftUpdateTimestamp();
 

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -419,11 +419,9 @@ export class MessageComposer extends WithSubscriptions {
       rawText: text,
     };
 
-    for (const validator of this.config.commands.sendValidators) {
-      const result = validator(validationContext);
-      if (result && !result.ready) {
-        return result;
-      }
+    const result = this.config.commands.sendValidator(validationContext);
+    if (result && !result.ready) {
+      return result;
     }
 
     return { command, ready: true };

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -429,15 +429,14 @@ export class MessageComposer extends WithSubscriptions {
     return { command, ready: true };
   };
 
-  isCommandSendable = (command: CommandResponse, text = this.textComposer.text) =>
-    this.validateCommandSendability(command, text).ready;
+  get isCommandSendable() {
+    const currentCommand = this.textComposer.command;
+    return !currentCommand || this.validateCommandSendability(currentCommand).ready;
+  }
 
   get hasSendableData() {
-    const currentCommand = this.textComposer.command;
-    const commandIsSendable = !currentCommand || this.isCommandSendable(currentCommand);
-
     return (
-      commandIsSendable &&
+      this.isCommandSendable &&
       !!(
         (!this.attachmentManager.uploadsInProgressCount &&
           (!this.textComposer.textIsEmpty ||

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -1,6 +1,12 @@
 import { textIsEmpty } from '../../textComposer';
 import type { CommandResponse } from '../../../types';
-import { getRawCommandName, notifyCommandDisabled } from '../textComposer/commandUtils';
+import { CommandSearchSource } from '../textComposer/commands';
+import {
+  getCommandByName,
+  getRawCommandName,
+  notifyCommandDisabled,
+  notifyCommandNotReady,
+} from '../textComposer/commandUtils';
 import type {
   MessageComposerMiddlewareState,
   MessageCompositionMiddleware,
@@ -12,9 +18,10 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 
 const getDisabledRawCommand = (
   composer: MessageComposer,
+  searchSource: Pick<CommandSearchSource, 'query'>,
   text?: string,
 ): CommandResponse | undefined => {
-  const rawCommand = composer.getKnownCommand(getRawCommandName(text));
+  const rawCommand = getCommandByName(searchSource, getRawCommandName(text));
   if (rawCommand && composer.isCommandDisabled(rawCommand)) {
     return rawCommand;
   }
@@ -22,7 +29,11 @@ const getDisabledRawCommand = (
 
 export const createCompositionValidationMiddleware = (
   composer: MessageComposer,
+  commandSearchSource?: Pick<CommandSearchSource, 'query'>,
 ): MessageCompositionMiddleware => {
+  const effectiveCommandSearchSource =
+    commandSearchSource ?? new CommandSearchSource(composer.channel);
+
   return {
     id: 'stream-io/message-composer-middleware/data-validation',
     handlers: {
@@ -34,32 +45,26 @@ export const createCompositionValidationMiddleware = (
         const { maxLengthOnSend } = composer.config.text ?? {};
         const inputText = state.message.text ?? '';
 
-        const disabledRawCommand = getDisabledRawCommand(composer, inputText);
+        const disabledRawCommand = getDisabledRawCommand(
+          composer,
+          effectiveCommandSearchSource,
+          inputText,
+        );
         if (disabledRawCommand) {
           notifyCommandDisabled(composer, disabledRawCommand);
           return await discard();
         }
 
-        const currentCommand = composer.getCurrentCommand(inputText);
+        const currentCommand =
+          composer.textComposer.command ??
+          getCommandByName(effectiveCommandSearchSource, getRawCommandName(inputText));
         if (currentCommand) {
-          const sendability = composer.getCommandSendability(currentCommand, inputText);
-
-          if (!sendability.ready) {
-            composer.client.notifications.addWarning({
-              message: 'Command not ready to be sent',
-              origin: {
-                emitter: 'MessageComposer',
-                context: { command: currentCommand, composer },
-              },
-              options: {
-                type: 'validation:command:not-ready',
-                metadata: {
-                  command: currentCommand.name,
-                  ...(sendability.reason ? { reason: sendability.reason } : {}),
-                  ...(sendability.metadata ?? {}),
-                },
-              },
-            });
+          if (
+            notifyCommandNotReady({
+              composer,
+              sendability: composer.validateCommandSendability(currentCommand, inputText),
+            })
+          ) {
             return await discard();
           }
         }

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -18,7 +18,7 @@ import type { MiddlewareHandlerParams } from '../../../middleware';
 
 const getDisabledRawCommand = (
   composer: MessageComposer,
-  searchSource: Pick<CommandSearchSource, 'query'>,
+  searchSource: CommandSearchSource,
   text?: string,
 ): CommandResponse | undefined => {
   const rawCommand = getCommandByName(searchSource, getRawCommandName(text));
@@ -29,7 +29,7 @@ const getDisabledRawCommand = (
 
 export const createCompositionValidationMiddleware = (
   composer: MessageComposer,
-  commandSearchSource?: Pick<CommandSearchSource, 'query'>,
+  commandSearchSource?: CommandSearchSource,
 ): MessageCompositionMiddleware => {
   const effectiveCommandSearchSource =
     commandSearchSource ?? new CommandSearchSource(composer.channel);

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -1,6 +1,5 @@
 import { textIsEmpty } from '../../textComposer';
 import type { CommandResponse } from '../../../types';
-import { CommandSearchSource } from '../textComposer/commands';
 import { getRawCommandName, notifyCommandDisabled } from '../textComposer/commandUtils';
 import type {
   MessageComposerMiddlewareState,
@@ -11,24 +10,11 @@ import type {
 import type { MessageComposer } from '../../messageComposer';
 import type { MiddlewareHandlerParams } from '../../../middleware';
 
-const getCommandByName = (
-  searchSource: CommandSearchSource,
-  commandName?: string,
-): CommandResponse | undefined => {
-  if (!commandName) return;
-
-  const normalizedCommandName = commandName.toLowerCase();
-  return searchSource
-    .query(normalizedCommandName)
-    .items.find((command) => command.name?.toLowerCase() === normalizedCommandName);
-};
-
 const getDisabledRawCommand = (
   composer: MessageComposer,
-  searchSource: CommandSearchSource,
   text?: string,
 ): CommandResponse | undefined => {
-  const rawCommand = getCommandByName(searchSource, getRawCommandName(text));
+  const rawCommand = composer.getKnownCommand(getRawCommandName(text));
   if (rawCommand && composer.isCommandDisabled(rawCommand)) {
     return rawCommand;
   }
@@ -37,8 +23,6 @@ const getDisabledRawCommand = (
 export const createCompositionValidationMiddleware = (
   composer: MessageComposer,
 ): MessageCompositionMiddleware => {
-  const commandSearchSource = new CommandSearchSource(composer.channel);
-
   return {
     id: 'stream-io/message-composer-middleware/data-validation',
     handlers: {
@@ -50,14 +34,34 @@ export const createCompositionValidationMiddleware = (
         const { maxLengthOnSend } = composer.config.text ?? {};
         const inputText = state.message.text ?? '';
 
-        const disabledRawCommand = getDisabledRawCommand(
-          composer,
-          commandSearchSource,
-          inputText,
-        );
+        const disabledRawCommand = getDisabledRawCommand(composer, inputText);
         if (disabledRawCommand) {
           notifyCommandDisabled(composer, disabledRawCommand);
           return await discard();
+        }
+
+        const currentCommand = composer.getCurrentCommand(inputText);
+        if (currentCommand) {
+          const sendability = composer.getCommandSendability(currentCommand, inputText);
+
+          if (!sendability.ready) {
+            composer.client.notifications.addWarning({
+              message: 'Command not ready to be sent',
+              origin: {
+                emitter: 'MessageComposer',
+                context: { command: currentCommand, composer },
+              },
+              options: {
+                type: 'validation:command:not-ready',
+                metadata: {
+                  command: currentCommand.name,
+                  ...(sendability.reason ? { reason: sendability.reason } : {}),
+                  ...(sendability.metadata ?? {}),
+                },
+              },
+            });
+            return await discard();
+          }
         }
 
         const hasExceededMaxLength =

--- a/src/messageComposer/middleware/messageComposer/compositionValidation.ts
+++ b/src/messageComposer/middleware/messageComposer/compositionValidation.ts
@@ -58,15 +58,14 @@ export const createCompositionValidationMiddleware = (
         const currentCommand =
           composer.textComposer.command ??
           getCommandByName(effectiveCommandSearchSource, getRawCommandName(inputText));
-        if (currentCommand) {
-          if (
-            notifyCommandNotReady({
-              composer,
-              sendability: composer.validateCommandSendability(currentCommand, inputText),
-            })
-          ) {
-            return await discard();
-          }
+        if (
+          currentCommand &&
+          notifyCommandNotReady({
+            composer,
+            sendability: composer.validateCommandSendability(currentCommand, inputText),
+          })
+        ) {
+          return await discard();
         }
 
         const hasExceededMaxLength =

--- a/src/messageComposer/middleware/messageComposer/textComposer.ts
+++ b/src/messageComposer/middleware/messageComposer/textComposer.ts
@@ -4,6 +4,7 @@ import type {
   MessageDraftComposerMiddlewareValueState,
   MessageDraftCompositionMiddleware,
 } from './types';
+import { getMentionedUsersInText } from '../textComposer/commandUtils';
 import type { MessageComposer } from '../../messageComposer';
 import type { MiddlewareHandlerParams } from '../../../middleware';
 
@@ -22,13 +23,7 @@ export const createTextComposerCompositionMiddleware = (
       // Instead of checking if a user is still mentioned every time the text changes,
       // just filter out non-mentioned users before submit, which is cheaper
       // and allows users to easily undo any accidental deletion
-      const mentioned_users = Array.from(
-        new Set(
-          mentionedUsers.filter(
-            ({ id, name }) => text.includes(`@${id}`) || text.includes(`@${name}`),
-          ),
-        ),
-      );
+      const mentioned_users = getMentionedUsersInText(text, mentionedUsers);
 
       // prevent introducing text and mentioned_users array into the payload sent to the server
       if (!text && mentioned_users.length === 0) return forward();
@@ -67,14 +62,7 @@ export const createDraftTextComposerCompositionMiddleware = (
       // just filter out non-mentioned users before submit, which is cheaper
       // and allows users to easily undo any accidental deletion
       const mentioned_users = mentionedUsers.length
-        ? Array.from(
-            new Set(
-              mentionedUsers.filter(
-                ({ id, name }) =>
-                  inputText.includes(`@${id}`) || inputText.includes(`@${name}`),
-              ),
-            ),
-          )
+        ? getMentionedUsersInText(inputText, mentionedUsers)
         : undefined;
 
       const text =

--- a/src/messageComposer/middleware/textComposer/commandUtils.ts
+++ b/src/messageComposer/middleware/textComposer/commandUtils.ts
@@ -47,7 +47,7 @@ export const getMentionedUsersInText = (text: string, mentionedUsers: UserRespon
   );
 
 export const getCommandByName = (
-  searchSource: Pick<CommandSearchSource, 'query'>,
+  searchSource: CommandSearchSource,
   commandName?: string,
 ): CommandResponse | undefined => {
   if (!commandName) return;

--- a/src/messageComposer/middleware/textComposer/commandUtils.ts
+++ b/src/messageComposer/middleware/textComposer/commandUtils.ts
@@ -1,5 +1,7 @@
 import type { MessageComposer } from '../../messageComposer';
-import type { CommandResponse } from '../../../types';
+import type { CommandResponse, UserResponse } from '../../../types';
+import type { CommandSendability } from '../../configuration';
+import type { CommandSearchSource } from './commands';
 
 export function escapeCommandRegExp(text: string) {
   return text.replace(/[-[\]{}()*+?.,/\\^$|#]/g, '\\$&');
@@ -18,6 +20,43 @@ export const getCompleteCommandInString = (text: string) => {
 
 export const stripCommandFromText = (text: string, commandName: string) =>
   text.replace(new RegExp(`^${escapeCommandRegExp(`/${commandName}`)}\\s*`), '');
+
+export const stripMentionTokens = (
+  text: string,
+  mentionedUsersInText: UserResponse[],
+  trigger = '@',
+) =>
+  mentionedUsersInText.reduce((value, user) => {
+    let next = value.replace(`${trigger}${user.id}`, '');
+
+    if (user.name) {
+      next = next.replace(`${trigger}${user.name}`, '');
+    }
+
+    return next.trim();
+  }, text.trim());
+
+export const getMentionedUsersInText = (text: string, mentionedUsers: UserResponse[]) =>
+  Array.from(
+    new Set(
+      mentionedUsers.filter(
+        ({ id, name }) =>
+          text.includes(`@${id}`) || (!!name && text.includes(`@${name}`)),
+      ),
+    ),
+  );
+
+export const getCommandByName = (
+  searchSource: Pick<CommandSearchSource, 'query'>,
+  commandName?: string,
+): CommandResponse | undefined => {
+  if (!commandName) return;
+
+  const normalizedCommandName = commandName.toLowerCase();
+  return searchSource
+    .query(normalizedCommandName)
+    .items.find((command) => command.name?.toLowerCase() === normalizedCommandName);
+};
 
 export const notifyCommandDisabled = (
   composer: MessageComposer,
@@ -40,6 +79,34 @@ export const notifyCommandDisabled = (
       metadata: {
         command: command.name,
         reason: disabledReason,
+      },
+    },
+  });
+
+  return true;
+};
+
+export const notifyCommandNotReady = ({
+  composer,
+  sendability,
+}: {
+  composer: MessageComposer;
+  sendability: CommandSendability;
+}) => {
+  if (sendability.ready) return;
+
+  composer.client.notifications.addWarning({
+    message: 'Command not ready to be sent',
+    origin: {
+      emitter: 'MessageComposer',
+      context: { command: sendability.command, composer },
+    },
+    options: {
+      type: 'validation:command:not-ready',
+      metadata: {
+        command: sendability.command.name,
+        ...(sendability.reason ? { reason: sendability.reason } : {}),
+        ...(sendability.metadata ?? {}),
       },
     },
   });

--- a/src/messageComposer/middleware/textComposer/commands.ts
+++ b/src/messageComposer/middleware/textComposer/commands.ts
@@ -6,7 +6,11 @@ import type { CommandResponse } from '../../../types';
 import { mergeWith } from '../../../utils/mergeWith';
 import type { MessageComposer } from '../../messageComposer';
 import type { CommandSuggestion, TextComposerMiddlewareOptions } from './types';
-import { getCompleteCommandInString, notifyCommandDisabled } from './commandUtils';
+import {
+  getCommandByName,
+  getCompleteCommandInString,
+  notifyCommandDisabled,
+} from './commandUtils';
 import { getTriggerCharWithToken, insertItemWithTrigger } from './textMiddlewareUtils';
 import type { TextComposerMiddlewareExecutorState } from './TextComposerMiddlewareExecutor';
 
@@ -124,7 +128,7 @@ export const createCommandsMiddleware = (
         const finalText = state.text.slice(0, state.selection.end);
         const commandName = getCompleteCommandInString(finalText);
         if (commandName) {
-          const command = searchSource?.query(commandName).items[0];
+          const command = getCommandByName(searchSource, commandName);
           const composer = options?.composer;
           if (command && !composer?.isCommandDisabled(command)) {
             return next({

--- a/src/messageComposer/middleware/textComposer/index.ts
+++ b/src/messageComposer/middleware/textComposer/index.ts
@@ -2,6 +2,7 @@ export * from './activeCommandGuard';
 export * from './commands';
 export * from './commandEffects';
 export * from './commandStringExtraction';
+export * from './commandUtils';
 export * from './mentions';
 export * from './validation';
 export * from './TextComposerMiddlewareExecutor';

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -3,6 +3,7 @@ import {
   getTriggerCharWithToken,
   insertItemWithTrigger,
 } from './textMiddlewareUtils';
+import { getMentionedUsersInText } from './commandUtils';
 import { BaseSearchSource, type SearchSourceOptions } from '../../../search';
 import { mergeWith } from '../../../utils/mergeWith';
 import type { TextComposerMiddlewareOptions, UserSuggestion } from './types';
@@ -351,10 +352,19 @@ export const createMentionsMiddleware = (
     handlers: {
       onChange: ({ state, next, complete, forward }) => {
         if (!state.selection) return forward();
+        const currentMentions = getMentionedUsersInText(state.text, state.mentionedUsers);
+        const mentionedUsersChanged =
+          currentMentions.length !== state.mentionedUsers.length ||
+          currentMentions.some(
+            (user, index) => user.id !== state.mentionedUsers[index]?.id,
+          );
+        const stateWithMentions = mentionedUsersChanged
+          ? { ...state, mentionedUsers: currentMentions }
+          : state;
 
         const triggerWithToken = getTriggerCharWithToken({
           trigger: finalOptions.trigger,
-          text: state.text.slice(0, state.selection.end),
+          text: stateWithMentions.text.slice(0, stateWithMentions.selection.end),
         });
 
         const newSearchTriggered =
@@ -368,18 +378,19 @@ export const createMentionsMiddleware = (
           !triggerWithToken || triggerWithToken.length < finalOptions.minChars;
 
         if (triggerWasRemoved) {
-          const hasStaleSuggestions = state.suggestions?.trigger === finalOptions.trigger;
-          const newState = { ...state };
+          const hasStaleSuggestions =
+            stateWithMentions.suggestions?.trigger === finalOptions.trigger;
+          const newState = { ...stateWithMentions };
           if (hasStaleSuggestions) {
             delete newState.suggestions;
           }
           return next(newState);
         }
 
-        searchSource.config.textComposerText = state.text;
+        searchSource.config.textComposerText = stateWithMentions.text;
 
         return complete({
-          ...state,
+          ...stateWithMentions,
           suggestions: {
             query: triggerWithToken.slice(1),
             searchSource,

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -77,6 +77,7 @@ export const calculateLevenshtein = (query: string, name: string) => {
 export type MentionsSearchSourceOptions = SearchSourceOptions & {
   mentionAllAppUsers?: boolean;
   textComposerText?: string;
+  trigger?: string;
   // todo: document that if you want transliteration, you need to provide the function, e.g. import {default: transliterate}  from '@sindresorhus/transliterate';
   // this is now replacing a parameter useMentionsTransliteration
   transliterate?: (text: string) => string;
@@ -94,12 +95,17 @@ export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
   config: MentionsSearchSourceOptions;
 
   constructor(channel: Channel, options?: MentionsSearchSourceOptions) {
-    const { mentionAllAppUsers, textComposerText, transliterate, ...restOptions } =
-      options || {};
+    const {
+      mentionAllAppUsers,
+      textComposerText,
+      transliterate,
+      trigger,
+      ...restOptions
+    } = options || {};
     super(restOptions);
     this.client = channel.getClient();
     this.channel = channel;
-    this.config = { mentionAllAppUsers, textComposerText };
+    this.config = { mentionAllAppUsers, textComposerText, trigger };
 
     if (transliterate) {
       this.transliterate = transliterate;
@@ -169,7 +175,8 @@ export class MentionsSearchSource extends BaseSearchSource<UserSuggestion> {
         ).toLowerCase();
 
         const maxDistance = 3;
-        const lastDigits = textComposerText.slice(-(maxDistance + 1)).includes('@');
+        const trigger = this.config.trigger ?? '@';
+        const lastDigits = textComposerText.slice(-(maxDistance + 1)).includes(trigger);
 
         if (updatedName) {
           const levenshtein = calculateLevenshtein(updatedQuery, updatedName);
@@ -336,7 +343,7 @@ export const createMentionsMiddleware = (
     searchSource = options.searchSource;
     searchSource.resetState();
   } else {
-    searchSource = new MentionsSearchSource(channel);
+    searchSource = new MentionsSearchSource(channel, { trigger: finalOptions.trigger });
   }
   searchSource.activate();
   return {
@@ -389,7 +396,9 @@ export const createMentionsMiddleware = (
         return complete({
           ...state,
           ...insertItemWithTrigger({
-            insertText: `@${selectedSuggestion.name || selectedSuggestion.id} `,
+            insertText: `${searchSource.config.trigger ?? finalOptions.trigger}${
+              selectedSuggestion.name || selectedSuggestion.id
+            } `,
             selection: state.selection,
             text: state.text,
             trigger: finalOptions.trigger,

--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -352,7 +352,16 @@ export const createMentionsMiddleware = (
     handlers: {
       onChange: ({ state, next, complete, forward }) => {
         if (!state.selection) return forward();
-        const currentMentions = getMentionedUsersInText(state.text, state.mentionedUsers);
+        // Only prune stale mentions during normal text editing. Entering command mode
+        // clears text/mentions through the `command.activate` effect, which first
+        // snapshots the previous TextComposer state so it can be restored on
+        // `clearCommand()`. Custom middleware is allowed to remove that effect,
+        // though, and in that opt-out case we must not silently drop mentions
+        // here just because the user typed a raw command like `/ban`.
+        const currentMentions =
+          state.command || state.text.trimStart().startsWith('/')
+            ? state.mentionedUsers
+            : getMentionedUsersInText(state.text, state.mentionedUsers);
         const mentionedUsersChanged =
           currentMentions.length !== state.mentionedUsers.length ||
           currentMentions.some(

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -584,7 +584,7 @@ describe('MessageComposer', () => {
       const { messageComposer } = setup({
         config: {
           commands: {
-            sendValidators: [validator],
+            sendValidator: validator,
           },
         },
       });
@@ -899,7 +899,7 @@ describe('MessageComposer', () => {
       const { messageComposer } = setup({
         config: {
           commands: {
-            sendValidators: [validator],
+            sendValidator: validator,
           },
         },
       });
@@ -928,7 +928,7 @@ describe('MessageComposer', () => {
       const { messageComposer } = setup({
         config: {
           commands: {
-            sendValidators: [validator],
+            sendValidator: validator,
           },
         },
       });
@@ -970,7 +970,7 @@ describe('MessageComposer', () => {
       const { messageComposer } = setup({
         config: {
           commands: {
-            sendValidators: [validator],
+            sendValidator: validator,
           },
         },
       });

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -614,6 +614,28 @@ describe('MessageComposer', () => {
       );
     });
 
+    it('should apply the default ban command validator', () => {
+      const { messageComposer } = setup();
+
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [{ name: 'ban', description: 'Ban a user' }],
+      });
+
+      messageComposer.textComposer.state.partialNext({
+        mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
+        selection: { start: 16, end: 16 },
+        text: '/ban @target-user',
+      });
+      expect(messageComposer.hasSendableData).toBe(false);
+
+      messageComposer.textComposer.state.partialNext({
+        mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
+        selection: { start: 23, end: 23 },
+        text: '/ban @target-user rude',
+      });
+      expect(messageComposer.hasSendableData).toBe(true);
+    });
+
     it('should return the correct compositionIsEmpty', () => {
       const { messageComposer } = setup();
 
@@ -862,6 +884,44 @@ describe('MessageComposer', () => {
         ready: false,
         reason: 'missing_args',
       });
+    });
+
+    it('should allow overriding default command validators via config', () => {
+      const validator = vi.fn(({ mentionedUsersInText }) =>
+        mentionedUsersInText.length > 0
+          ? { ready: true as const }
+          : { ready: false as const, reason: 'missing_user' as const },
+      );
+      const { messageComposer } = setup({
+        config: {
+          commands: {
+            validators: [validator],
+          },
+        },
+      });
+
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [{ name: 'ban', description: 'Ban a user' }],
+      });
+      messageComposer.textComposer.state.partialNext({
+        mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
+        selection: { start: 16, end: 16 },
+        text: '/ban @target-user',
+      });
+
+      expect(
+        messageComposer.getCommandSendability(
+          messageComposer.getCurrentCommand('/ban @target-user')!,
+          '/ban @target-user',
+        ),
+      ).toEqual({ ready: true });
+      expect(validator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: expect.objectContaining({ name: 'ban' }),
+          commandArgsText: '@target-user',
+          rawText: '/ban @target-user',
+        }),
+      );
     });
 
     it('should register subscriptions', () => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -573,6 +573,47 @@ describe('MessageComposer', () => {
       expect(messageComposer.hasSendableData).toBe(false);
     });
 
+    it('should account for command sendability in hasSendableData', () => {
+      const validator = vi.fn(({ mentionedUsersInText }) =>
+        mentionedUsersInText.length > 0
+          ? undefined
+          : { ready: false as const, reason: 'missing_user' as const },
+      );
+      const { messageComposer } = setup({
+        config: {
+          commands: {
+            validators: [validator],
+          },
+        },
+      });
+
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [{ name: 'ban', description: 'Ban a user' }],
+      });
+
+      messageComposer.textComposer.state.partialNext({
+        mentionedUsers: [],
+        selection: { start: 4, end: 4 },
+        text: '/ban',
+      });
+      expect(messageComposer.hasSendableData).toBe(false);
+
+      messageComposer.textComposer.state.partialNext({
+        mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
+        selection: { start: 16, end: 16 },
+        text: '/ban @target-user',
+      });
+      expect(messageComposer.hasSendableData).toBe(true);
+      expect(validator).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          command: expect.objectContaining({ name: 'ban' }),
+          commandArgsText: '@target-user',
+          mentionedUsersInText: [{ id: 'target-user', name: 'Target User' }],
+          rawText: '/ban @target-user',
+        }),
+      );
+    });
+
     it('should return the correct compositionIsEmpty', () => {
       const { messageComposer } = setup();
 
@@ -784,6 +825,43 @@ describe('MessageComposer', () => {
         }),
       ).toBe('quoted_message');
       expect(messageComposer.getCommandDisabledReason({ name: 'giphy' })).toBeUndefined();
+    });
+
+    it('should return command sendability for current raw commands', () => {
+      const validator = vi.fn(({ commandArgsText }) =>
+        commandArgsText.length > 0
+          ? undefined
+          : {
+              metadata: { expected: 'args' },
+              ready: false as const,
+              reason: 'missing_args',
+            },
+      );
+      const { messageComposer } = setup({
+        config: {
+          commands: {
+            validators: [validator],
+          },
+        },
+      });
+
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [{ name: 'custom', description: 'Custom command' }],
+      });
+
+      expect(messageComposer.getCurrentCommand('/custom')).toEqual(
+        expect.objectContaining({ name: 'custom' }),
+      );
+      expect(
+        messageComposer.getCommandSendability(
+          messageComposer.getCurrentCommand('/custom')!,
+          '/custom',
+        ),
+      ).toEqual({
+        metadata: { expected: 'args' },
+        ready: false,
+        reason: 'missing_args',
+      });
     });
 
     it('should register subscriptions', () => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -12,9 +12,11 @@ import {
   Thread,
 } from '../../../src';
 import { DeepPartial } from '../../../src/types.utility';
+import { CommandSearchSource } from '../../../src/messageComposer/middleware/textComposer/commands';
 import { MessageComposer } from '../../../src/messageComposer/messageComposer';
 import { DraftResponse, MessageResponse } from '../../../src/types';
 import { MockOfflineDB } from '../offline-support/MockOfflineDB';
+import { getCommandByName } from '../../../src/messageComposer/middleware/textComposer/commandUtils';
 
 const generateUuidV4Output = 'test-uuid';
 // Mock dependencies
@@ -574,15 +576,15 @@ describe('MessageComposer', () => {
     });
 
     it('should account for command sendability in hasSendableData', () => {
-      const validator = vi.fn(({ mentionedUsersInText }) =>
+      const validator = vi.fn(({ command, mentionedUsersInText }) =>
         mentionedUsersInText.length > 0
           ? undefined
-          : { ready: false as const, reason: 'missing_user' as const },
+          : { command, ready: false as const, reason: 'missing_user' as const },
       );
       const { messageComposer } = setup({
         config: {
           commands: {
-            validators: [validator],
+            sendValidators: [validator],
           },
         },
       });
@@ -592,6 +594,7 @@ describe('MessageComposer', () => {
       });
 
       messageComposer.textComposer.state.partialNext({
+        command: { description: 'Ban a user', name: 'ban' },
         mentionedUsers: [],
         selection: { start: 4, end: 4 },
         text: '/ban',
@@ -599,6 +602,7 @@ describe('MessageComposer', () => {
       expect(messageComposer.hasSendableData).toBe(false);
 
       messageComposer.textComposer.state.partialNext({
+        command: { description: 'Ban a user', name: 'ban' },
         mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
         selection: { start: 16, end: 16 },
         text: '/ban @target-user',
@@ -622,6 +626,7 @@ describe('MessageComposer', () => {
       });
 
       messageComposer.textComposer.state.partialNext({
+        command: { description: 'Ban a user', name: 'ban' },
         mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
         selection: { start: 16, end: 16 },
         text: '/ban @target-user',
@@ -629,11 +634,42 @@ describe('MessageComposer', () => {
       expect(messageComposer.hasSendableData).toBe(false);
 
       messageComposer.textComposer.state.partialNext({
+        command: { description: 'Ban a user', name: 'ban' },
         mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
         selection: { start: 23, end: 23 },
         text: '/ban @target-user rude',
       });
       expect(messageComposer.hasSendableData).toBe(true);
+    });
+
+    it('should require mentions for default moderation target commands', () => {
+      const { messageComposer } = setup();
+
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [
+          { name: 'mute', description: 'Mute a user' },
+          { name: 'unmute', description: 'Unmute a user' },
+          { name: 'unban', description: 'Unban a user' },
+        ],
+      });
+
+      for (const commandName of ['mute', 'unmute', 'unban'] as const) {
+        messageComposer.textComposer.state.partialNext({
+          command: { description: `${commandName} a user`, name: commandName },
+          mentionedUsers: [],
+          selection: { start: commandName.length + 1, end: commandName.length + 1 },
+          text: `/${commandName}`,
+        });
+        expect(messageComposer.hasSendableData).toBe(false);
+
+        messageComposer.textComposer.state.partialNext({
+          command: { description: `${commandName} a user`, name: commandName },
+          mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
+          selection: { start: commandName.length + 14, end: commandName.length + 14 },
+          text: `/${commandName} @target-user`,
+        });
+        expect(messageComposer.hasSendableData).toBe(true);
+      }
     });
 
     it('should return the correct compositionIsEmpty', () => {
@@ -850,10 +886,11 @@ describe('MessageComposer', () => {
     });
 
     it('should return command sendability for current raw commands', () => {
-      const validator = vi.fn(({ commandArgsText }) =>
+      const validator = vi.fn(({ command, commandArgsText }) =>
         commandArgsText.length > 0
           ? undefined
           : {
+              command,
               metadata: { expected: 'args' },
               ready: false as const,
               reason: 'missing_args',
@@ -862,7 +899,7 @@ describe('MessageComposer', () => {
       const { messageComposer } = setup({
         config: {
           commands: {
-            validators: [validator],
+            sendValidators: [validator],
           },
         },
       });
@@ -870,16 +907,12 @@ describe('MessageComposer', () => {
       vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
         commands: [{ name: 'custom', description: 'Custom command' }],
       });
+      const customCommand = { description: 'Custom command', name: 'custom' };
 
-      expect(messageComposer.getCurrentCommand('/custom')).toEqual(
-        expect.objectContaining({ name: 'custom' }),
-      );
       expect(
-        messageComposer.getCommandSendability(
-          messageComposer.getCurrentCommand('/custom')!,
-          '/custom',
-        ),
+        messageComposer.validateCommandSendability(customCommand, '/custom'),
       ).toEqual({
+        command: customCommand,
         metadata: { expected: 'args' },
         ready: false,
         reason: 'missing_args',
@@ -887,15 +920,15 @@ describe('MessageComposer', () => {
     });
 
     it('should allow overriding default command validators via config', () => {
-      const validator = vi.fn(({ mentionedUsersInText }) =>
+      const validator = vi.fn(({ command, mentionedUsersInText }) =>
         mentionedUsersInText.length > 0
-          ? { ready: true as const }
-          : { ready: false as const, reason: 'missing_user' as const },
+          ? { command, ready: true as const }
+          : { command, ready: false as const, reason: 'missing_user' as const },
       );
       const { messageComposer } = setup({
         config: {
           commands: {
-            validators: [validator],
+            sendValidators: [validator],
           },
         },
       });
@@ -904,17 +937,21 @@ describe('MessageComposer', () => {
         commands: [{ name: 'ban', description: 'Ban a user' }],
       });
       messageComposer.textComposer.state.partialNext({
+        command: { description: 'Ban a user', name: 'ban' },
         mentionedUsers: [{ id: 'target-user', name: 'Target User' }],
         selection: { start: 16, end: 16 },
         text: '/ban @target-user',
       });
 
       expect(
-        messageComposer.getCommandSendability(
-          messageComposer.getCurrentCommand('/ban @target-user')!,
+        messageComposer.validateCommandSendability(
+          messageComposer.textComposer.command!,
           '/ban @target-user',
         ),
-      ).toEqual({ ready: true });
+      ).toEqual({
+        command: messageComposer.textComposer.command!,
+        ready: true,
+      });
       expect(validator).toHaveBeenCalledWith(
         expect.objectContaining({
           command: expect.objectContaining({ name: 'ban' }),
@@ -922,6 +959,36 @@ describe('MessageComposer', () => {
           rawText: '/ban @target-user',
         }),
       );
+    });
+
+    it('should resolve raw commands from the registered command source', () => {
+      const validator = vi.fn(({ command, commandArgsText }) =>
+        commandArgsText.length > 0
+          ? undefined
+          : { command, ready: false as const, reason: 'missing_args' as const },
+      );
+      const { messageComposer } = setup({
+        config: {
+          commands: {
+            sendValidators: [validator],
+          },
+        },
+      });
+      const customSearchSource = new CommandSearchSource(messageComposer.channel);
+      vi.spyOn(customSearchSource, 'query').mockReturnValue({
+        items: [{ description: 'Custom command', id: 'custom', name: 'custom' }],
+        next: null,
+      });
+      const customCommand = getCommandByName(customSearchSource, 'custom');
+
+      expect(customCommand).toEqual(expect.objectContaining({ name: 'custom' }));
+      expect(
+        messageComposer.validateCommandSendability(customCommand!, '/custom'),
+      ).toEqual({
+        command: customCommand!,
+        ready: false,
+        reason: 'missing_args',
+      });
     });
 
     it('should register subscriptions', () => {

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -261,7 +261,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     const { messageComposer, validationMiddleware } = setupMiddleware({
       config: {
         commands: {
-          sendValidators: [validator],
+          sendValidator: validator,
         },
       },
     });
@@ -302,7 +302,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     const { messageComposer, commandSearchSource } = setupMiddleware({
       config: {
         commands: {
-          sendValidators: [validator],
+          sendValidator: validator,
         },
       },
     });
@@ -338,7 +338,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     const { messageComposer } = setupMiddleware({
       config: {
         commands: {
-          sendValidators: [validator],
+          sendValidator: validator,
         },
       },
     });

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -281,6 +281,56 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     );
   });
 
+  it('should discard ban commands without a reason by default', async () => {
+    const { messageComposer, validationMiddleware } = setupMiddleware();
+    vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+      commands: [{ name: 'ban', description: 'Ban a user' }],
+    });
+    vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue('/ban @user1');
+    vi.spyOn(messageComposer.textComposer, 'mentionedUsers', 'get').mockReturnValue([
+      { id: 'user1', name: 'User One' },
+    ]);
+    const addWarningSpy = vi.spyOn(messageComposer.client.notifications, 'addWarning');
+
+    const result = await validationMiddleware.handlers.compose(
+      setupMiddlewareInputs(setupCompositionState('/ban @user1')),
+    );
+
+    expect(result.status).toBe('discard');
+    expect(addWarningSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          metadata: expect.objectContaining({
+            command: 'ban',
+            reason: 'missing_reason',
+          }),
+          type: 'validation:command:not-ready',
+        }),
+      }),
+    );
+  });
+
+  it('should allow ban commands with mention and reason by default', async () => {
+    const { messageComposer, validationMiddleware } = setupMiddleware();
+    vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+      commands: [{ name: 'ban', description: 'Ban a user' }],
+    });
+    vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue(
+      '/ban @user1 rude behavior',
+    );
+    vi.spyOn(messageComposer.textComposer, 'mentionedUsers', 'get').mockReturnValue([
+      { id: 'user1', name: 'User One' },
+    ]);
+    const addWarningSpy = vi.spyOn(messageComposer.client.notifications, 'addWarning');
+
+    const result = await validationMiddleware.handlers.compose(
+      setupMiddlewareInputs(setupCompositionState('/ban @user1 rude behavior')),
+    );
+
+    expect(result.status).toBeUndefined();
+    expect(addWarningSpy).not.toHaveBeenCalled();
+  });
+
   it('should allow raw known commands if command is not disabled', async () => {
     const { messageComposer, validationMiddleware } = setupMiddleware();
     vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -380,7 +380,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
         options: expect.objectContaining({
           metadata: expect.objectContaining({
             command: 'ban',
-            reason: 'missing_reason',
+            reason: 'missing-ban-reason',
           }),
           type: 'validation:command:not-ready',
         }),
@@ -431,7 +431,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
           options: expect.objectContaining({
             metadata: expect.objectContaining({
               command: commandName,
-              reason: 'missing_mention',
+              reason: 'missing-mention',
             }),
             type: 'validation:command:not-ready',
           }),

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Channel } from '../../../../../src/channel';
 import { StreamChat } from '../../../../../src/client';
+import type { MessageComposerConfig } from '../../../../../src/messageComposer';
 import { MessageComposer } from '../../../../../src/messageComposer/messageComposer';
 import {
   createCompositionValidationMiddleware,
@@ -14,10 +15,15 @@ import { MiddlewareStatus } from '../../../../../src/middleware';
 import { MessageComposerMiddlewareState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
 import { MessageDraftComposerMiddlewareValueState } from '../../../../../src/messageComposer/middleware/messageComposer/types';
 import { LocalMessage, MessageResponse } from '../../../../../src';
+import type { DeepPartial } from '../../../../../src/types.utility';
 import { generateChannel } from '../../../test-utils/generateChannel';
 
 const setupMiddleware = (
-  custom: { composer?: MessageComposer; editedMessage?: MessageResponse } = {},
+  custom: {
+    composer?: MessageComposer;
+    config?: DeepPartial<MessageComposerConfig>;
+    editedMessage?: MessageResponse;
+  } = {},
 ) => {
   const user = { id: 'user' };
   const client = new StreamChat('apiKey');
@@ -36,6 +42,7 @@ const setupMiddleware = (
     new MessageComposer({
       client,
       compositionContext: channel,
+      config: custom.config,
       composition: custom.editedMessage,
     });
 
@@ -228,6 +235,47 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
             command: 'ban',
             reason: 'quoted_message',
           },
+        }),
+      }),
+    );
+  });
+
+  it('should discard commands that are not ready to send', async () => {
+    const validator = vi.fn(({ mentionedUsersInText }) =>
+      mentionedUsersInText.length > 0
+        ? undefined
+        : {
+            metadata: { source: 'test-validator' },
+            ready: false as const,
+            reason: 'missing_user' as const,
+          },
+    );
+    const { messageComposer, validationMiddleware } = setupMiddleware({
+      config: {
+        commands: {
+          validators: [validator],
+        },
+      },
+    });
+    vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+      commands: [{ name: 'ban', description: 'Ban a user' }],
+    });
+    const addWarningSpy = vi.spyOn(messageComposer.client.notifications, 'addWarning');
+
+    const result = await validationMiddleware.handlers.compose(
+      setupMiddlewareInputs(setupCompositionState('/ban')),
+    );
+
+    expect(result.status).toBe('discard');
+    expect(addWarningSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          metadata: expect.objectContaining({
+            command: 'ban',
+            reason: 'missing_user',
+            source: 'test-validator',
+          }),
+          type: 'validation:command:not-ready',
         }),
       }),
     );

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -7,6 +7,7 @@ import {
   createCompositionValidationMiddleware,
   createDraftCompositionValidationMiddleware,
 } from '../../../../../src/messageComposer/middleware/messageComposer/compositionValidation';
+import { CommandSearchSource } from '../../../../../src/messageComposer/middleware/textComposer/commands';
 import {
   AttachmentLoadingState,
   LocalImageAttachment,
@@ -46,9 +47,15 @@ const setupMiddleware = (
       composition: custom.editedMessage,
     });
 
+  const commandSearchSource = new CommandSearchSource(messageComposer.channel);
+
   return {
+    commandSearchSource,
     messageComposer,
-    validationMiddleware: createCompositionValidationMiddleware(messageComposer),
+    validationMiddleware: createCompositionValidationMiddleware(
+      messageComposer,
+      commandSearchSource,
+    ),
   };
 };
 
@@ -241,10 +248,11 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
   });
 
   it('should discard commands that are not ready to send', async () => {
-    const validator = vi.fn(({ mentionedUsersInText }) =>
+    const validator = vi.fn(({ command, mentionedUsersInText }) =>
       mentionedUsersInText.length > 0
         ? undefined
         : {
+            command,
             metadata: { source: 'test-validator' },
             ready: false as const,
             reason: 'missing_user' as const,
@@ -253,7 +261,7 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
     const { messageComposer, validationMiddleware } = setupMiddleware({
       config: {
         commands: {
-          validators: [validator],
+          sendValidators: [validator],
         },
       },
     });
@@ -277,6 +285,76 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
           }),
           type: 'validation:command:not-ready',
         }),
+      }),
+    );
+  });
+
+  it('should resolve raw commands through the provided command search source', async () => {
+    const validator = vi.fn(({ command }) =>
+      command.name === 'custom'
+        ? {
+            command,
+            ready: false as const,
+            reason: 'missing_args' as const,
+          }
+        : undefined,
+    );
+    const { messageComposer, commandSearchSource } = setupMiddleware({
+      config: {
+        commands: {
+          sendValidators: [validator],
+        },
+      },
+    });
+    vi.spyOn(commandSearchSource, 'query').mockReturnValue({
+      items: [{ description: 'Custom command', id: 'custom', name: 'custom' }],
+      next: null,
+    });
+
+    const result = await createCompositionValidationMiddleware(
+      messageComposer,
+      commandSearchSource,
+    ).handlers.compose(setupMiddlewareInputs(setupCompositionState('/custom')));
+
+    expect(result.status).toBe('discard');
+    expect(validator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.objectContaining({ name: 'custom' }),
+        rawText: '/custom',
+      }),
+    );
+  });
+
+  it('should initialize a default command search source when none is provided', async () => {
+    const validator = vi.fn(({ command }) =>
+      command.name === 'custom'
+        ? {
+            command,
+            ready: false as const,
+            reason: 'missing_args' as const,
+          }
+        : undefined,
+    );
+    const { messageComposer } = setupMiddleware({
+      config: {
+        commands: {
+          sendValidators: [validator],
+        },
+      },
+    });
+    vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+      commands: [{ name: 'custom', description: 'Custom command' }],
+    });
+
+    const result = await createCompositionValidationMiddleware(
+      messageComposer,
+    ).handlers.compose(setupMiddlewareInputs(setupCompositionState('/custom')));
+
+    expect(result.status).toBe('discard');
+    expect(validator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: expect.objectContaining({ name: 'custom' }),
+        rawText: '/custom',
       }),
     );
   });
@@ -329,6 +407,37 @@ describe('stream-io/message-composer-middleware/data-validation', () => {
 
     expect(result.status).toBeUndefined();
     expect(addWarningSpy).not.toHaveBeenCalled();
+  });
+
+  it('should discard mute, unmute and unban commands without a mention by default', async () => {
+    for (const commandName of ['mute', 'unmute', 'unban'] as const) {
+      const { messageComposer, validationMiddleware } = setupMiddleware();
+      vi.spyOn(messageComposer.channel, 'getConfig').mockReturnValue({
+        commands: [{ name: commandName, description: `${commandName} a user` }],
+      });
+      vi.spyOn(messageComposer.textComposer, 'text', 'get').mockReturnValue(
+        `/${commandName}`,
+      );
+      vi.spyOn(messageComposer.textComposer, 'mentionedUsers', 'get').mockReturnValue([]);
+      const addWarningSpy = vi.spyOn(messageComposer.client.notifications, 'addWarning');
+
+      const result = await validationMiddleware.handlers.compose(
+        setupMiddlewareInputs(setupCompositionState(`/${commandName}`)),
+      );
+
+      expect(result.status).toBe('discard');
+      expect(addWarningSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: expect.objectContaining({
+            metadata: expect.objectContaining({
+              command: commandName,
+              reason: 'missing_mention',
+            }),
+            type: 'validation:command:not-ready',
+          }),
+        }),
+      );
+    }
   });
 
   it('should allow raw known commands if command is not disabled', async () => {

--- a/test/unit/MessageComposer/middleware/textComposer/TextComposerMiddlewareExecutor.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/TextComposerMiddlewareExecutor.test.ts
@@ -193,6 +193,31 @@ describe('TextComposerMiddlewareExecutor', () => {
     expect(textComposer.mentionedUsers).toContainEqual(selectedSuggestion);
   });
 
+  it('should prune stale mentions on change', async () => {
+    const {
+      messageComposer: { textComposer },
+    } = setup();
+    await textComposer.handleChange({
+      text: '@jo',
+      selection: { start: 3, end: 3 },
+    });
+
+    const selectedSuggestion = {
+      id: 'user1',
+      name: 'John Doe',
+    } as TextComposerSuggestion<UserResponse>;
+
+    await textComposer.handleSelect(selectedSuggestion);
+    expect(textComposer.mentionedUsers).toContainEqual(selectedSuggestion);
+
+    await textComposer.handleChange({
+      text: '',
+      selection: { start: 0, end: 0 },
+    });
+
+    expect(textComposer.mentionedUsers).toEqual([]);
+  });
+
   it('should handle suggestion selection with commands', async () => {
     const {
       messageComposer: { textComposer },


### PR DESCRIPTION
## Goal

Closes REACT-971

Add API that allows to verify, whether the message composer in command mode has state ready to be composed and sent to the server.

This are the rules:

- **ban** - requires mention and additional text in order the `MessageComposer.isCommandSendable` returns `true`
- **unban** - requires mention in order the `MessageComposer.isCommandSendable` returns `true`
- **mute** - requires mention in order the `MessageComposer.isCommandSendable` returns `true`
- **unmute** - requires mention in order the `MessageComposer.isCommandSendable` returns `true`

It is possible to provide custom command sendability validation function(s) in case the integrators have custom commands and want to apply custom validation rules.

**Mentioned users state kept up-to-date on text change**
Make sure that the mentioned users array in text composer state is not stale. Until now, this was verified only at the composition time. Now we prune stale user mentions on every text change middleware execution.
