### PR TITLE
feat(search): add ChannelMemberSearchSource

### DIFF
--- a/src/search/ChannelMemberSearchSource.ts
+++ b/src/search/ChannelMemberSearchSource.ts
@@ -1,0 +1,85 @@
+import { BaseSearchSource } from './BaseSearchSource';
+import { FilterBuilder, type FilterBuilderOptions } from '../pagination';
+import type { Channel } from '../channel';
+import type {
+  ChannelMemberResponse,
+  MemberFilters,
+  MemberSort,
+  QueryMembersOptions,
+} from '../types';
+import type { SearchSourceOptions } from './types';
+
+type CustomContext = Record<string, unknown>;
+
+export type ChannelMemberSearchSourceFilterBuilderContext<
+  C extends CustomContext = CustomContext,
+> = { searchQuery?: string } & C;
+
+export class ChannelMemberSearchSource<
+  TFilterContext extends CustomContext = CustomContext,
+> extends BaseSearchSource<ChannelMemberResponse> {
+  readonly type = 'members';
+  channel: Channel;
+  filters: MemberFilters | undefined;
+  sort: MemberSort | undefined;
+  searchOptions: Omit<QueryMembersOptions, 'limit' | 'offset'> | undefined;
+  filterBuilder: FilterBuilder<
+    MemberFilters,
+    ChannelMemberSearchSourceFilterBuilderContext<TFilterContext>
+  >;
+
+  constructor(
+    channel: Channel,
+    options?: SearchSourceOptions,
+    filterBuilderOptions: FilterBuilderOptions<
+      MemberFilters,
+      ChannelMemberSearchSourceFilterBuilderContext<TFilterContext>
+    > = {},
+  ) {
+    super(options);
+    this.channel = channel;
+    this.filterBuilder = new FilterBuilder<
+      MemberFilters,
+      ChannelMemberSearchSourceFilterBuilderContext<TFilterContext>
+    >({
+      initialFilterConfig: {
+        default: {
+          enabled: true,
+          generate: ({ searchQuery }) =>
+            searchQuery
+              ? {
+                  $or: [
+                    { name: { $autocomplete: searchQuery } },
+                    { id: { $eq: searchQuery } },
+                  ],
+                }
+              : null,
+        },
+      },
+      ...filterBuilderOptions,
+    });
+  }
+
+  canExecuteQuery = (newSearchString?: string) => {
+    const hasNewSearchQuery = typeof newSearchString !== 'undefined';
+
+    return this.isActive && !this.isLoading && (this.hasNext || hasNewSearchQuery);
+  };
+
+  protected async query(searchQuery: string) {
+    const filters = this.filterBuilder.buildFilters({
+      baseFilters: this.filters,
+      context: {
+        searchQuery,
+      } as ChannelMemberSearchSourceFilterBuilderContext<TFilterContext>,
+    });
+    const sort = this.sort ?? [];
+    const options = { ...this.searchOptions, limit: this.pageSize, offset: this.offset };
+    const { members } = await this.channel.queryMembers(filters ?? {}, sort, options);
+    return { items: members };
+  }
+
+  protected filterQueryResults(items: ChannelMemberResponse[]) {
+    return items;
+  }
+}

