### PR TITLE
fix: prevent user mentions when missing CreateMention permission

### DIFF
--- a/src/messageComposer/middleware/textComposer/mentions.ts
+++ b/src/messageComposer/middleware/textComposer/mentions.ts
@@ -142,7 +142,7 @@ export const getAllowedMentionTypesFromCapabilities = (
   channel: hasOwnCapability(ownCapabilities, 'notify-channel'),
   here: hasOwnCapability(ownCapabilities, 'notify-here'),
   role: hasOwnCapability(ownCapabilities, 'notify-role'),
-  user: true,
+  user: hasOwnCapability(ownCapabilities, 'create-mention'),
   user_group: hasOwnCapability(ownCapabilities, 'notify-group'),
 });
 

--- a/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
@@ -61,7 +61,8 @@ describe('calculateLevenshtein', () => {
   });
 });
 
-const ALL_NOTIFY_MENTION_CAPABILITIES = [
+const ALL_MENTION_CAPABILITIES = [
+  'create-mention',
   'notify-channel',
   'notify-group',
   'notify-here',
@@ -136,7 +137,7 @@ describe('MentionsSearchSource', () => {
 
     channel = {
       data: {
-        own_capabilities: [...ALL_NOTIFY_MENTION_CAPABILITIES],
+        own_capabilities: [...ALL_MENTION_CAPABILITIES],
         team: 'engineering',
       },
       getClient: vi.fn().mockReturnValue(client),
@@ -190,22 +191,29 @@ describe('MentionsSearchSource', () => {
       channel: false,
       here: false,
       role: false,
-      user: true,
+      user: false,
       user_group: false,
     });
-    expect(
-      getAllowedMentionTypesFromCapabilities([...ALL_NOTIFY_MENTION_CAPABILITIES]),
-    ).toEqual({
-      channel: true,
-      here: true,
-      role: true,
-      user: true,
-      user_group: true,
-    });
+    expect(getAllowedMentionTypesFromCapabilities([...ALL_MENTION_CAPABILITIES])).toEqual(
+      {
+        channel: true,
+        here: true,
+        role: true,
+        user: true,
+        user_group: true,
+      },
+    );
     expect(getAllowedMentionTypesFromCapabilities(['notify-role'])).toEqual({
       channel: false,
       here: false,
       role: true,
+      user: false,
+      user_group: false,
+    });
+    expect(getAllowedMentionTypesFromCapabilities(['create-mention'])).toEqual({
+      channel: false,
+      here: false,
+      role: false,
       user: true,
       user_group: false,
     });
@@ -404,7 +412,7 @@ describe('MentionsSearchSource', () => {
     );
   });
 
-  it('should skip special mention queries when own_capabilities are missing', async () => {
+  it('should skip mention queries when own_capabilities are missing', async () => {
     channel.data = { team: 'engineering' };
     const source = new MentionsSearchSource(channel);
     source.activate();
@@ -416,12 +424,12 @@ describe('MentionsSearchSource', () => {
     expect(client.searchUserGroups).not.toHaveBeenCalled();
     expect(getSuggestion(result.items, 'channel', 'channel')).toBeUndefined();
     expect(getSuggestion(result.items, 'here', 'here')).toBeUndefined();
-    expect(result.items.every((item) => item.mentionType === 'user')).toBe(true);
+    expect(result.items).toEqual([]);
   });
 
   it('should only query mention sources allowed by own_capabilities', async () => {
     channel.data = {
-      own_capabilities: ['notify-role'],
+      own_capabilities: ['notify-role', 'create-mention'],
       team: 'engineering',
     };
     const source = new MentionsSearchSource(channel);


### PR DESCRIPTION
## Goal

Prevent including users / members in mentions suggestions when CreateMention channel permission is missing in `own_capabilities`.

Up until now, the `'create-mention'` was not included in `own_capabilities` and so the client side code could not perform decision, whether user mentions can be used during the message composition.