### PR TITLE
fix(thread): handle notification.mark_unread event

### DIFF
--- a/src/thread.ts
+++ b/src/thread.ts
@@ -272,6 +272,7 @@ export class Thread extends WithSubscriptions {
     this.addUnsubscribeFunction(this.subscribeMarkThreadStale());
     this.addUnsubscribeFunction(this.subscribeNewReplies());
     this.addUnsubscribeFunction(this.subscribeRepliesRead());
+    this.addUnsubscribeFunction(this.subscribeRepliesMarkUnread());
     this.addUnsubscribeFunction(this.subscribeMessageDeleted());
     this.addUnsubscribeFunction(this.subscribeMessageUpdated());
   };
@@ -402,6 +403,35 @@ export class Thread extends WithSubscriptions {
             user,
             lastReadMessageId: event.last_read_message_id,
             unreadMessageCount: 0,
+          },
+        },
+      }));
+    }).unsubscribe;
+
+  private subscribeRepliesMarkUnread = () =>
+    this.client.on('notification.mark_unread', (event) => {
+      // Filter: must have required fields and match this thread
+      if (!event.user || !event.last_read_at || !event.thread) return;
+      if (event.thread.parent_message_id !== this.id) return;
+
+      // Filter: only process own user's events (can't mark unread for others)
+      const ownMessage = event.user.id === this.client.user?.id;
+      if (!ownMessage) return;
+
+      const userId = event.user.id;
+      const user = event.user;
+      const lastReadAt = event.last_read_at;
+      const unreadCount = event.unread_messages ?? 0;
+
+      this.state.next((current) => ({
+        ...current,
+        read: {
+          ...current.read,
+          [userId]: {
+            lastReadAt: new Date(lastReadAt),
+            user,
+            lastReadMessageId: event.last_read_message_id,
+            unreadMessageCount: unreadCount,
           },
         },
       }));

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -814,6 +814,118 @@ describe('Threads 2.0', () => {
         });
       });
 
+      describe('Event: notification.mark_unread', () => {
+        it('does not update read state with events from other threads', () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: TEST_USER_ID },
+                unread_messages: 0,
+              },
+            ],
+          });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.read[TEST_USER_ID]?.unreadMessageCount).to.equal(0);
+
+          client.dispatchEvent({
+            type: 'notification.mark_unread',
+            user: { id: TEST_USER_ID },
+            unread_messages: 5,
+            last_read_at: new Date().toISOString(),
+            thread: generateThreadResponse(
+              channelResponse,
+              generateMsg(), // Different parent message ID
+            ) as ThreadResponse,
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.read[TEST_USER_ID]?.unreadMessageCount).to.equal(0);
+
+          thread.unregisterSubscriptions();
+        });
+
+        it('does not update read state when event is for a different user', () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: TEST_USER_ID },
+                unread_messages: 0,
+                last_read_message_id: 'msg-1',
+              },
+            ],
+          });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.read[TEST_USER_ID]?.unreadMessageCount).to.equal(0);
+
+          // Dispatch event for a DIFFERENT user (bob), not the current user
+          client.dispatchEvent({
+            type: 'notification.mark_unread',
+            user: { id: 'bob' }, // bob is NOT the current user (TEST_USER_ID)
+            unread_messages: 5,
+            last_read_at: new Date().toISOString(),
+            last_read_message_id: 'msg-4',
+            thread: generateThreadResponse(
+              channelResponse,
+              generateMsg({ id: parentMessageResponse.id }),
+            ) as ThreadResponse,
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+          // TEST_USER_ID's state should remain unchanged because event was for 'bob'
+          expect(stateAfter.read[TEST_USER_ID]?.unreadMessageCount).to.equal(0);
+          expect(stateAfter.read[TEST_USER_ID]?.lastReadMessageId).to.equal('msg-1');
+
+          thread.unregisterSubscriptions();
+        });
+
+        it('correctly updates unread count for current user', () => {
+          const lastReadAt = new Date();
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: lastReadAt.toISOString(),
+                last_read_message_id: 'msg-1',
+                unread_messages: 0,
+                user: { id: TEST_USER_ID },
+              },
+            ],
+          });
+          thread.registerSubscriptions();
+
+          const stateBefore = thread.state.getLatestValue();
+          expect(stateBefore.read[TEST_USER_ID]?.unreadMessageCount).to.equal(0);
+
+          const newLastReadAt = new Date(lastReadAt.getTime() - 60000); // 1 minute earlier
+
+          client.dispatchEvent({
+            type: 'notification.mark_unread',
+            user: { id: TEST_USER_ID },
+            unread_messages: 5,
+            last_read_at: newLastReadAt.toISOString(),
+            last_read_message_id: 'msg-4',
+            thread: generateThreadResponse(
+              channelResponse,
+              generateMsg({ id: parentMessageResponse.id }),
+            ) as ThreadResponse,
+          });
+
+          const stateAfter = thread.state.getLatestValue();
+          expect(stateAfter.read[TEST_USER_ID]?.unreadMessageCount).to.equal(5);
+          expect(stateAfter.read[TEST_USER_ID]?.lastReadAt.toISOString()).to.equal(
+            newLastReadAt.toISOString(),
+          );
+          expect(stateAfter.read[TEST_USER_ID]?.lastReadMessageId).to.equal('msg-4');
+
+          thread.unregisterSubscriptions();
+        });
+      });
+
       describe('Event: message.new', () => {
         it('ignores a reply if it does not belong to the associated thread', () => {
           const thread = createTestThread();


### PR DESCRIPTION
## Summary

Fixes #3076

`Thread` currently subscribes to `message.read` events to keep its read state up to date, but never subscribes to `notification.mark_unread` events. This means that when a user marks a thread as unread, the `Thread`'s local state never reflects it — `unreadMessageCount` stays stale until the thread is reloaded.

## Root cause

`Channel` already has a working handler for `notification.mark_unread` (see `channel.ts`), and `Thread` already has all the state infrastructure needed (`ThreadUserReadState` with `unreadMessageCount`, `lastReadAt`, `lastReadMessageId`) — it was just never wired up to this event.

## Changes

- Added `subscribeRepliesMarkUnread()` to `Thread`, following the same `.on()` + filter pattern as the existing `subscribeRepliesRead()`
- Registered the new subscription in `registerSubscriptions()`
- Added 3 new test cases in `threads.test.ts`:
  - Ignores events from other threads (filtered by `parent_message_id`)
  - Ignores events for other users (only updates the current user's state)
  - Correctly updates `unreadMessageCount`, `lastReadAt`, and `lastReadMessageId` for the current user

## Testing

All existing tests in `threads.test.ts` pass (87/87), including the 3 new ones added for this fix.

## Notes

- Did not add `first_unread_message_id` tracking since `ThreadUserReadState` doesn't currently have an equivalent field (unlike `ChannelState`) — happy to add this in a follow-up if desired.
- Did not call `messageReceiptsTracker`, consistent with the existing `subscribeRepliesRead()` handler, since thread delivery receipts aren't supported yet.

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
