### PR TITLE
fix: avoid sorting unless we match a command

### DIFF
--- a/src/messageComposer/middleware/textComposer/commands.ts
+++ b/src/messageComposer/middleware/textComposer/commands.ts
@@ -48,28 +48,30 @@ export class CommandSearchSource extends BaseSearchSourceSync<CommandSuggestion>
         ),
     );
 
-    // sort alphabetically unless you're matching the first char
-    selectedCommands.sort((a, b) => {
-      let nameA = a.name?.toLowerCase();
-      let nameB = b.name?.toLowerCase();
-      if (nameA?.indexOf(searchQuery) === 0) {
-        nameA = `0${nameA}`;
-      }
-      if (nameB?.indexOf(searchQuery) === 0) {
-        nameB = `0${nameB}`;
-      }
-      // Should confirm possible null / undefined when TS is fully implemented
-      if (nameA != null && nameB != null) {
-        if (nameA < nameB) {
-          return -1;
+    if (searchQuery) {
+      // sort alphabetically unless you're matching the first char
+      selectedCommands.sort((a, b) => {
+        let nameA = a.name?.toLowerCase();
+        let nameB = b.name?.toLowerCase();
+        if (nameA?.indexOf(searchQuery) === 0) {
+          nameA = `0${nameA}`;
         }
-        if (nameA > nameB) {
-          return 1;
+        if (nameB?.indexOf(searchQuery) === 0) {
+          nameB = `0${nameB}`;
         }
-      }
+        // Should confirm possible null / undefined when TS is fully implemented
+        if (nameA != null && nameB != null) {
+          if (nameA < nameB) {
+            return -1;
+          }
+          if (nameA > nameB) {
+            return 1;
+          }
+        }
 
-      return 0;
-    });
+        return 0;
+      });
+    }
 
     return {
       items: selectedCommands.map((command) => ({

--- a/test/unit/MessageComposer/middleware/textComposer/CommandSearchSource.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/CommandSearchSource.test.ts
@@ -83,6 +83,53 @@ describe('CommandSearchSource', () => {
     expect(newState.items).toEqual(initialState.items);
   });
 
+  describe('sorting', () => {
+    it('preserves the configured command order when the search query is empty', async () => {
+      const source = new CommandSearchSource(channel);
+      source.activate();
+
+      // The configured order (giphy, ban, mute, unmute) is intentionally not
+      // alphabetical. With an empty query every command matches, and the result
+      // must keep the configured order rather than being sorted alphabetically
+      // (which would be ban, giphy, mute, unmute).
+      const result = await source.query('');
+
+      expect(result.items.map((item) => item.name)).toEqual([
+        'giphy',
+        'ban',
+        'mute',
+        'unmute',
+      ]);
+    });
+
+    it('does not sort when the query is empty even if the config order is already non-alphabetical', async () => {
+      mockCommands = [
+        { name: 'zeta', description: '' },
+        { name: 'alpha', description: '' },
+        { name: 'gamma', description: '' },
+      ];
+      getConfigMock.mockReturnValue({ commands: mockCommands });
+      const source = new CommandSearchSource(channel);
+      source.activate();
+
+      const result = await source.query('');
+
+      expect(result.items.map((item) => item.name)).toEqual(['zeta', 'alpha', 'gamma']);
+    });
+
+    it('still sorts matches (prefix first, then alphabetical) when a query is provided', async () => {
+      const source = new CommandSearchSource(channel);
+      source.activate();
+
+      // 'u' matches 'mute' (config index 2) and 'unmute' (config index 3).
+      // 'unmute' is a prefix match, so it floats above 'mute' despite appearing
+      // later in the configured order.
+      const result = await source.query('u');
+
+      expect(result.items.map((item) => item.name)).toEqual(['unmute', 'mute']);
+    });
+  });
+
   it('should not decorate commands with disabled state', async () => {
     mockCommands = [
       { name: 'ban', description: 'Ban a user', set: 'moderation_set' },


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

This PR should fix [this issue](https://app.notion.com/p/stream-wiki/The-instant-commands-list-isn-t-in-the-order-defined-by-the-design-The-commands-appear-alphabetical-3826a5d7f9f6807fbb7be653a0175057?source=copy_link).

It prevents automatically sorting the commands alphabetically when no query has been applied, so as to prevent overriding the sorting that comes from the backend. Commands can be sorted on their own (order of application on the dashboard) and this order is always respected in the response for each `channel`.

## Changelog

-