--- a/src/search/MessageSearchSource.ts
+++ b/src/search/MessageSearchSource.ts
@@ -130,7 +130,7 @@ export class MessageSearchSource<
   }
 
   protected async query(searchQuery: string) {
-    if (!this.client.userID || !searchQuery || this.next === null) return { items: [] };
+    if (!this.client.userID || this.next === null) return { items: [] };
 
     const channelFilters = this.messageSearchChannelFilterBuilder.buildFilters({
       baseFilters: {

--- a/src/search/index.ts
+++ b/src/search/index.ts
@@ -1,4 +1,5 @@
 export * from './BaseSearchSource';
+export * from './ChannelMemberSearchSource';
 export * from './SearchController';
 export * from './UserSearchSource';
 export * from './ChannelSearchSource';

--- a/test/unit/search/ChannelMemberSearchSource.test.ts
+++ b/test/unit/search/ChannelMemberSearchSource.test.ts
@@ -23,7 +23,7 @@ const createChannel = () =>
   }) as unknown as Channel;
 
 const getAutocompleteFilters = (searchQuery: string): Partial<MemberFilters> => ({
-  $or: [{ id: { $eq: searchQuery } }, { name: { $autocomplete: searchQuery } }],
+  $or: [{ name: { $autocomplete: searchQuery } }, { id: { $eq: searchQuery } }],
 });
 
 describe('ChannelMemberSearchSource', () => {

--- a/test/unit/search/ChannelMemberSearchSource.test.ts
+++ b/test/unit/search/ChannelMemberSearchSource.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Channel } from '../../../src/channel';
+import { ChannelMemberSearchSource } from '../../../src/search/ChannelMemberSearchSource';
+import type {
+  ChannelMemberResponse,
+  MemberFilters,
+  MemberSort,
+} from '../../../src/types';
+
+const createChannelMember = (
+  overrides: Partial<ChannelMemberResponse> = {},
+): ChannelMemberResponse => ({
+  created_at: '2026-01-01T00:00:00.000000000Z',
+  updated_at: '2026-01-01T00:00:00.000000000Z',
+  user_id: 'user-1',
+  ...overrides,
+});
+
+const createChannel = () =>
+  ({
+    queryMembers: vi.fn(),
+  }) as unknown as Channel;
+
+const getAutocompleteFilters = (searchQuery: string): Partial<MemberFilters> => ({
+  $or: [{ id: { $eq: searchQuery } }, { name: { $autocomplete: searchQuery } }],
+});
+
+describe('ChannelMemberSearchSource', () => {
+  const mockMembers: ChannelMemberResponse[] = [
+    createChannelMember({ user_id: 'user-1', user: { id: 'user-1', name: 'Alice' } }),
+    createChannelMember({ user_id: 'user-2', user: { id: 'user-2', name: 'Bob' } }),
+  ];
+  let channel: Channel;
+  let searchSource: ChannelMemberSearchSource;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    channel = createChannel();
+    vi.spyOn(channel, 'queryMembers').mockResolvedValue({
+      duration: '0.01s',
+      members: mockMembers,
+    });
+    searchSource = new ChannelMemberSearchSource(channel);
+    searchSource.activate();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('initializes with member search source defaults', () => {
+    expect(searchSource.type).toBe('members');
+    expect(searchSource.channel).toBe(channel);
+    expect(searchSource.pageSize).toBe(10);
+    expect(searchSource.offset).toBe(0);
+    expect(searchSource.filterBuilder.filterConfig.getLatestValue()).toEqual({
+      default: {
+        enabled: true,
+        generate: expect.any(Function),
+      },
+    });
+    expect(
+      searchSource.filterBuilder.filterConfig.getLatestValue().default.generate({
+        searchQuery: 'jo',
+      }),
+    ).toEqual(getAutocompleteFilters('jo'));
+    expect(
+      searchSource.filterBuilder.filterConfig.getLatestValue().default.generate({
+        searchQuery: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('initializes with custom options', () => {
+    const customSource = new ChannelMemberSearchSource(channel, { pageSize: 30 });
+
+    expect(customSource.pageSize).toBe(30);
+  });
+
+  it('initializes with custom filter builder options', () => {
+    const customSource = new ChannelMemberSearchSource<{ joined: boolean }>(
+      channel,
+      { pageSize: 25 },
+      {
+        initialContext: { joined: true },
+        initialFilterConfig: {
+          joined: {
+            enabled: true,
+            generate: ({ joined }) => ({ joined: joined as boolean }),
+          },
+          default: {
+            enabled: true,
+            generate: ({ searchQuery }) =>
+              searchQuery ? getAutocompleteFilters(searchQuery) : null,
+          },
+        },
+      },
+    );
+
+    expect(customSource.pageSize).toBe(25);
+    expect(customSource.filterBuilder.context.getLatestValue()).toEqual({ joined: true });
+    expect(
+      customSource.filterBuilder.filterConfig.getLatestValue().joined.generate({
+        joined: false,
+      }),
+    ).toEqual({ joined: false });
+    expect(
+      customSource.filterBuilder.filterConfig.getLatestValue().default.generate({
+        searchQuery: 'x',
+        joined: false,
+      }),
+    ).toEqual(getAutocompleteFilters('x'));
+  });
+
+  describe('canExecuteQuery', () => {
+    it('allows empty search queries for initial load', () => {
+      expect(searchSource.canExecuteQuery('')).toBe(true);
+    });
+
+    it('allows pagination when there is another page', () => {
+      expect(searchSource.canExecuteQuery()).toBe(true);
+    });
+
+    it('returns false when inactive', () => {
+      searchSource.deactivate();
+
+      expect(searchSource.canExecuteQuery('')).toBe(false);
+      expect(searchSource.canExecuteQuery()).toBe(false);
+    });
+
+    it('returns false while loading', () => {
+      searchSource.state.partialNext({ isLoading: true });
+
+      expect(searchSource.canExecuteQuery('')).toBe(false);
+      expect(searchSource.canExecuteQuery()).toBe(false);
+    });
+
+    it('returns false when there is no next page and no new search query', () => {
+      searchSource.state.partialNext({ hasNext: false });
+
+      expect(searchSource.canExecuteQuery()).toBe(false);
+    });
+  });
+
+  describe('query', () => {
+    it('calls buildFilters internally', async () => {
+      const spyBuildFilters = vi
+        .spyOn(searchSource.filterBuilder, 'buildFilters')
+        .mockReturnValue({});
+
+      // @ts-expect-error accessing protected method
+      await searchSource.query('test-search');
+
+      expect(spyBuildFilters).toHaveBeenCalledWith({
+        baseFilters: undefined,
+        context: { searchQuery: 'test-search' },
+      });
+    });
+
+    it('passes filters, sort, and options to channel.queryMembers', async () => {
+      const filters: MemberFilters = { user_id: 'user-2' };
+      const sort: MemberSort = [{ name: 1 }];
+      searchSource.filters = filters;
+      searchSource.sort = sort;
+      searchSource.searchOptions = { user_id_gt: 'user-0' };
+
+      // @ts-expect-error accessing protected method
+      await searchSource.query('John');
+
+      expect(channel.queryMembers).toHaveBeenCalledWith(
+        {
+          ...getAutocompleteFilters('John'),
+          user_id: 'user-2',
+        },
+        sort,
+        {
+          user_id_gt: 'user-0',
+          limit: searchSource.pageSize,
+          offset: searchSource.offset,
+        },
+      );
+    });
+
+    it('returns items from query', async () => {
+      // @ts-expect-error accessing protected method
+      const result = await searchSource.query('any');
+
+      expect(result.items).toEqual(mockMembers);
+    });
+  });
+
+  describe('search', () => {
+    it('executes empty search queries after debounce', async () => {
+      searchSource.search('');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(searchSource.items).toEqual(mockMembers);
+      expect(searchSource.searchQuery).toBe('');
+      expect(channel.queryMembers).toHaveBeenCalledWith({}, [], {
+        limit: 10,
+        offset: 0,
+      });
+    });
+
+    it('executes typed search queries with autocomplete filters', async () => {
+      searchSource.search('john');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(searchSource.searchQuery).toBe('john');
+      expect(channel.queryMembers).toHaveBeenCalledWith(
+        getAutocompleteFilters('john'),
+        [],
+        { limit: 10, offset: 0 },
+      );
+    });
+
+    it('debounces rapid search calls and only executes the last query', async () => {
+      searchSource.search('j');
+      searchSource.search('jo');
+      searchSource.search('john');
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(channel.queryMembers).toHaveBeenCalledTimes(1);
+      expect(channel.queryMembers).toHaveBeenCalledWith(
+        getAutocompleteFilters('john'),
+        [],
+        { limit: 10, offset: 0 },
+      );
+    });
+
+    it('resets state for a new search query', async () => {
+      searchSource.search('first');
+      await vi.advanceTimersByTimeAsync(300);
+
+      searchSource.search('second');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(searchSource.searchQuery).toBe('second');
+      expect(channel.queryMembers).toHaveBeenLastCalledWith(
+        getAutocompleteFilters('second'),
+        [],
+        { limit: 10, offset: 0 },
+      );
+    });
+
+    it('paginates without starting a new search query', async () => {
+      const queryMembersMock = vi.spyOn(channel, 'queryMembers');
+      const firstPage = [
+        createChannelMember({ user_id: 'user-3' }),
+        createChannelMember({ user_id: 'user-4' }),
+      ];
+      const secondPage = [createChannelMember({ user_id: 'user-5' })];
+
+      queryMembersMock
+        .mockResolvedValueOnce({ duration: '0.01s', members: firstPage })
+        .mockResolvedValueOnce({ duration: '0.01s', members: secondPage });
+
+      const paginatedSource = new ChannelMemberSearchSource(channel, { pageSize: 2 });
+      paginatedSource.activate();
+
+      paginatedSource.search('');
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(paginatedSource.items).toEqual(firstPage);
+      expect(paginatedSource.hasNext).toBe(true);
+
+      paginatedSource.search();
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(queryMembersMock).toHaveBeenNthCalledWith(2, {}, [], {
+        limit: 2,
+        offset: 2,
+      });
+      expect(paginatedSource.items).toEqual([...firstPage, ...secondPage]);
+      expect(paginatedSource.hasNext).toBe(false);
+    });
+
+    it('cancels scheduled search queries', async () => {
+      searchSource.search('john');
+      searchSource.cancelScheduledQuery();
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(channel.queryMembers).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns items unchanged from filterQueryResults', () => {
+    // @ts-expect-error accessing protected method
+    const result = searchSource.filterQueryResults(mockMembers);
+
+    expect(result).toEqual(mockMembers);
+  });
+});

--- a/test/unit/search/MessageSearchSource.test.ts
+++ b/test/unit/search/MessageSearchSource.test.ts
@@ -210,6 +210,35 @@ describe('MessageSearchSource', () => {
     expect(searchMock).not.toHaveBeenCalled();
   });
 
+  it('returns empty items when next is null', async () => {
+    searchSource.state.partialNext({ next: null });
+
+    // @ts-expect-error protected access
+    const result = await searchSource.query('test');
+
+    expect(result).toEqual({ items: [] });
+    expect(searchMock).not.toHaveBeenCalled();
+  });
+
+  it('executes search with empty search query', async () => {
+    // @ts-expect-error protected access
+    const result = await searchSource.query('');
+
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        members: { $in: [user.id] },
+      }),
+      { type: 'regular' },
+      expect.objectContaining({
+        limit: searchSource.pageSize,
+        next: undefined,
+        sort: { created_at: -1 },
+      }),
+    );
+    expect(result.items).toEqual(messages);
+    expect(result.next).toBe('next-token');
+  });
+
   it('builds filters and calls client.search with correct args', async () => {
     searchSource.messageSearchFilters = { 'mentioned_users.id': { $contains: 'abc' } };
     searchSource.messageSearchChannelFilters = { type: 'messaging' };


### PR DESCRIPTION
## Goal

Add ChannelMemberSearchSource that can be used to paginate and search for channel members in channel management UIs.

Also removes condition for existence of searchQuery in MessageSearchSource.