### PR TITLE
fix: run type tests under TypeScript 6 and add missing response fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test": "yarn test-unit",
     "test-types": "yarn run-test-types && yarn run-types-gen",
     "run-test-types": "node test/typescript/index.js",
-    "run-types-gen": "tsc --esModuleInterop true --noEmit true --strictNullChecks true --noImplicitAny true --strict true test/typescript/*.ts",
+    "run-types-gen": "tsc -p test/typescript/tsconfig.json",
     "test-unit": "vitest",
     "test-coverage": "vitest run --coverage",
     "fix-staged": "lint-staged --config .lintstagedrc.fix.json --concurrent 1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export type AppSettingsAPIResponse = APIResponse & {
     id?: string | number;
     allow_multi_user_devices?: boolean;
     feed_audit_logs_enabled?: boolean;
+    moderation_onboarding_complete?: boolean | null;
     // TODO
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     call_types: any;

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,7 @@ export type AppSettingsAPIResponse = APIResponse & {
   app?: {
     id?: string | number;
     allow_multi_user_devices?: boolean;
+    feed_audit_logs_enabled?: boolean;
     // TODO
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     call_types: any;
@@ -2533,6 +2534,7 @@ export type BlockList = {
   team?: string;
   type?: string;
   validate?: boolean;
+  is_confusable_folding_enabled?: boolean;
   is_leet_check_enabled?: boolean;
   is_plural_check_enabled?: boolean;
 };
@@ -2692,6 +2694,7 @@ export type ConnectionOpen = {
   connection_id: string;
   cid?: string;
   created_at?: string;
+  received_at?: string;
   me?: OwnUserResponse;
   type?: string;
 };

--- a/test/typescript/tsconfig.json
+++ b/test/typescript/tsconfig.json
@@ -1,8 +1,17 @@
 {
+  // Type-checks the generated API response fixtures (data.ts) and the
+  // hand-written unit-test.ts against the built declarations in dist/types.
+  //
+  // Extends the root config so module resolution, lib and strictness (notably
+  // moduleResolution "bundler" and skipLibCheck) match what `yarn build`
+  // emits. Invoked via `tsc -p` (see the run-types-gen script): passing the
+  // files on the command line instead trips TypeScript 6's error TS5112
+  // ("tsconfig.json is present but will not be loaded if files are specified
+  // on commandline").
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "noImplicitAny": true,
-    "strict": true,
-    "strictNullChecks": true
-  }
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["./*.ts"]
 }


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Two related changes, both driven by getting `yarn test-types` healthy again.

### 1. Run the API type-definition tests under TypeScript 6

**What / Why.** TypeScript was bumped to `^6.0.3` in #1742. TS6 makes it a **hard error (TS5112)** to specify files on the command line while a `tsconfig.json` is in scope:

```
error TS5112: tsconfig.json is present but will not be loaded if files are
specified on commandline. Use '--ignoreConfig' to skip this error.
```

`run-types-gen` did exactly that (`tsc … test/typescript/*.ts`), so every `yarn test-types` run failed. (It only ever surfaced in the weekly **Scheduled tests** job — `type.yml` is disabled — and the 3× retry can't help a deterministic error.)

**How.**
- `run-types-gen` now runs `tsc -p test/typescript/tsconfig.json` (project mode — no files on the command line, so no TS5112).
- That config now **extends the root `tsconfig.json`** so module resolution (`moduleResolution: bundler`) and `skipLibCheck` match what `yarn build` emits — without it, `tsc`'s bare CLI defaults fail on `TS1340` for the emitted `import("ws")` type in `dist/types/insights.d.ts`.
- Added `noEmit: true` (the old config had none, so on error `tsc` emitted stray `.js` files).

The SDK source itself was already TS6-clean (`yarn types`/`build`/`lint`/unit tests all pass under TS 6.0.3).

### 2. Add missing fields to API response types

With the type tests running again, they surfaced three fields the live API returns that the SDK response types didn't declare (the same drift already failing the scheduled job back in May). Added as optional fields:

- `received_at` → `ConnectionOpen`
- `is_confusable_folding_enabled` → `BlockList` / `BlockListResponse`
- `feed_audit_logs_enabled` → `AppSettingsAPIResponse.app`

### Verification
- **Local (TS 6.0.3):** TS5112 gone; `run-types-gen` confirmed to still catch drift; all three new fields recognized after rebuild; `yarn types`, `yarn build`, `yarn lint`, `yarn vitest run` green.
- **End-to-end:** ran the real `yarn test-types` against the live API by dispatching the Scheduled tests workflow on this branch. The first run proved TS5112 was gone and failed only on the three drift fields above; a follow-up run after adding the fields confirms the result (see comments).

## Changelog

- Add optional `received_at` (`ConnectionOpen`), `is_confusable_folding_enabled` (`BlockList`/`BlockListResponse`) and `feed_audit_logs_enabled` (app settings) to the response types.
- Internal: the API type-definition tests (`yarn test-types`) now run under TypeScript 6.
