### PR TITLE
feat: allow augmenting event types

### DIFF
--- a/src/custom_types.ts
+++ b/src/custom_types.ts
@@ -2,6 +2,7 @@ export interface CustomAttachmentData {}
 export interface CustomChannelData {}
 export interface CustomCommandData {}
 export interface CustomEventData {}
+export interface CustomEventTypes {}
 export interface CustomMemberData {}
 export interface CustomMessageData {}
 export interface CustomPollOptionData {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type {
   CustomChannelData,
   CustomCommandData,
   CustomEventData,
+  CustomEventTypes,
   CustomMemberData,
   CustomMessageComposerData,
   CustomMessageData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import type {
   CustomChannelData,
   CustomCommandData,
   CustomEventData,
+  CustomEventTypes,
   CustomMemberData,
   CustomMessageData,
   CustomPollData,
@@ -1702,7 +1703,7 @@ export type UserCustomEvent = CustomEventData & {
 
 export type EventHandler = (event: Event) => void;
 
-export type EventTypes = 'all' | keyof typeof EVENT_MAP;
+export type EventTypes = 'all' | keyof typeof EVENT_MAP | keyof CustomEventTypes;
 
 /**
  * Filter Types


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Adds a new exported interface `CustomEventTypes`. It should be a map where keys are custom event type strings. That allows augmenting SDK's `EventTypes` union with more types:

```ts
import { StreamChat, type EventTypes } from "stream-chat";

declare module "stream-chat" {
  interface CustomEventTypes {
    "custom.event": true;
  }
}

type R = "custom.event" extends EventTypes ? "yes" : "no"; // --> "yes"
new StreamChat("...").channel("...").sendEvent({
  type: "custom.event", // --> allowed
});
```

Useful in combination with `CustomEventData`.

Nice next step, but out of scope for this PR, is strongly typing event data based on event type - both for internal and custom events.