### PR TITLE
fix: only run husky in a git checkout so npm consumers don't break

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "test-coverage": "vitest run --coverage",
     "fix-staged": "lint-staged --config .lintstagedrc.fix.json --concurrent 1",
     "semantic-release": "semantic-release",
-    "postinstall": "husky",
+    "postinstall": "node -e \"require('fs').existsSync('scripts/install-husky.mjs') && import('./scripts/install-husky.mjs')\"",
     "prepare": "yarn run build"
   },
   "engines": {

--- a/scripts/install-husky.mjs
+++ b/scripts/install-husky.mjs
@@ -1,0 +1,11 @@
+import { existsSync } from 'node:fs';
+
+// husky installs this repo's local git hooks and is a dev-only dependency. It is
+// invoked from a presence-guarded postinstall (see package.json) so it never runs
+// for consumers — this file is intentionally not published. The .git check is a
+// secondary guard for non-checkout environments; husky's own default() already
+// no-ops gracefully on a missing .git or HUSKY=0, and any genuine setup error is
+// left to surface rather than be swallowed. See #1763.
+if (existsSync('.git')) {
+  (await import('husky')).default();
+}


### PR DESCRIPTION
## Problem

`postinstall` ran `husky` unconditionally. npm executes a dependency's `postinstall` for every consumer, but `husky` is a `devDependency` and isn't installed in a consumer's tree, so `npm install stream-chat` failed:

```
npm error code 127
npm error sh: husky: command not found
```

Closes #1763.

## Why husky has to stay in `postinstall`

Yarn Berry (this repo's package manager) runs the **root workspace's `postinstall`** on `yarn install` but **not** its `prepare`. So moving husky to `prepare` would silently stop installing contributors' git hooks. husky must stay in `postinstall`; the fix is to stop *running* it for consumers.

## Fix

- `postinstall` now invokes a dev-only `scripts/install-husky.mjs` **only when it is present** — and that file is intentionally **not** added to `package.json#files`, so consumers never receive it and the guard short-circuits to a no-op.
- The invocation runs via `node` (not a shell `|| true`) so it's cross-platform — npm runs consumer postinstalls through `cmd.exe` on Windows, where `||`/`true` aren't valid.
- `scripts/install-husky.mjs` runs husky only inside a git checkout, and lets genuine husky setup errors **surface** (not swallowed) so contributors learn if hook installation actually fails.
- `prepare: yarn run build` is unchanged (npm git-ref installs still build a package).

## Testing

Verified end-to-end with a packed tarball (`yarn pack`) installed into a throwaway consumer, and a fresh `git clone` + `yarn install`:

| Scenario | Result |
| --- | --- |
| `npm install <tarball>` (consumer) | exit 0 · husky never executed · package imports |
| fresh `git clone` + `yarn install` (contributor) | `core.hooksPath=.husky/_` · hooks installed |
| control: old `postinstall: husky` | reproduces `code 127` / `husky: command not found` |
| simulated husky setup error | surfaces (exit 1) instead of being swallowed |

`yarn lint` clean.
