### PR TITLE
fix: add custom in moderation_payload on /check

### DIFF
--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -361,6 +361,7 @@ export class Moderation {
    * @param {Array} moderationPayload.texts array Array of texts to be checked for moderation
    * @param {Array} moderationPayload.images array Array of images to be checked for moderation
    * @param {Array} moderationPayload.videos array Array of videos to be checked for moderation
+   * @param {object} moderationPayload.custom object Additional custom data to attach to the moderation review queue item
    * @param {Array<CustomCheckFlag>} flags Array of CustomCheckFlag to be passed to flag the entity
    * @returns
    */
@@ -369,6 +370,8 @@ export class Moderation {
     entityID: string,
     entityCreatorID: string,
     moderationPayload: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      custom?: Record<string, any>;
       images?: string[];
       texts?: string[];
       videos?: string[];


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog
- Add `custom` in `moderation_payload` on `/check` endpoint to allow attaching custom data to moderated review queue items.
