### PR TITLE
fix(poll): preserve cleared option identity without collapsing empty rows

### DIFF
--- a/src/messageComposer/middleware/pollComposer/state.ts
+++ b/src/messageComposer/middleware/pollComposer/state.ts
@@ -137,6 +137,27 @@ export const pollCompositionStateProcessors: Partial<
     // For single option updates
     const { index, text } = value;
     const prevOptions = data.options || [];
+    const targetOption = prevOptions[index];
+
+    if (!targetOption) {
+      return { options: prevOptions };
+    }
+
+    const nextOptionsAfterTarget = prevOptions.slice(index + 1);
+    const shouldPreserveClearedOption =
+      !text &&
+      nextOptionsAfterTarget.length > 0 &&
+      nextOptionsAfterTarget.every((option) => !option.text);
+
+    if (shouldPreserveClearedOption) {
+      return {
+        options: [
+          ...prevOptions.slice(0, index),
+          { ...targetOption, text },
+          ...nextOptionsAfterTarget,
+        ],
+      };
+    }
 
     const shouldRemoveOption =
       prevOptions && prevOptions.slice(index + 1).length > 0 && !text;
@@ -146,7 +167,7 @@ export const pollCompositionStateProcessors: Partial<
 
     const newOptions = [
       ...optionListHead,
-      ...(shouldRemoveOption ? [] : [{ ...prevOptions[index], text }]),
+      ...(shouldRemoveOption ? [] : [{ ...targetOption, text }]),
       ...optionListTail,
     ];
 

--- a/test/unit/MessageComposer/middleware/pollComposer/state.test.ts
+++ b/test/unit/MessageComposer/middleware/pollComposer/state.test.ts
@@ -369,9 +369,8 @@ describe('PollComposerStateMiddleware', () => {
       expect(result.status).toBeUndefined;
     });
 
-    it('should remove an option when it is empty and there are more options after it', async () => {
+    it('should preserve the cleared option id while keeping following empty options', async () => {
       const stateMiddleware = setup();
-      // Set up initial state with two options
       const initialState = getInitialState();
       initialState.data.options = [
         { id: 'option-1', text: 'Option 1' },
@@ -380,8 +379,8 @@ describe('PollComposerStateMiddleware', () => {
 
       const result = await stateMiddleware.handlers.handleFieldChange(
         setupHandlerParams({
-          nextState: { ...getInitialState() },
-          previousState: { ...getInitialState() },
+          nextState: { ...initialState },
+          previousState: { ...initialState },
           targetFields: {
             options: {
               index: 0,
@@ -391,8 +390,70 @@ describe('PollComposerStateMiddleware', () => {
         }),
       );
 
-      expect(result.state.nextState.data.options.length).toBe(1);
+      expect(result.state.nextState.data.options.length).toBe(2);
+      expect(result.state.nextState.data.options[0].id).toBe('option-1');
       expect(result.state.nextState.data.options[0].text).toBe('');
+      expect(result.state.nextState.data.options[1]).toEqual({
+        id: 'option-2',
+        text: '',
+      });
+      expect(result.status).toBeUndefined;
+    });
+
+    it('should not preserve the option when clearing it if a following option has text', async () => {
+      const stateMiddleware = setup();
+      const initialState = getInitialState();
+      initialState.data.options = [
+        { id: 'option-1', text: 'Option 1' },
+        { id: 'option-2', text: 'Option 2' },
+        { id: 'option-3', text: '' },
+      ];
+
+      const result = await stateMiddleware.handlers.handleFieldChange(
+        setupHandlerParams({
+          nextState: { ...initialState },
+          previousState: { ...initialState },
+          targetFields: {
+            options: {
+              index: 0,
+              text: '',
+            },
+          },
+        }),
+      );
+
+      expect(result.state.nextState.data.options).toEqual([
+        { id: 'option-2', text: 'Option 2' },
+        { id: 'option-3', text: '' },
+      ]);
+      expect(result.status).toBeUndefined;
+    });
+
+    it('should not preserve trailing empty options for whitespace-only option text', async () => {
+      const stateMiddleware = setup();
+      const initialState = getInitialState();
+      initialState.data.options = [
+        { id: 'option-1', text: 'Option 1' },
+        { id: 'option-2', text: '' },
+      ];
+
+      const result = await stateMiddleware.handlers.handleFieldChange(
+        setupHandlerParams({
+          nextState: { ...initialState },
+          previousState: { ...initialState },
+          targetFields: {
+            options: {
+              index: 0,
+              text: '   ',
+            },
+          },
+        }),
+      );
+
+      expect(result.state.nextState.data.options).toEqual([
+        { id: 'option-1', text: '   ' },
+        { id: 'option-2', text: '' },
+      ]);
       expect(result.status).toBeUndefined;
     });
 


### PR DESCRIPTION
## Goal

Preserve the cleared option instance instead of replacing it with a later empty placeholder row, so clearing text remains a mutation of the same logical option rather than an implicit remove-and-replace. This prevents re-mounts and loss of focus in the UI. Changing the option id has potentially more unknown side effects.

