### PR TITLE
fix: channels sorting with predefined filters

### DIFF
--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -1,10 +1,11 @@
-import type { StreamChat } from './client';
+import type { QueryChannelsResponseWithChannels, StreamChat } from './client';
 import type {
   ChannelFilters,
   ChannelOptions,
   ChannelSort,
   ChannelStateOptions,
   Event,
+  QueryChannelsAPIResponse,
 } from './types';
 import type { ValueOrPatch } from './store';
 import { isPatch, StateStore } from './store';
@@ -33,6 +34,8 @@ export type ChannelManagerPagination = {
   hasNext: boolean;
   isLoading: boolean;
   isLoadingNext: boolean;
+  mutationFilters?: ChannelFilters;
+  mutationSort?: ChannelSort;
   options: ChannelOptions;
   sort: ChannelSort;
 };
@@ -133,9 +136,14 @@ export type ChannelManagerOptions = {
   lockChannelOrder?: boolean;
 };
 
+export type QueryChannelsRequestOutput = Channel[] | QueryChannelsResponseWithChannels;
+
 export type QueryChannelsRequestType = (
-  ...params: Parameters<StreamChat['queryChannels']>
-) => Promise<Channel[]>;
+  filters: ChannelFilters,
+  sort?: ChannelSort,
+  options?: ChannelOptions,
+  stateOptions?: ChannelStateOptions,
+) => Promise<QueryChannelsRequestOutput>;
 
 export const DEFAULT_CHANNEL_MANAGER_OPTIONS = {
   abortInFlightQuery: false,
@@ -151,6 +159,54 @@ export const DEFAULT_CHANNEL_MANAGER_OPTIONS = {
 export const DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS = {
   offset: 0,
 };
+
+const mapPredefinedFilterSortToChannelSort = (
+  sort: NonNullable<QueryChannelsAPIResponse['predefined_filter']>['sort'],
+): ChannelSort =>
+  (sort ?? []).map(({ direction = 1, field }) => ({
+    [field]: direction,
+  })) as ChannelSort;
+
+const getMutationPaginationParams = ({
+  queryChannelsResponse,
+  sort,
+}: {
+  queryChannelsResponse?: Pick<QueryChannelsAPIResponse, 'predefined_filter'>;
+  sort: ChannelSort;
+}): Pick<ChannelManagerPagination, 'mutationFilters' | 'mutationSort'> => {
+  const predefinedFilter = queryChannelsResponse?.predefined_filter;
+
+  if (!predefinedFilter) {
+    return {};
+  }
+
+  return {
+    mutationFilters: predefinedFilter.filter as ChannelFilters,
+    mutationSort:
+      predefinedFilter.sort !== undefined
+        ? mapPredefinedFilterSortToChannelSort(predefinedFilter.sort)
+        : sort,
+  };
+};
+
+const getMutationFiltersAndSort = (
+  pagination: ChannelManagerPagination,
+): Pick<ChannelManagerPagination, 'filters' | 'sort'> => ({
+  filters: pagination.mutationFilters ?? pagination.filters,
+  sort: pagination.mutationSort ?? pagination.sort,
+});
+
+const omitMutationPaginationParams = (pagination: ChannelManagerPagination) => {
+  const paginationWithoutMutationParams = { ...pagination };
+  delete paginationWithoutMutationParams.mutationFilters;
+  delete paginationWithoutMutationParams.mutationSort;
+
+  return paginationWithoutMutationParams;
+};
+
+const isQueryChannelsResponseWithChannels = (
+  response: QueryChannelsRequestOutput,
+): response is QueryChannelsResponseWithChannels => !Array.isArray(response);
 
 /**
  * A class that manages a list of channels and changes it based on configuration and WS events. The
@@ -279,23 +335,34 @@ export class ChannelManager extends WithSubscriptions {
       ...options,
     };
     try {
-      const channels = await this.queryChannelsRequest(
+      const queryChannelsResponse = await this.queryChannelsRequest(
         filters,
         sort,
         options,
-        stateOptions,
+        { ...stateOptions, withResponse: true },
       );
+      const channels = isQueryChannelsResponseWithChannels(queryChannelsResponse)
+        ? queryChannelsResponse.channels
+        : queryChannelsResponse;
       const newOffset = offset + (channels?.length ?? 0);
       const newOptions = { ...options, offset: newOffset };
       const { pagination } = this.state.getLatestValue();
+      const mutationPaginationParams = getMutationPaginationParams({
+        queryChannelsResponse: isQueryChannelsResponseWithChannels(queryChannelsResponse)
+          ? queryChannelsResponse
+          : undefined,
+        sort,
+      });
+      const paginationWithoutMutationParams = omitMutationPaginationParams(pagination);
 
       this.state.partialNext({
         channels,
         pagination: {
-          ...pagination,
+          ...paginationWithoutMutationParams,
           hasNext: (channels?.length ?? 0) >= (limit ?? 1),
           isLoading: false,
           options: newOptions,
+          ...mutationPaginationParams,
         },
         initialized: true,
         error: undefined,
@@ -368,7 +435,7 @@ export class ChannelManager extends WithSubscriptions {
       this.state.next((currentState) => ({
         ...currentState,
         pagination: {
-          ...currentState.pagination,
+          ...omitMutationPaginationParams(currentState.pagination),
           isLoading: true,
           isLoadingNext: false,
           filters,
@@ -434,12 +501,15 @@ export class ChannelManager extends WithSubscriptions {
       this.state.partialNext({
         pagination: { ...pagination, isLoading: false, isLoadingNext: true },
       });
-      const nextChannels = await this.queryChannelsRequest(
+      const queryChannelsResponse = await this.queryChannelsRequest(
         filters,
         sort,
         options,
         this.stateOptions,
       );
+      const nextChannels = isQueryChannelsResponseWithChannels(queryChannelsResponse)
+        ? queryChannelsResponse.channels
+        : queryChannelsResponse;
       const { channels } = this.state.getLatestValue();
       const newOffset = offset + (nextChannels?.length ?? 0);
       const newOptions = { ...options, offset: newOffset };
@@ -498,7 +568,7 @@ export class ChannelManager extends WithSubscriptions {
       return;
     }
 
-    const { sort } = pagination ?? {};
+    const { sort } = getMutationFiltersAndSort(pagination);
 
     this.setChannels(
       promoteChannel({
@@ -535,7 +605,7 @@ export class ChannelManager extends WithSubscriptions {
     if (!channels) {
       return;
     }
-    const { filters, sort } = pagination ?? {};
+    const { filters, sort } = getMutationFiltersAndSort(pagination);
 
     const channelType = event.channel_type;
     const channelId = event.channel_id;
@@ -594,7 +664,7 @@ export class ChannelManager extends WithSubscriptions {
     });
 
     const { channels, pagination } = this.state.getLatestValue();
-    const { filters, sort } = pagination ?? {};
+    const { filters, sort } = getMutationFiltersAndSort(pagination);
 
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
@@ -631,7 +701,7 @@ export class ChannelManager extends WithSubscriptions {
     });
 
     const { channels, pagination } = this.state.getLatestValue();
-    const { sort, filters } = pagination ?? {};
+    const { filters, sort } = getMutationFiltersAndSort(pagination);
 
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
@@ -658,7 +728,7 @@ export class ChannelManager extends WithSubscriptions {
 
   private memberUpdatedHandler = (event: Event) => {
     const { pagination, channels } = this.state.getLatestValue();
-    const { filters, sort } = pagination;
+    const { filters, sort } = getMutationFiltersAndSort(pagination);
     if (
       !event.member?.user ||
       event.member.user.id !== this.client.userID ||

--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -358,6 +358,11 @@ export class ChannelManager extends WithSubscriptions {
       this.state.partialNext({
         channels,
         pagination: {
+          // Drop response derived filter/sort from the previous query before applying
+          // the current response. Non predefined queries do not return this metadata,
+          // so keeping the old values would make later WS mutations use stale
+          // predefined filter semantics. Also the predefined_filter might change, producing
+          // a different combination as well so we always need to first clean up.
           ...paginationWithoutResponseParams,
           hasNext: (channels?.length ?? 0) >= (limit ?? 1),
           isLoading: false,

--- a/src/channel_manager.ts
+++ b/src/channel_manager.ts
@@ -34,9 +34,9 @@ export type ChannelManagerPagination = {
   hasNext: boolean;
   isLoading: boolean;
   isLoadingNext: boolean;
-  mutationFilters?: ChannelFilters;
-  mutationSort?: ChannelSort;
   options: ChannelOptions;
+  responseFilters?: ChannelFilters;
+  responseSort?: ChannelSort;
   sort: ChannelSort;
 };
 
@@ -167,13 +167,13 @@ const mapPredefinedFilterSortToChannelSort = (
     [field]: direction,
   })) as ChannelSort;
 
-const getMutationPaginationParams = ({
+const getResponsePaginationParams = ({
   queryChannelsResponse,
   sort,
 }: {
   queryChannelsResponse?: Pick<QueryChannelsAPIResponse, 'predefined_filter'>;
   sort: ChannelSort;
-}): Pick<ChannelManagerPagination, 'mutationFilters' | 'mutationSort'> => {
+}): Pick<ChannelManagerPagination, 'responseFilters' | 'responseSort'> => {
   const predefinedFilter = queryChannelsResponse?.predefined_filter;
 
   if (!predefinedFilter) {
@@ -181,27 +181,27 @@ const getMutationPaginationParams = ({
   }
 
   return {
-    mutationFilters: predefinedFilter.filter as ChannelFilters,
-    mutationSort:
+    responseFilters: predefinedFilter.filter as ChannelFilters,
+    responseSort:
       predefinedFilter.sort !== undefined
         ? mapPredefinedFilterSortToChannelSort(predefinedFilter.sort)
         : sort,
   };
 };
 
-const getMutationFiltersAndSort = (
+const getResponseFiltersAndSort = (
   pagination: ChannelManagerPagination,
 ): Pick<ChannelManagerPagination, 'filters' | 'sort'> => ({
-  filters: pagination.mutationFilters ?? pagination.filters,
-  sort: pagination.mutationSort ?? pagination.sort,
+  filters: pagination.responseFilters ?? pagination.filters,
+  sort: pagination.responseSort ?? pagination.sort,
 });
 
-const omitMutationPaginationParams = (pagination: ChannelManagerPagination) => {
-  const paginationWithoutMutationParams = { ...pagination };
-  delete paginationWithoutMutationParams.mutationFilters;
-  delete paginationWithoutMutationParams.mutationSort;
+const omitResponsePaginationParams = (pagination: ChannelManagerPagination) => {
+  const paginationWithoutResponseParams = { ...pagination };
+  delete paginationWithoutResponseParams.responseFilters;
+  delete paginationWithoutResponseParams.responseSort;
 
-  return paginationWithoutMutationParams;
+  return paginationWithoutResponseParams;
 };
 
 const isQueryChannelsResponseWithChannels = (
@@ -347,22 +347,22 @@ export class ChannelManager extends WithSubscriptions {
       const newOffset = offset + (channels?.length ?? 0);
       const newOptions = { ...options, offset: newOffset };
       const { pagination } = this.state.getLatestValue();
-      const mutationPaginationParams = getMutationPaginationParams({
+      const responsePaginationParams = getResponsePaginationParams({
         queryChannelsResponse: isQueryChannelsResponseWithChannels(queryChannelsResponse)
           ? queryChannelsResponse
           : undefined,
         sort,
       });
-      const paginationWithoutMutationParams = omitMutationPaginationParams(pagination);
+      const paginationWithoutResponseParams = omitResponsePaginationParams(pagination);
 
       this.state.partialNext({
         channels,
         pagination: {
-          ...paginationWithoutMutationParams,
+          ...paginationWithoutResponseParams,
           hasNext: (channels?.length ?? 0) >= (limit ?? 1),
           isLoading: false,
           options: newOptions,
-          ...mutationPaginationParams,
+          ...responsePaginationParams,
         },
         initialized: true,
         error: undefined,
@@ -435,7 +435,7 @@ export class ChannelManager extends WithSubscriptions {
       this.state.next((currentState) => ({
         ...currentState,
         pagination: {
-          ...omitMutationPaginationParams(currentState.pagination),
+          ...omitResponsePaginationParams(currentState.pagination),
           isLoading: true,
           isLoadingNext: false,
           filters,
@@ -568,7 +568,7 @@ export class ChannelManager extends WithSubscriptions {
       return;
     }
 
-    const { sort } = getMutationFiltersAndSort(pagination);
+    const { sort } = getResponseFiltersAndSort(pagination);
 
     this.setChannels(
       promoteChannel({
@@ -605,7 +605,7 @@ export class ChannelManager extends WithSubscriptions {
     if (!channels) {
       return;
     }
-    const { filters, sort } = getMutationFiltersAndSort(pagination);
+    const { filters, sort } = getResponseFiltersAndSort(pagination);
 
     const channelType = event.channel_type;
     const channelId = event.channel_id;
@@ -664,7 +664,7 @@ export class ChannelManager extends WithSubscriptions {
     });
 
     const { channels, pagination } = this.state.getLatestValue();
-    const { filters, sort } = getMutationFiltersAndSort(pagination);
+    const { filters, sort } = getResponseFiltersAndSort(pagination);
 
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
@@ -701,7 +701,7 @@ export class ChannelManager extends WithSubscriptions {
     });
 
     const { channels, pagination } = this.state.getLatestValue();
-    const { filters, sort } = getMutationFiltersAndSort(pagination);
+    const { filters, sort } = getResponseFiltersAndSort(pagination);
 
     const considerArchivedChannels = shouldConsiderArchivedChannels(filters);
     const isTargetChannelArchived = isChannelArchived(channel);
@@ -728,7 +728,7 @@ export class ChannelManager extends WithSubscriptions {
 
   private memberUpdatedHandler = (event: Event) => {
     const { pagination, channels } = this.state.getLatestValue();
-    const { filters, sort } = getMutationFiltersAndSort(pagination);
+    const { filters, sort } = getResponseFiltersAndSort(pagination);
     if (
       !event.member?.user ||
       event.member.user.id !== this.client.userID ||

--- a/src/client.ts
+++ b/src/client.ts
@@ -281,6 +281,13 @@ function isString(x: unknown): x is string {
 
 type MessageComposerTearDownFunction = () => void;
 
+export type QueryChannelsResponseWithChannels = Omit<
+  QueryChannelsAPIResponse,
+  'channels'
+> & {
+  channels: Channel[];
+};
+
 type MessageComposerSetupFunction = ({
   composer,
 }: {
@@ -1888,20 +1895,20 @@ export class StreamChat {
   }
 
   /**
-   * queryChannelsRequest - Queries channels and returns the raw response
+   * queryChannelsRequestWithResponse - Queries channels and returns the full API response
    *
    * @param {ChannelFilters} filterConditions object MongoDB style filters. Can be empty object when using predefined_filter in options.
    * @param {ChannelSort} [sort] Sort options, for instance {created_at: -1}.
    * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_updated: -1}, {created_at: 1}]
    * @param {ChannelOptions} [options] Options object. Can include predefined_filter, filter_values, and sort_values for using predefined filters.
    *
-   * @return {Promise<Array<ChannelAPIResponse>>} search channels response
+   * @return {Promise<QueryChannelsAPIResponse>} full search channels response
    */
-  async queryChannelsRequest(
+  async queryChannelsRequestWithResponse(
     filterConditions: ChannelFilters,
     sort: ChannelSort = [],
     options: ChannelOptions = {},
-  ) {
+  ): Promise<QueryChannelsAPIResponse> {
     const defaultOptions: ChannelOptions = {
       state: true,
       watch: true,
@@ -1934,9 +1941,28 @@ export class StreamChat {
           ...restOptions,
         };
 
-    const data = await this.post<QueryChannelsAPIResponse>(
-      this.baseURL + '/channels',
-      payload,
+    return await this.post<QueryChannelsAPIResponse>(this.baseURL + '/channels', payload);
+  }
+
+  /**
+   * queryChannelsRequest - Queries channels and returns the raw channel response list.
+   *
+   * @param {ChannelFilters} filterConditions object MongoDB style filters. Can be empty object when using predefined_filter in options.
+   * @param {ChannelSort} [sort] Sort options, for instance {created_at: -1}.
+   * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_updated: -1}, {created_at: 1}]
+   * @param {ChannelOptions} [options] Options object. Can include predefined_filter, filter_values, and sort_values for using predefined filters.
+   *
+   * @return {Promise<Array<ChannelAPIResponse>>} search channels response
+   */
+  async queryChannelsRequest(
+    filterConditions: ChannelFilters,
+    sort: ChannelSort = [],
+    options: ChannelOptions = {},
+  ) {
+    const data = await this.queryChannelsRequestWithResponse(
+      filterConditions,
+      sort,
+      options,
     );
 
     // FIXME: In the next major release, return the full QueryChannelsAPIResponse
@@ -1960,11 +1986,28 @@ export class StreamChat {
    */
   async queryChannels(
     filterConditions: ChannelFilters,
+    sort: ChannelSort,
+    options: ChannelOptions,
+    stateOptions: ChannelStateOptions & { withResponse: true },
+  ): Promise<QueryChannelsResponseWithChannels>;
+  async queryChannels(
+    filterConditions?: ChannelFilters,
+    sort?: ChannelSort,
+    options?: ChannelOptions,
+    stateOptions?: ChannelStateOptions,
+  ): Promise<Channel[]>;
+  async queryChannels(
+    filterConditions: ChannelFilters,
     sort: ChannelSort = [],
     options: ChannelOptions = {},
     stateOptions: ChannelStateOptions = {},
-  ) {
-    const channels = await this.queryChannelsRequest(filterConditions, sort, options);
+  ): Promise<Channel[] | QueryChannelsResponseWithChannels> {
+    const queryChannelsResponse = await this.queryChannelsRequestWithResponse(
+      filterConditions,
+      sort,
+      options,
+    );
+    const channels = queryChannelsResponse.channels;
 
     this.dispatchEvent({
       type: 'channels.queried',
@@ -1980,7 +2023,16 @@ export class StreamChat {
       });
     }
 
-    return this.hydrateActiveChannels(channels, stateOptions, options);
+    const hydratedChannels = this.hydrateActiveChannels(channels, stateOptions, options);
+
+    if (stateOptions.withResponse) {
+      return {
+        ...queryChannelsResponse,
+        channels: hydratedChannels,
+      };
+    }
+
+    return hydratedChannels;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -1896,6 +1896,12 @@ export class StreamChat {
 
   /**
    * queryChannelsRequestWithResponse - Queries channels and returns the full API response
+   * including top-level metadata such as `predefined_filter`.
+   *
+   * This exists as a compatibility bridge, as changing `queryChannelsRequest()` to return
+   * `QueryChannelsAPIResponse` would be a breaking change because it currently returns
+   * only the channel list. In the next major release, the request/response APIs should
+   * be consolidated so callers can access the full response through the primary API.
    *
    * @param {ChannelFilters} filterConditions object MongoDB style filters. Can be empty object when using predefined_filter in options.
    * @param {ChannelSort} [sort] Sort options, for instance {created_at: -1}.
@@ -1947,6 +1953,11 @@ export class StreamChat {
   /**
    * queryChannelsRequest - Queries channels and returns the raw channel response list.
    *
+   * This preserves the historical return shape for backwards compatibility. Use
+   * `queryChannelsRequestWithResponse()` when response level metadata such as
+   * `predefined_filter` is needed. In the next major release these APIs should be
+   * consolidated into a single full-response API.
+   *
    * @param {ChannelFilters} filterConditions object MongoDB style filters. Can be empty object when using predefined_filter in options.
    * @param {ChannelSort} [sort] Sort options, for instance {created_at: -1}.
    * When using multiple fields, make sure you use array of objects to guarantee field order, for instance [{last_updated: -1}, {created_at: 1}]
@@ -1981,6 +1992,7 @@ export class StreamChat {
    * @param {ChannelStateOptions} [stateOptions] State options object. These options will only be used for state management and won't be sent in the request.
    * - stateOptions.skipInitialization - Skips the initialization of the state for the channels matching the ids in the list.
    * - stateOptions.skipHydration - Skips returning the channels as instances of the Channel class and rather returns the raw query response.
+   * - stateOptions.withResponse - Returns the full query response with hydrated channels. This is a compatibility bridge for internal callers that need response-level metadata while the default return value remains `Channel[]`.
    *
    * @return {Promise<Array<Channel>>} search channels response
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1111,6 +1111,7 @@ export type ChannelStateOptions = {
   offlineMode?: boolean;
   skipInitialization?: string[];
   skipHydration?: boolean;
+  withResponse?: boolean;
 };
 
 export type CreateChannelOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1111,6 +1111,14 @@ export type ChannelStateOptions = {
   offlineMode?: boolean;
   skipInitialization?: string[];
   skipHydration?: boolean;
+  /**
+   * Returns the full query response with hydrated channels from `queryChannels()`.
+   *
+   * This is a compatibility bridge for internal callers that need response level
+   * metadata such as `predefined_filter`. The default `queryChannels()` return value
+   * remains `Channel[]` to avoid a breaking change. This should be folded into a
+   * single full response API in the next major release.
+   */
   withResponse?: boolean;
 };
 

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -1535,7 +1535,7 @@ describe('ChannelManager', () => {
       sinon.reset();
     });
 
-    describe('predefined filter mutation metadata', () => {
+    describe('predefined filter response metadata', () => {
       it('does not promote an archived channel into a resolved non-archived list on message.new', async () => {
         await queryChannelsWithPredefinedFilterResponse({
           filter: { archived: false },
@@ -1674,7 +1674,7 @@ describe('ChannelManager', () => {
         ).to.deep.equal(['channel3', 'channel1', 'channel2']);
       });
 
-      it('keeps non-predefined query mutation behavior based on caller filters and sort', async () => {
+      it('keeps non-predefined query behavior based on caller filters and sort', async () => {
         vi.spyOn(client, 'post').mockResolvedValueOnce({
           duration: '0.01s',
           channels: channelsResponse,
@@ -1694,7 +1694,7 @@ describe('ChannelManager', () => {
         expect(setChannelsStub).toHaveBeenCalledTimes(0);
       });
 
-      it('preserves resolved predefined mutation metadata after loading the next page', async () => {
+      it('preserves resolved predefined response metadata after loading the next page', async () => {
         vi.spyOn(client, 'post')
           .mockResolvedValueOnce({
             duration: '0.01s',
@@ -1738,7 +1738,7 @@ describe('ChannelManager', () => {
         expect(setChannelsStub).toHaveBeenCalledTimes(0);
       });
 
-      it('clears resolved predefined mutation metadata when switching to a non-predefined query', async () => {
+      it('clears resolved predefined response metadata when switching to a non-predefined query', async () => {
         vi.spyOn(client, 'post')
           .mockResolvedValueOnce({
             duration: '0.01s',

--- a/test/unit/channel_manager.test.ts
+++ b/test/unit/channel_manager.test.ts
@@ -10,6 +10,7 @@ import {
   channelManagerEventToHandlerMapping,
   DEFAULT_CHANNEL_MANAGER_PAGINATION_OPTIONS,
   QueryChannelsRequestType,
+  QueryChannelsAPIResponse,
 } from '../../src';
 
 import { generateChannel } from './test-utils/generateChannel';
@@ -1477,6 +1478,41 @@ describe('ChannelManager', () => {
       (typeof utils)['findLastPinnedChannelIndex']
     >;
     let extractSortValueStub: MockInstance<(typeof utils)['extractSortValue']>;
+    const setChannelMembership = (
+      channelId: string,
+      membership: Record<string, unknown>,
+    ) => {
+      const channel = client.channel('messaging', channelId);
+      channel.state.membership = {
+        user: { id: client.userID },
+        user_id: client.userID,
+        ...membership,
+      } as never;
+
+      return channel;
+    };
+    const queryChannelsWithPredefinedFilterResponse = async ({
+      filter,
+      sort,
+    }: {
+      filter: Record<string, unknown>;
+      sort?: NonNullable<QueryChannelsAPIResponse['predefined_filter']>['sort'];
+    }) => {
+      vi.spyOn(client, 'post').mockResolvedValueOnce({
+        duration: '0.01s',
+        channels: channelsResponse,
+        predefined_filter: {
+          name: 'messaging_channels',
+          filter,
+          sort,
+        },
+      } satisfies QueryChannelsAPIResponse);
+
+      await channelManager.queryChannels({}, [], {
+        predefined_filter: 'messaging_channels',
+      });
+      setChannelsStub.mockClear();
+    };
 
     beforeEach(() => {
       setChannelsStub = vi.spyOn(channelManager, 'setChannels');
@@ -1497,6 +1533,247 @@ describe('ChannelManager', () => {
       vi.resetAllMocks();
       sinon.restore();
       sinon.reset();
+    });
+
+    describe('predefined filter mutation metadata', () => {
+      it('does not promote an archived channel into a resolved non-archived list on message.new', async () => {
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: { archived: false },
+        });
+        setChannelMembership('channel2', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not promote an unarchived channel into a resolved archived list on message.new', async () => {
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: { archived: true },
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not move a pinned channel when resolved predefined sort considers pinned_at', async () => {
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: {},
+          sort: [{ field: 'pinned_at', direction: -1 }],
+        });
+        setChannelMembership('channel2', {
+          pinned_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not promote an archived channel into a resolved non-archived list on notification.message_new', async () => {
+        const clock = sinon.useFakeTimers();
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: { archived: false },
+        });
+        const channel = setChannelMembership('channel4', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+        getAndWatchChannelStub.mockResolvedValueOnce(channel);
+
+        client.dispatchEvent({
+          type: 'notification.message_new',
+          channel: { type: 'messaging', id: 'channel4' } as unknown as ChannelResponse,
+        });
+
+        await clock.runAllAsync();
+        clock.restore();
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('does not add an archived channel into a resolved non-archived list on channel.visible', async () => {
+        const clock = sinon.useFakeTimers();
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: { archived: false },
+        });
+        const channel = setChannelMembership('channel4', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+        getAndWatchChannelStub.mockResolvedValueOnce(channel);
+
+        client.dispatchEvent({
+          type: 'channel.visible',
+          channel_id: 'channel4',
+          channel_type: 'messaging',
+        });
+
+        await clock.runAllAsync();
+        clock.restore();
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('uses resolved predefined filter metadata when handling member.updated archive changes', async () => {
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: { archived: false },
+        });
+        setChannelMembership('channel2', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'member.updated',
+          channel_id: 'channel2',
+          channel_type: 'messaging',
+          member: { user: { id: client.userID } },
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledOnce();
+        expect(
+          (setChannelsStub.mock.calls[0][0] as Channel[]).map((c) => c.id),
+        ).to.deep.equal(['channel1', 'channel3']);
+      });
+
+      it('uses resolved predefined sort metadata when handling member.updated pin changes', async () => {
+        await queryChannelsWithPredefinedFilterResponse({
+          filter: {},
+          sort: [{ field: 'pinned_at', direction: -1 }],
+        });
+        setChannelMembership('channel1', {
+          pinned_at: '2024-01-15T10:30:00Z',
+        });
+        setChannelMembership('channel3', {
+          pinned_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'member.updated',
+          channel_id: 'channel3',
+          channel_type: 'messaging',
+          member: { user: { id: client.userID } },
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledOnce();
+        expect(
+          (setChannelsStub.mock.calls[0][0] as Channel[]).map((c) => c.id),
+        ).to.deep.equal(['channel3', 'channel1', 'channel2']);
+      });
+
+      it('keeps non-predefined query mutation behavior based on caller filters and sort', async () => {
+        vi.spyOn(client, 'post').mockResolvedValueOnce({
+          duration: '0.01s',
+          channels: channelsResponse,
+        } satisfies QueryChannelsAPIResponse);
+        await channelManager.queryChannels({ archived: false }, [], { limit: 10 });
+        setChannelsStub.mockClear();
+        setChannelMembership('channel2', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('preserves resolved predefined mutation metadata after loading the next page', async () => {
+        vi.spyOn(client, 'post')
+          .mockResolvedValueOnce({
+            duration: '0.01s',
+            channels: channelsResponse,
+            predefined_filter: {
+              name: 'messaging_channels',
+              filter: { archived: false },
+              sort: [{ field: 'pinned_at', direction: -1 }],
+            },
+          } satisfies QueryChannelsAPIResponse)
+          .mockResolvedValueOnce({
+            duration: '0.01s',
+            channels: [
+              generateChannel({ channel: { id: 'channel4' } }),
+              generateChannel({ channel: { id: 'channel5' } }),
+            ],
+            predefined_filter: {
+              name: 'messaging_channels',
+              filter: { archived: false },
+              sort: [{ field: 'pinned_at', direction: -1 }],
+            },
+          } satisfies QueryChannelsAPIResponse);
+
+        await channelManager.queryChannels({}, [], {
+          predefined_filter: 'messaging_channels',
+          limit: 2,
+          offset: 0,
+        });
+        await channelManager.loadNext();
+        setChannelsStub.mockClear();
+        setChannelMembership('channel2', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledTimes(0);
+      });
+
+      it('clears resolved predefined mutation metadata when switching to a non-predefined query', async () => {
+        vi.spyOn(client, 'post')
+          .mockResolvedValueOnce({
+            duration: '0.01s',
+            channels: channelsResponse,
+            predefined_filter: {
+              name: 'messaging_channels',
+              filter: { archived: false },
+              sort: [{ field: 'pinned_at', direction: -1 }],
+            },
+          } satisfies QueryChannelsAPIResponse)
+          .mockResolvedValueOnce({
+            duration: '0.01s',
+            channels: channelsResponse,
+          } satisfies QueryChannelsAPIResponse);
+
+        await channelManager.queryChannels({}, [], {
+          predefined_filter: 'messaging_channels',
+        });
+        await channelManager.queryChannels({}, [], { limit: 10 });
+        setChannelsStub.mockClear();
+        setChannelMembership('channel2', {
+          archived_at: '2024-01-15T10:30:00Z',
+        });
+
+        client.dispatchEvent({
+          type: 'message.new',
+          channel_type: 'messaging',
+          channel_id: 'channel2',
+        });
+
+        expect(setChannelsStub).toHaveBeenCalledOnce();
+        expect(
+          (setChannelsStub.mock.calls[0][0] as Channel[]).map((c) => c.id),
+        ).to.deep.equal(['channel2', 'channel1', 'channel3']);
+      });
     });
 
     describe('channelDeletedHandler, channelHiddenHandler and notificationRemovedFromChannelHandler', () => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

  This PR fixes ChannelManager list mutation behavior for `queryChannels()` calls that use `options.predefined_filter`.

Previously, predefined filter requests were sent correctly, but `queryChannelsRequest()` returned only `data.channels`, so the top level `predefined_filter` metadata from `/channels` was discarded. That metadata contains the backend resolved effective filter and sort. Without it, `ChannelManager` continued using only the original caller inputs for WS-driven list mutations.

For predefined queries, the caller input can be intentionally empty:

  ```ts
  filters = {};
  sort = [];
  options = { predefined_filter: 'messaging_channels' };
```

  while the backend may resolve the actual list semantics to:
```
  predefined_filter: {
    filter: { archived: false },
    sort: [{ field: 'pinned_at', direction: -1 }],
  }
```

Because `ChannelManager` did not have access to that resolved metadata, events such as `message.new`, `notification.message_new`, `channel.visible` and `member.updated` behaved as if archived and pinned handling was disabled. That could allow archived channels to be promoted into non-archived lists, unarchived channels to be promoted into archived lists or pinned channels to move when `pinned_at` sorting should keep them stable.

This PR adds an explicit full response query path:

```
queryChannelsRequestWithResponse()
```

The existing `queryChannelsRequest()` keeps its current behavior and still returns only raw channel API responses. `queryChannels()` also keeps returning `Channel[]` normally. When called with:

```
  stateOptions.withResponse = true
```

`queryChannels()` returns the full query response with hydrated channels:
```
  {
    ...queryChannelsResponse,
    channels: Channel[],
  }
```

`ChannelManager` then uses this internal `withResponse` path so it can read `response.predefined_filter` without changing the default public `queryChannels()` behaviour.

`ChannelManager` now keeps the original request inputs separate from the backend resolved response metadata through 2 new state properties:

- `responseFilters`
- `responseSort`

The original `filters`, `sort` and `options` remain the source of truth for `pagination`, `loadNext()`, retries, offline DB query context and preserving the existing pagination state semantics. The new `responseFilters` and `responseSort` are used only for local WS driven channel list mutation decisions (i.e when do we promote a `channel` and how).

The predefined filter response `sort` shape is:

```
[{ field: 'pinned_at', direction: -1 }]
```

but `ChannelManager` utilities expect `ChannelSort`:

```
[{ pinned_at: -1 }]
```

so we also convert the response sort before storing it as `responseSort`.

I also considered using the existing `channels.queried` event to pass this metadata to `ChannelManager`, however I decided against that for now because `channels.queried` is `client` wide and not scoped to a specific `ChannelManager` request. Without a request/correlation ID, multiple `ChannelManagers` or direct `client.queryChannels()` calls could very well race and attach resolved metadata to the wrong list. The metadata is also local list state, not general client state and event ordering would be fragile because `ChannelManager` updates pagination after its query resolves. The explicit `withResponse` return path keeps the data tied directly to the request that produced it.

## Changelog

-
