### PR TITLE
fix(push-preferences): align chat push preference types with the API

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -21,6 +21,7 @@ import type {
   ChannelFilters,
   ChannelMemberAPIResponse,
   ChannelMemberResponse,
+  ChannelPushPreference,
   ChannelQueryOptions,
   ChannelResponse,
   ChannelUpdateOptions,
@@ -56,7 +57,6 @@ import type {
   PinnedMessagePaginationOptions,
   PinnedMessagesSort,
   PollVoteData,
-  PushPreference,
   QueryChannelAPIResponse,
   QueryMembersOptions,
   Reaction,
@@ -112,7 +112,7 @@ export class Channel {
   lastTypingEvent: Date | null;
   isTyping: boolean;
   disconnected: boolean;
-  push_preferences?: PushPreference;
+  push_preferences?: ChannelPushPreference;
   public readonly messageComposer: MessageComposer;
   public readonly messageReceiptsTracker: MessageReceiptsTracker;
   public readonly cooldownTimer: CooldownTimer;

--- a/src/types.ts
+++ b/src/types.ts
@@ -694,6 +694,8 @@ export type ChatLevelPushPreference =
   | 'default'
   | (string & {});
 
+export type CallLevelPushPreference = 'all' | 'none' | 'default' | (string & {});
+
 /** Granular all/none toggle used by the chat sub-preferences. */
 export type PushPreferenceLevel = 'all' | 'none' | (string & {});
 
@@ -716,6 +718,7 @@ export type ChatPreferences = {
  * defaults to the connected user for client-side auth.
  */
 export type PushPreference = {
+  call_level?: CallLevelPushPreference;
   channel_cid?: string;
   chat_level?: ChatLevelPushPreference;
   chat_preferences?: ChatPreferences;
@@ -726,6 +729,7 @@ export type PushPreference = {
 
 /** Per-user push preferences returned by the API (matches OpenAPI `PushPreferencesResponse`). */
 export type PushPreferencesResponse = {
+  call_level?: CallLevelPushPreference;
   chat_level?: ChatLevelPushPreference;
   chat_preferences?: ChatPreferences;
   disabled_until?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -380,7 +380,7 @@ export type ChannelAPIResponse = {
   hidden?: boolean;
   membership?: ChannelMemberResponse | null;
   pending_messages?: PendingMessageResponse[];
-  push_preferences?: PushPreference;
+  push_preferences?: ChannelPushPreference;
   read?: ReadResponse[];
   threads?: ThreadResponse[];
   watcher_count?: number;
@@ -685,25 +685,63 @@ export type GetUnreadCountAPIResponse = APIResponse & {
   total_unread_count_by_team?: Record<string, number>;
 };
 
-export type ChatLevelPushPreference = 'all' | 'none' | 'mentions' | (string & {});
+export type ChatLevelPushPreference =
+  | 'all'
+  | 'mentions' // deprecated by the API in favor of 'direct_mentions'
+  | 'direct_mentions'
+  | 'all_mentions'
+  | 'none'
+  | 'default'
+  | (string & {});
 
-export type PushPreference = {
-  callLevel?: 'all' | 'none' | (string & {});
-  chatLevel?: ChatLevelPushPreference;
-  disabledUntil?: string; // snooze till this time
-  removeDisable?: boolean; // Temporary flag for resetting disabledUntil
+/** Granular all/none toggle used by the chat sub-preferences. */
+export type PushPreferenceLevel = 'all' | 'none' | (string & {});
+
+/** Per-mention-type chat push preferences (matches OpenAPI `ChatPreferencesInput`). */
+export type ChatPreferences = {
+  channel_mentions?: PushPreferenceLevel;
+  default_preference?: PushPreferenceLevel;
+  direct_mentions?: PushPreferenceLevel;
+  group_mentions?: PushPreferenceLevel;
+  here_mentions?: PushPreferenceLevel;
+  role_mentions?: PushPreferenceLevel;
+  thread_replies?: PushPreferenceLevel;
 };
 
+/**
+ * Input accepted by {@link StreamChat.setPushPreferences} (matches OpenAPI `PushPreferenceInput`).
+ *
+ * Set `channel_cid` to scope the preference to a single channel; leave it empty to
+ * set the user-level default. `user_id` is required for server-side auth and
+ * defaults to the connected user for client-side auth.
+ */
+export type PushPreference = {
+  channel_cid?: string;
+  chat_level?: ChatLevelPushPreference;
+  chat_preferences?: ChatPreferences;
+  disabled_until?: string; // snooze until this time
+  remove_disable?: boolean; // stop snoozing (clears disabled_until)
+  user_id?: string;
+};
+
+/** Per-user push preferences returned by the API (matches OpenAPI `PushPreferencesResponse`). */
+export type PushPreferencesResponse = {
+  chat_level?: ChatLevelPushPreference;
+  chat_preferences?: ChatPreferences;
+  disabled_until?: string;
+};
+
+/** Per-channel push preferences returned by the API (matches OpenAPI `ChannelPushPreferencesResponse`). */
 export type ChannelPushPreference = {
-  chatLevel?: ChatLevelPushPreference; // "all", "none", "mentions", or other custom strings
-  disabledUntil?: string;
-  removeDisable?: boolean; // Temporary flag for resetting disabledUntil
+  chat_level?: ChatLevelPushPreference; // "all", "mentions", "direct_mentions", "all_mentions", "none", "default" or other custom strings
+  disabled_until?: string;
 };
 
 export type UpsertPushPreferencesResponse = APIResponse & {
-  // Mapping of user IDs to their push preferences
-  userChannelPreferences: Record<string, Record<string, ChannelPushPreference>>;
-  userPreferences: Record<string, PushPreference>; // Mapping of user -> channel id -> push preferences
+  // Mapping of user id -> channel cid -> channel push preferences
+  user_channel_preferences: Record<string, Record<string, ChannelPushPreference>>;
+  // Mapping of user id -> user push preferences
+  user_preferences: Record<string, PushPreferencesResponse>;
 };
 
 export type GetUnreadCountBatchAPIResponse = APIResponse & {
@@ -862,7 +900,7 @@ export type OwnUserBase = {
   unread_threads: number;
   invisible?: boolean;
   privacy_settings?: PrivacySettings;
-  push_preferences?: PushPreference;
+  push_preferences?: PushPreferencesResponse;
   roles?: string[];
   total_unread_count_by_team?: Record<string, number> | null;
 };


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

**What** — Re-models the chat push notification preference types so they match the client-side API.

**Why** — Reported in GetStream/stream-chat-react-native#3341. The shipped `PushPreference` was camelCase (`callLevel`, `chatLevel`, `disabledUntil`, `removeDisable`) and missing `channel_cid` / `user_id`, so channel-level and server-side preferences couldn't be set type-safely. The canonical client-side OpenAPI spec (`chat-openapi-clientside.yaml`) shows `/push_preferences` is entirely **snake_case**, and `setPushPreferences` posts the body verbatim (no camelCase→snake_case transform) — so the existing camelCase keys never reached the server.

**How** — Aligned to `PushPreferenceInput` / `PushPreferencesResponse` / `ChannelPushPreferencesResponse`, scoped to chat and calls (feeds out of scope):

- `PushPreference` (input): `call_level`, `channel_cid`, `chat_level`, `chat_preferences`, `disabled_until`, `remove_disable`, `user_id`.
- New `ChatPreferences` (granular per-mention prefs) and `PushPreferencesResponse`.
- Widened `ChatLevelPushPreference` to `all | mentions | direct_mentions | all_mentions | none | default`.
- Fixed `ChannelPushPreference`, `UpsertPushPreferencesResponse`, and `push_preferences` on `ChannelAPIResponse` / `OwnUserBase`.
- `client.setPushPreferences(prefs: PushPreference[])` is unchanged — it already wraps the array as `{ preferences }`.

⚠️ **Breaking (type-level):** the old camelCase keys are **removed**, not kept as aliases — `callLevel`, `chatLevel`, `disabledUntil`, `removeDisable` on the input types and `userPreferences` / `userChannelPreferences` on the response. They were silently ignored by the server (input) or never populated (response), so nothing breaks at runtime, but code referencing the old names will need to switch to snake_case.

Verified with `yarn types` and `yarn lint` (zero warnings); full unit suite green.

## Changelog

- Fix `PushPreference` types to match the API: add `channel_cid` and `user_id`, switch to snake_case (`chat_level`, `chat_preferences`, `disabled_until`, `remove_disable`), add `ChatPreferences` / `PushPreferencesResponse`, and remove the non-functional camelCase keys.
