### PR TITLE
fix: include fixed queue cache in client

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -293,6 +293,7 @@ import { StateStore } from './store';
 import type { MessageComposer } from './messageComposer';
 import type { AbstractOfflineDB } from './offline-support';
 import { getPendingTaskChannelData } from './offline-support/util';
+import { FixedSizeQueueCache } from './utils/FixedSizeQueueCache';
 
 function isString(x: unknown): x is string {
   return typeof x === 'string' || x instanceof String;
@@ -393,6 +394,7 @@ export class StreamChat {
   defaultWSTimeout: number;
   sdkIdentifier?: SdkIdentifier;
   deviceIdentifier?: DeviceIdentifier;
+  messageComposerFixedSizeQueue: FixedSizeQueueCache<string, MessageComposer>;
   private nextRequestAbortController: AbortController | null = null;
   /**
    * @private
@@ -573,6 +575,9 @@ export class StreamChat {
     this.polls = new PollManager({ client: this });
     this.reminders = new ReminderManager({ client: this });
     this.messageDeliveryReporter = new MessageDeliveryReporter({ client: this });
+    this.messageComposerFixedSizeQueue = new FixedSizeQueueCache<string, MessageComposer>(
+      64,
+    );
   }
 
   /**
@@ -1060,6 +1065,7 @@ export class StreamChat {
     // reset thread manager
     this.threads.resetState();
     this.uploadManager.reset();
+    this.messageComposerFixedSizeQueue.clear();
 
     // Since we wipe all user data already, we should reset token manager as well
     closePromise

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ export class StreamChat {
   defaultWSTimeout: number;
   sdkIdentifier?: SdkIdentifier;
   deviceIdentifier?: DeviceIdentifier;
-  messageComposerFixedSizeQueue: FixedSizeQueueCache<string, MessageComposer>;
+  messageComposerCache: FixedSizeQueueCache<string, MessageComposer>;
   private nextRequestAbortController: AbortController | null = null;
   /**
    * @private
@@ -575,9 +575,7 @@ export class StreamChat {
     this.polls = new PollManager({ client: this });
     this.reminders = new ReminderManager({ client: this });
     this.messageDeliveryReporter = new MessageDeliveryReporter({ client: this });
-    this.messageComposerFixedSizeQueue = new FixedSizeQueueCache<string, MessageComposer>(
-      64,
-    );
+    this.messageComposerCache = new FixedSizeQueueCache<string, MessageComposer>(64);
   }
 
   /**
@@ -1065,7 +1063,7 @@ export class StreamChat {
     // reset thread manager
     this.threads.resetState();
     this.uploadManager.reset();
-    this.messageComposerFixedSizeQueue.clear();
+    this.messageComposerCache.clear();
 
     // Since we wipe all user data already, we should reset token manager as well
     closePromise

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ export class StreamChat {
   defaultWSTimeout: number;
   sdkIdentifier?: SdkIdentifier;
   deviceIdentifier?: DeviceIdentifier;
-  messageComposerCache: FixedSizeQueueCache<string, MessageComposer>;
+  readonly messageComposerCache: FixedSizeQueueCache<string, MessageComposer>;
   private nextRequestAbortController: AbortController | null = null;
   /**
    * @private

--- a/src/utils/FixedSizeQueueCache.ts
+++ b/src/utils/FixedSizeQueueCache.ts
@@ -77,9 +77,7 @@ export class FixedSizeQueueCache<K, T> {
    */
   clear() {
     if (this.dispose) {
-      for (const [key, entry] of this.map.entries()) {
-        this.dispose(key, entry);
-      }
+      this.map.forEach((entry, key) => this.dispose?.(key, entry));
     }
     this.map.clear();
     this.keys = [];

--- a/src/utils/FixedSizeQueueCache.ts
+++ b/src/utils/FixedSizeQueueCache.ts
@@ -71,4 +71,17 @@ export class FixedSizeQueueCache<K, T> {
 
     return foundItem;
   }
+
+  /**
+   * Clears queue entirely and disposes of each item individually.
+   */
+  clear() {
+    if (this.dispose) {
+      for (const [key, entry] of this.map.entries()) {
+        this.dispose(key, entry);
+      }
+    }
+    this.map.clear();
+    this.keys = [];
+  }
 }

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -368,16 +368,16 @@ describe('Client disconnectUser', () => {
 
 	it('should clear the message composer cache', async () => {
 		const client = new StreamChat('', '');
-		client.messageComposerFixedSizeQueue.add('cid:a', {});
-		client.messageComposerFixedSizeQueue.add('cid:b', {});
+		client.messageComposerCache.add('cid:a', {});
+		client.messageComposerCache.add('cid:b', {});
 
 		const { resolve, promise } = Promise.withResolvers();
 		client.wsConnection = { disconnect: () => promise };
 		client.wsFallback = null;
 		const disconnectPromise = client.disconnectUser();
 
-		expect(client.messageComposerFixedSizeQueue.peek('cid:a')).to.be.undefined;
-		expect(client.messageComposerFixedSizeQueue.peek('cid:b')).to.be.undefined;
+		expect(client.messageComposerCache.peek('cid:a')).to.be.undefined;
+		expect(client.messageComposerCache.peek('cid:b')).to.be.undefined;
 
 		resolve();
 		await disconnectPromise;

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -365,6 +365,23 @@ describe('Client disconnectUser', () => {
 		await disconnectPromise;
 		expect(client.uploadManager.uploads).to.deep.equal({});
 	});
+
+	it('should clear the message composer cache', async () => {
+		const client = new StreamChat('', '');
+		client.messageComposerFixedSizeQueue.add('cid:a', {});
+		client.messageComposerFixedSizeQueue.add('cid:b', {});
+
+		const { resolve, promise } = Promise.withResolvers();
+		client.wsConnection = { disconnect: () => promise };
+		client.wsFallback = null;
+		const disconnectPromise = client.disconnectUser();
+
+		expect(client.messageComposerFixedSizeQueue.peek('cid:a')).to.be.undefined;
+		expect(client.messageComposerFixedSizeQueue.peek('cid:b')).to.be.undefined;
+
+		resolve();
+		await disconnectPromise;
+	});
 });
 
 describe('Detect node environment', () => {

--- a/test/unit/utils/FixedSizeQueueCache.test.ts
+++ b/test/unit/utils/FixedSizeQueueCache.test.ts
@@ -138,4 +138,113 @@ describe('FixedSizeQueueCache', () => {
     expect(cache.get('key3')).toBeUndefined();
     expect(cache.get('key4')).toBe('value4');
   });
+
+  describe('clear', () => {
+    it('should remove all entries', () => {
+      const cache = new FixedSizeQueueCache(3);
+      cache.add('key1', 'value1');
+      cache.add('key2', 'value2');
+      cache.add('key3', 'value3');
+
+      cache.clear();
+
+      expect(cache.get('key1')).toBeUndefined();
+      expect(cache.get('key2')).toBeUndefined();
+      expect(cache.get('key3')).toBeUndefined();
+    });
+
+    it('should leave the cache reusable at full capacity', () => {
+      const cache = new FixedSizeQueueCache(2);
+      cache.add('key1', 'value1');
+      cache.add('key2', 'value2');
+
+      cache.clear();
+
+      cache.add('key3', 'value3');
+      cache.add('key4', 'value4');
+
+      expect(cache.get('key3')).toBe('value3');
+      expect(cache.get('key4')).toBe('value4');
+    });
+
+    it('should respect eviction order after clear (LRU state is reset)', () => {
+      const cache = new FixedSizeQueueCache(2);
+      cache.add('key1', 'value1');
+      cache.add('key2', 'value2');
+
+      cache.clear();
+
+      // After clear, key3 is the oldest entry and should be evicted by key5
+      cache.add('key3', 'value3');
+      cache.add('key4', 'value4');
+      cache.add('key5', 'value5');
+
+      expect(cache.get('key3')).toBeUndefined();
+      expect(cache.get('key4')).toBe('value4');
+      expect(cache.get('key5')).toBe('value5');
+    });
+
+    it('should call dispose for every remaining entry when dispose is configured', () => {
+      const dispose = vi.fn();
+      const cache = new FixedSizeQueueCache<string, number>(3, { dispose });
+
+      cache.add('key1', 1);
+      cache.add('key2', 2);
+      cache.add('key3', 3);
+
+      cache.clear();
+
+      expect(dispose).toHaveBeenCalledTimes(3);
+      expect(dispose).toHaveBeenCalledWith('key1', 1);
+      expect(dispose).toHaveBeenCalledWith('key2', 2);
+      expect(dispose).toHaveBeenCalledWith('key3', 3);
+    });
+
+    it('should not throw when dispose is not configured', () => {
+      const cache = new FixedSizeQueueCache(2);
+      cache.add('key1', 'value1');
+      cache.add('key2', 'value2');
+
+      expect(() => cache.clear()).not.toThrow();
+    });
+
+    it('should not re-dispose items already evicted via overflow', () => {
+      const dispose = vi.fn();
+      const cache = new FixedSizeQueueCache<string, number>(2, { dispose });
+
+      cache.add('key1', 1);
+      cache.add('key2', 2);
+      cache.add('key3', 3); // evicts key1 - dispose called for key1
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(dispose).toHaveBeenCalledWith('key1', 1);
+
+      dispose.mockClear();
+      cache.clear();
+
+      expect(dispose).toHaveBeenCalledTimes(2);
+      expect(dispose).toHaveBeenCalledWith('key2', 2);
+      expect(dispose).toHaveBeenCalledWith('key3', 3);
+    });
+
+    it('should be a no-op on an empty cache', () => {
+      const dispose = vi.fn();
+      const cache = new FixedSizeQueueCache(2, { dispose });
+
+      expect(() => cache.clear()).not.toThrow();
+      expect(dispose).not.toHaveBeenCalled();
+    });
+
+    it('should not double-dispose when called consecutively', () => {
+      const dispose = vi.fn();
+      const cache = new FixedSizeQueueCache<string, number>(2, { dispose });
+
+      cache.add('key1', 1);
+      cache.clear();
+      cache.clear();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(dispose).toHaveBeenCalledWith('key1', 1);
+    });
+  });
 });


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
                                                                                                                                                                                                                                                                                                                            
Move the `FixedSizeQueueCache<string, MessageComposer>` that backs thread/edit composer reuse from module scope in the UI SDKs onto the `StreamChat` client instance and drain it on `disconnectUser()`.
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
The React and RN UI SDKs currently keep this cache at module scope inside their respective `useMessageComposerController`/`useCreateMessageComposer` hooks:                                                                                                                        
                                                                                                                                                                                                                                                                                                                          
```ts                                                                                                                                                                                                                                                                                                                     
const queueCache = new FixedSizeQueueCache<string, MessageComposer>(64); 
```                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                          
Because the cache is module scoped and not exported, it survives for the lifetime of the JS process across `connectUser`/`disconnectUser` cycles and across `StreamChat` instances. Each cached composer holds a `Channel` object bound to the session that existed when it was created.
                                                                                                                                                                                                                                                                                                                          
After a **logout** then **login** flow (whether via reconnecting the same `StreamChat.getInstance()` singleton or by constructing a bran new `new StreamChat()`), the hook resolves the same tag (`legacy_thread_<id>`/`message_<id>`) and returns a composer whose channel was torn down by the previous `disconnectUser()` (and is marked as `channel.disconnected`. Mounting it then throws, because:                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
- `useEffect` runs `messageComposer.registerSubscriptions()`
- `subscribe*` helpers read `this.client`                                                                                                                                                                                                                                                                                   
- `get client() { return this.channel.getClient() }`
- `Channel.getClient()` throws with `"You can't use a channel after client.disconnect() was called"`
                                                                                                                                                                                                                                                                                                                          
The throw happens inside a React passive effect mount, so it propagates to the root error boundary and takes down the screen. Since the cache is module scoped and not exported, applications have no way to invalidate it on user switch and they cannot follow the existing "refresh stale channel objects on user switch" guidance. Nor should they need to as this should all be handled internally.                                                        
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                
To tackle this, we do the following:
                                                                                                          
1. `StreamChat.messageComposerFixedSizeQueue` - instantiated in the constructor at capacity `64` as it was before. Owned per client instance, so it can never be reused across instances. Also solves the multiple `client` instances issue.
2. `FixedSizeQueueCache.clear()` - runs the optional `dispose` callback for each entry if it, then resets `map` and `keys`. Lets consumers register subscription teardown via dispose if they want explicit lifecycle cleanup at disconnect. Currently we don't expose a clear way to do this, but since we didn't have that before anyway I'm keeping it that way in this iteration and we can possibly extend later on.                                                                                            
3. `disconnectUser()` - calls `this.messageComposerFixedSizeQueue.clear()` and makes sure the cache is flushed entirely so that no `MessageComposer` instances get to leak.
                                                                                                                                                                                                                                                                                                                          
After ths, both reproduction paths are covered:                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                          
- Singleton reconnect - `clear()` drains the cache at disconnect and the next mount does a cache miss and rebuilds against the fresh channel.                                                                                                                                                                                       
- New `StreamChat()` per login - the new instance has its own empty cache and the old instance's cache is unreachable from the new client even if it lives on in memory.                                                              
                                                                                                                                                                                                                                                                                                                          
Will resolve [this GH issue](https://github.com/GetStream/stream-chat-react-native/issues/3642).

## Changelog

-
