### PR TITLE
fix: increasing/decreasing member count on member event cause incorrect member count

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2165,9 +2165,6 @@ export class Channel {
             ...channelState.members,
             [memberCopy.user.id]: memberCopy,
           };
-          if (channel.data?.member_count && event.type === 'member.added') {
-            channel.data.member_count += 1;
-          }
         }
 
         const currentUserId = this.getClient().userID;
@@ -2189,10 +2186,6 @@ export class Channel {
           delete newMembers[event.user.id];
 
           channelState.members = newMembers;
-
-          if (channel.data?.member_count) {
-            channel.data.member_count = Math.max(channel.data.member_count - 1, 0);
-          }
 
           // TODO?: unset membership
         }

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -277,6 +277,28 @@ describe('Channel _handleChannelEvent', function () {
 		expect(channel.state.membership).to.equal(channel.state.members[user.id]);
 	});
 
+	it('does not change channel.data.member_count on member.added or member.removed', () => {
+		channel.data = { member_count: 5 };
+
+		const newMember = generateMember({ user: { id: 'user-new' } });
+
+		channel._handleChannelEvent({
+			type: 'member.added',
+			user: newMember.user,
+			member: newMember,
+		});
+
+		expect(channel.data.member_count).to.equal(5);
+
+		channel._handleChannelEvent({
+			type: 'member.removed',
+			user: newMember.user,
+			member: newMember,
+		});
+
+		expect(channel.data.member_count).to.equal(5);
+	});
+
 	it('message.new does not reset the unreadCount for current user messages', function () {
 		channel.state.unreadCount = 100;
 		channel._handleChannelEvent({
@@ -1258,6 +1280,17 @@ describe('Channel _handleChannelEvent', function () {
 		expect(channelQuerySpy).toHaveBeenCalledTimes(1);
 
 		// Make sure that we don't wipe out any data
+	});
+
+	it('channel.updated updates member_count from the event channel data', () => {
+		channel.data = { member_count: 5 };
+
+		channel._handleChannelEvent({
+			type: 'channel.updated',
+			channel: { member_count: 10 },
+		});
+
+		expect(channel.data.member_count).to.equal(10);
 	});
 
 	it(`should make sure that state reload doesn't wipe out existing data`, async () => {


### PR DESCRIPTION
The issue:
When adding more than one member at once to a channel, this is the WS event sequence I get:
- Channel has 4 members now, we're adding 2 new members in a single API call
- `member.added` event arrives -> stream-chat-js increases member count by one, current value is 5
- `channel.updated` event arrives with member count 6 -> stream-chat-js sets member count from WS event to 6
- `member.added` event arrives -> stream-chat-js increases member count by one, current value is 7 ❌

The solution:
Since `channel.updated` is dispatched every time we add/remove members, it's safe to set member count only from that event, and don't increase/decrease counter on member events.

## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
