### PR TITLE
feat: control mention type usage in MessageComposer via channel permissions

### DIFF
--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -92,7 +92,6 @@ export const calculateLevenshtein = (query: string, name: string) => {
 };
 
 export type MentionsSearchSourceOptions = SearchSourceOptions & {
-  allowedMentionTypes?: Partial<Record<MentionType, boolean>>;
   mentionAllAppUsers?: boolean;
   suggestionFactoryMappers?: MentionSuggestionFactoryMapperOverrides;
   textComposerText?: string;
@@ -134,13 +133,18 @@ export type MentionSuggestionFactoryMapperOverrides = {
   [TMentionType in MentionType]?: MentionSuggestionFactoryMapper<TMentionType>;
 };
 
-const DEFAULT_ALLOWED_MENTION_TYPES: Record<MentionType, boolean> = {
-  channel: true,
-  here: true,
-  role: true,
+const hasOwnCapability = (ownCapabilities: string[] | undefined, capability: string) =>
+  ownCapabilities?.includes(capability) ?? false;
+
+export const getAllowedMentionTypesFromCapabilities = (
+  ownCapabilities?: string[],
+): Record<MentionType, boolean> => ({
+  channel: hasOwnCapability(ownCapabilities, 'notify-channel'),
+  here: hasOwnCapability(ownCapabilities, 'notify-here'),
+  role: hasOwnCapability(ownCapabilities, 'notify-role'),
   user: true,
-  user_group: true,
-};
+  user_group: hasOwnCapability(ownCapabilities, 'notify-group'),
+});
 
 type UserGroupSearchCursor = Pick<SearchUserGroupsOptions, 'id_gt' | 'name_gt'>;
 type UserPaginationState = {
@@ -299,7 +303,6 @@ export class MentionsSearchSource extends BaseSearchSource<MentionSuggestion> {
 
   constructor(channel: Channel, options?: MentionsSearchSourceOptions) {
     const {
-      allowedMentionTypes,
       mentionAllAppUsers,
       suggestionFactoryMappers,
       textComposerText,
@@ -311,10 +314,6 @@ export class MentionsSearchSource extends BaseSearchSource<MentionSuggestion> {
     this.client = channel.getClient();
     this.channel = channel;
     this.config = {
-      allowedMentionTypes: {
-        ...DEFAULT_ALLOWED_MENTION_TYPES,
-        ...allowedMentionTypes,
-      },
       mentionAllAppUsers,
       suggestionFactoryMappers,
       textComposerText,
@@ -371,7 +370,9 @@ export class MentionsSearchSource extends BaseSearchSource<MentionSuggestion> {
   };
 
   isMentionTypeAllowed = (mentionType: MentionType) =>
-    this.config.allowedMentionTypes?.[mentionType] ?? true;
+    getAllowedMentionTypesFromCapabilities(this.channel.data?.own_capabilities)[
+      mentionType
+    ];
 
   protected mapMentionSuggestion = <TMentionType extends MentionType>(
     mentionType: TMentionType,

--- a/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
+  getAllowedMentionTypesFromCapabilities,
   MentionsSearchSource,
   calculateLevenshtein,
 } from '../../../../../src/messageComposer/middleware/textComposer/mentions';
@@ -59,6 +60,13 @@ describe('calculateLevenshtein', () => {
     expect(calculateLevenshtein('test!', 'test?')).toBe(1);
   });
 });
+
+const ALL_NOTIFY_MENTION_CAPABILITIES = [
+  'notify-channel',
+  'notify-group',
+  'notify-here',
+  'notify-role',
+] as const;
 
 describe('MentionsSearchSource', () => {
   let channel: Channel;
@@ -127,7 +135,10 @@ describe('MentionsSearchSource', () => {
     } as unknown as StreamChat;
 
     channel = {
-      data: { team: 'engineering' },
+      data: {
+        own_capabilities: [...ALL_NOTIFY_MENTION_CAPABILITIES],
+        team: 'engineering',
+      },
       getClient: vi.fn().mockReturnValue(client),
       state: {
         members: mockMembers,
@@ -146,19 +157,11 @@ describe('MentionsSearchSource', () => {
   it('should initialize with correct type', () => {
     const source = new MentionsSearchSource(channel);
     expect(source.type).toBe('mentions');
-    expect(source.config.allowedMentionTypes).toEqual({
-      channel: true,
-      here: true,
-      role: true,
-      user: true,
-      user_group: true,
-    });
     expect(source.config.mentionAllAppUsers).toBeUndefined;
     expect(source.config.textComposerText).toBeUndefined;
     expect(source.config.transliterate).toBeUndefined;
 
     const customizedSource = new MentionsSearchSource(channel, {
-      allowedMentionTypes: { role: false, user_group: false },
       mentionAllAppUsers: true,
       suggestionFactoryMappers: {
         role: (value, { searchToken }) => ({
@@ -174,19 +177,38 @@ describe('MentionsSearchSource', () => {
       textComposerText: '@',
       transliterate: (text: string) => text.toLowerCase(),
     });
-    expect(customizedSource.config.allowedMentionTypes).toEqual({
-      channel: true,
-      here: true,
-      role: false,
-      user: true,
-      user_group: false,
-    });
     expect(customizedSource.config.mentionAllAppUsers).toBe(true);
     expect(customizedSource.config.suggestionFactoryMappers?.role).toBeInstanceOf(
       Function,
     );
     expect(customizedSource.config.textComposerText).toBe('@');
     expect(customizedSource.transliterate).toBeInstanceOf(Function);
+  });
+
+  it('should derive allowed mention types from channel own_capabilities', () => {
+    expect(getAllowedMentionTypesFromCapabilities(undefined)).toEqual({
+      channel: false,
+      here: false,
+      role: false,
+      user: true,
+      user_group: false,
+    });
+    expect(
+      getAllowedMentionTypesFromCapabilities([...ALL_NOTIFY_MENTION_CAPABILITIES]),
+    ).toEqual({
+      channel: true,
+      here: true,
+      role: true,
+      user: true,
+      user_group: true,
+    });
+    expect(getAllowedMentionTypesFromCapabilities(['notify-role'])).toEqual({
+      channel: false,
+      here: false,
+      role: true,
+      user: true,
+      user_group: false,
+    });
   });
 
   it('should return built-ins and users on empty query without role or user group search', async () => {
@@ -382,15 +404,9 @@ describe('MentionsSearchSource', () => {
     );
   });
 
-  it('should respect allowedMentionTypes and skip disabled source queries', async () => {
-    const source = new MentionsSearchSource(channel, {
-      allowedMentionTypes: {
-        channel: false,
-        here: false,
-        role: false,
-        user_group: false,
-      },
-    });
+  it('should skip special mention queries when own_capabilities are missing', async () => {
+    channel.data = { team: 'engineering' };
+    const source = new MentionsSearchSource(channel);
     source.activate();
     source.config.textComposerText = '@adm';
 
@@ -403,18 +419,43 @@ describe('MentionsSearchSource', () => {
     expect(result.items.every((item) => item.mentionType === 'user')).toBe(true);
   });
 
-  it('should skip user queries when user mentions are disabled', async () => {
-    const source = new MentionsSearchSource(channel, {
-      allowedMentionTypes: { user: false },
-      mentionAllAppUsers: true,
-    });
+  it('should only query mention sources allowed by own_capabilities', async () => {
+    channel.data = {
+      own_capabilities: ['notify-role'],
+      team: 'engineering',
+    };
+    const source = new MentionsSearchSource(channel);
     source.activate();
-    source.config.textComposerText = '@john';
+    source.config.textComposerText = '@adm';
 
-    const result = await source.query('john');
+    const result = await source.query('adm');
 
-    expect(client.queryUsers).not.toHaveBeenCalled();
-    expect(result.items.some((item) => item.mentionType === 'user')).toBe(false);
+    expect(client.searchRoles).toHaveBeenCalledWith({ query: 'adm' });
+    expect(client.searchUserGroups).not.toHaveBeenCalled();
+    expect(getSuggestion(result.items, 'role', 'admin')).toBeDefined();
+    expect(getSuggestion(result.items, 'user_group', 'admins-group')).toBeUndefined();
+    expect(getSuggestion(result.items, 'channel', 'channel')).toBeUndefined();
+    expect(getSuggestion(result.items, 'here', 'here')).toBeUndefined();
+  });
+
+  it('should react to own_capabilities changes without recreating the source', async () => {
+    channel.data = { team: 'engineering' };
+    const source = new MentionsSearchSource(channel);
+    source.activate();
+    source.config.textComposerText = '@ch';
+
+    const withoutCapabilities = await source.query('ch');
+    expect(
+      getSuggestion(withoutCapabilities.items, 'channel', 'channel'),
+    ).toBeUndefined();
+
+    channel.data = {
+      own_capabilities: ['notify-channel'],
+      team: 'engineering',
+    };
+
+    const withCapabilities = await source.query('ch');
+    expect(getSuggestion(withCapabilities.items, 'channel', 'channel')).toBeDefined();
   });
 
   it('should query members from API when not all members are loaded', async () => {


### PR DESCRIPTION
## Goal

Control the use of broadcast mentions in message composer suggestions via server-side permission setup, not client-side config.