### PR TITLE
fix: support array in sort param for UserSearchSource

### DIFF
--- a/src/search/UserSearchSource.ts
+++ b/src/search/UserSearchSource.ts
@@ -60,7 +60,13 @@ export class UserSearchSource<
       baseFilters: this.filters,
       context: { searchQuery } as UserSearchSourceFilterBuilderContext<TFilterContext>,
     });
-    const sort = { id: 1, ...this.sort } as UserSort;
+    let sort: UserSort;
+    if (Array.isArray(this.sort)) {
+      const hasIdSort = this.sort.some((entry) => 'id' in entry);
+      sort = hasIdSort ? this.sort : [...this.sort, { id: 1 }];
+    } else {
+      sort = { id: 1, ...this.sort };
+    }
     const options = { ...this.searchOptions, limit: this.pageSize, offset: this.offset };
     const { users } = await this.client.queryUsers(filters, sort, options);
     return { items: users };

--- a/test/unit/search/UserSearchSource.test.ts
+++ b/test/unit/search/UserSearchSource.test.ts
@@ -177,6 +177,46 @@ describe('UserSearchSource', () => {
     );
   });
 
+  it('appends a default id sort when sort is an array without an id key', async () => {
+    searchSource.sort = [{ created_at: -1 }] as UserSort;
+
+    // @ts-expect-error accessing protected method
+    await searchSource.query('John');
+
+    expect(queryUsersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ created_at: -1 }, { id: 1 }],
+      expect.anything(),
+    );
+  });
+
+  it('leaves the sort array unchanged when it already contains an id key', async () => {
+    const sort = [{ id: -1 }, { created_at: -1 }] as UserSort;
+    searchSource.sort = sort;
+
+    // @ts-expect-error accessing protected method
+    await searchSource.query('John');
+
+    expect(queryUsersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ id: -1 }, { created_at: -1 }],
+      expect.anything(),
+    );
+  });
+
+  it('uses only the default id sort when sort is an empty array', async () => {
+    searchSource.sort = [] as UserSort;
+
+    // @ts-expect-error accessing protected method
+    await searchSource.query('John');
+
+    expect(queryUsersMock).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ id: 1 }],
+      expect.anything(),
+    );
+  });
+
   it('returns items from query', async () => {
     // @ts-expect-error accessing protected method
     const result = await searchSource.query('any');


### PR DESCRIPTION
## CLA

Supports providing `sort` option for `UserSearchSource` as an array, which is the preferred way to provide the sort option:

```
source.sort = [{ name: 1 }];
```

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
