### PR TITLE
fix: allow empty search query in message search source

### DIFF
--- a/src/search/MessageSearchSource.ts
+++ b/src/search/MessageSearchSource.ts
@@ -130,7 +130,12 @@ export class MessageSearchSource<
   }
 
   protected async query(searchQuery: string) {
-    if (!this.client.userID || !searchQuery || this.next === null) return { items: [] };
+    if (
+      !this.client.userID ||
+      (!searchQuery && !this.allowEmptySearchString) ||
+      this.next === null
+    )
+      return { items: [] };
 
     const channelFilters = this.messageSearchChannelFilterBuilder.buildFilters({
       baseFilters: {

--- a/test/unit/search/MessageSearchSource.test.ts
+++ b/test/unit/search/MessageSearchSource.test.ts
@@ -210,6 +210,26 @@ describe('MessageSearchSource', () => {
     expect(searchMock).not.toHaveBeenCalled();
   });
 
+  it('returns empty items when searchQuery is empty and allowEmptySearchString is false', async () => {
+    // @ts-expect-error protected access
+    const result = await searchSource.query('');
+    expect(result).toEqual({ items: [] });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('queries with an empty searchQuery when allowEmptySearchString is true', async () => {
+    const searchSource = new MessageSearchSource(client, {
+      allowEmptySearchString: true,
+    });
+
+    // @ts-expect-error protected access
+    const result = await searchSource.query('');
+
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    expect(result.items).toEqual(messages);
+    expect(result.next).toBe('next-token');
+  });
+
   it('builds filters and calls client.search with correct args', async () => {
     searchSource.messageSearchFilters = { 'mentioned_users.id': { $contains: 'abc' } };
     searchSource.messageSearchChannelFilters = { type: 'messaging' };


### PR DESCRIPTION
## CLA

`MessageSearchSource` had a condition to return early if `searchQuery` was empty, which made the `allowEmptySearchString` flag useless.

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
