### PR TITLE
feat: localized unread count

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1250,7 +1250,7 @@ export class Channel {
   /**
    * markReadLocally - Resets this user's unread count locally, without any backend call. Intended for
    * channels that have read events disabled (e.g. livestreams) when the client is created with the
-   * `enableLocalUnreadCount` option. Dispatches a dedicated, client-only `message.local_read` event
+   * `isLocalUnreadCountEnabled` option. Dispatches a dedicated, client-only `message.local_read` event
    * that runs through the same `_handleChannelEvent` read logic as a real `message.read` (minus the
    * delivery-report network sync), so the read-state update lives in one place. When offline support
    * is enabled, the offline DB persists the reset for read-events-disabled channels, so the local
@@ -1470,8 +1470,8 @@ export class Channel {
       return false;
 
     // Return false if channel doesn't allow read events, unless the client opted into a local
-    // unread count (e.g. livestreams where read events are disabled). See `enableLocalUnreadCount`.
-    if (!this.getClient().options.enableLocalUnreadCount && !this.hasReadEvents()) {
+    // unread count (e.g. livestreams where read events are disabled). See `isLocalUnreadCountEnabled`.
+    if (!this.getClient().options.isLocalUnreadCountEnabled && !this.hasReadEvents()) {
       return false;
     }
 
@@ -2004,7 +2004,7 @@ export class Channel {
         }
         break;
       // `message.local_read` is the client-only event dispatched by `markReadLocally()` when read
-      // events are disabled (e.g. livestreams with `enableLocalUnreadCount`). It reuses the exact
+      // events are disabled (e.g. livestreams with `isLocalUnreadCountEnabled`). It reuses the exact
       // `message.read` state logic so the read-state update lives in one place — only the
       // delivery-report network sync below is skipped for it.
       case 'message.local_read':

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1248,12 +1248,13 @@ export class Channel {
   }
 
   /**
-   * markReadLocally - Resets this user's unread count locally, without any backend call or offline-DB
-   * write. Intended for channels that have read events disabled (e.g. livestreams) when the client is
-   * created with the `enableLocalUnreadCount` option. Dispatches a dedicated, client-only
-   * `message.local_read` event that runs through the same `_handleChannelEvent` read logic as a real
-   * `message.read` (minus the delivery-report network sync), so the read-state update lives in one
-   * place. The offline DB has no handler for the type, so nothing is persisted.
+   * markReadLocally - Resets this user's unread count locally, without any backend call. Intended for
+   * channels that have read events disabled (e.g. livestreams) when the client is created with the
+   * `enableLocalUnreadCount` option. Dispatches a dedicated, client-only `message.local_read` event
+   * that runs through the same `_handleChannelEvent` read logic as a real `message.read` (minus the
+   * delivery-report network sync), so the read-state update lives in one place. When offline support
+   * is enabled, the offline DB persists the reset for read-events-disabled channels, so the local
+   * count stays consistent across app restarts.
    */
   markReadLocally() {
     const client = this.getClient();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1248,6 +1248,31 @@ export class Channel {
   }
 
   /**
+   * markReadLocally - Resets this user's unread count locally, without any backend call or offline-DB
+   * write. Intended for channels that have read events disabled (e.g. livestreams) when the client is
+   * created with the `enableLocalUnreadCount` option. Dispatches a dedicated, client-only
+   * `message.local_read` event that runs through the same `_handleChannelEvent` read logic as a real
+   * `message.read` (minus the delivery-report network sync), so the read-state update lives in one
+   * place. The offline DB has no handler for the type, so nothing is persisted.
+   */
+  markReadLocally() {
+    const client = this.getClient();
+    if (!client.userID) return;
+
+    const event: Event = {
+      channel_id: this.id,
+      channel_type: this.type,
+      cid: this.cid,
+      created_at: new Date().toISOString(),
+      last_read_message_id: this.lastMessage()?.id,
+      team: this.data?.team,
+      type: 'message.local_read',
+      user: client.user,
+    };
+    client.dispatchEvent(event);
+  }
+
+  /**
    * clean - Cleans the channel state and fires stop typing if needed
    */
   clean() {
@@ -1429,8 +1454,10 @@ export class Channel {
     if (message.user?.id && this.getClient().userMuteStatus(message.user.id))
       return false;
 
-    // Return false if channel doesn't allow read events.
+    // Return false if channel doesn't allow read events, unless the client opted into a local
+    // unread count (e.g. livestreams where read events are disabled). See `enableLocalUnreadCount`.
     if (
+      !this.getClient().options.enableLocalUnreadCount &&
       Array.isArray(this.data?.own_capabilities) &&
       !this.data?.own_capabilities.includes('read-events')
     ) {
@@ -1965,6 +1992,11 @@ export class Channel {
           delete channelState.typing[event.user.id];
         }
         break;
+      // `message.local_read` is the client-only event dispatched by `markReadLocally()` when read
+      // events are disabled (e.g. livestreams with `enableLocalUnreadCount`). It reuses the exact
+      // `message.read` state logic so the read-state update lives in one place — only the
+      // delivery-report network sync below is skipped for it.
+      case 'message.local_read':
       case 'message.read':
         if (event.user?.id && event.created_at) {
           const previousReadState = channelState.read[event.user.id];
@@ -1987,7 +2019,11 @@ export class Channel {
 
           if (isOwnEvent) {
             channelState.unreadCount = 0;
-            client.syncDeliveredCandidates([this]);
+            // Delivery reporting buffers a `markChannelsDelivered` network request; the local read
+            // must not hit the backend, so only sync for the real server `message.read`.
+            if (event.type === 'message.read') {
+              client.syncDeliveredCandidates([this]);
+            }
           }
         }
         break;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1446,6 +1446,20 @@ export class Channel {
     }
   }
 
+  /**
+   * hasReadEvents - Whether read events are enabled for the current user on this channel. The channel
+   * is treated as not having read events only when its `own_capabilities` are known and exclude
+   * `read-events` (e.g. livestreams); when capabilities are unknown we assume read events are enabled.
+   *
+   * @return {boolean}
+   */
+  hasReadEvents() {
+    return !(
+      Array.isArray(this.data?.own_capabilities) &&
+      !this.data.own_capabilities.includes('read-events')
+    );
+  }
+
   _countMessageAsUnread(message: LocalMessage | MessageResponse) {
     if (message.shadowed) return false;
     if (message.silent) return false;
@@ -1456,11 +1470,7 @@ export class Channel {
 
     // Return false if channel doesn't allow read events, unless the client opted into a local
     // unread count (e.g. livestreams where read events are disabled). See `enableLocalUnreadCount`.
-    if (
-      !this.getClient().options.enableLocalUnreadCount &&
-      Array.isArray(this.data?.own_capabilities) &&
-      !this.data?.own_capabilities.includes('read-events')
-    ) {
+    if (!this.getClient().options.enableLocalUnreadCount && !this.hasReadEvents()) {
       return false;
     }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -4,6 +4,7 @@ import { CooldownTimer } from './CooldownTimer';
 import { MessageComposer } from './messageComposer';
 import { MessageReceiptsTracker } from './messageDelivery';
 import {
+  channelHasReadEvents,
   generateChannelTempCid,
   logChatPromiseExecution,
   messageSetPagination,
@@ -1451,20 +1452,6 @@ export class Channel {
     }
   }
 
-  /**
-   * hasReadEvents - Whether read events are enabled for the current user on this channel. The channel
-   * is treated as not having read events only when its `own_capabilities` are known and exclude
-   * `read-events` (e.g. livestreams); when capabilities are unknown we assume read events are enabled.
-   *
-   * @return {boolean}
-   */
-  hasReadEvents() {
-    return !(
-      Array.isArray(this.data?.own_capabilities) &&
-      !this.data.own_capabilities.includes('read-events')
-    );
-  }
-
   _countMessageAsUnread(message: LocalMessage | MessageResponse) {
     if (message.shadowed) return false;
     if (message.silent) return false;
@@ -1475,7 +1462,10 @@ export class Channel {
 
     // Return false if channel doesn't allow read events, unless the client opted into a local
     // unread count (e.g. livestreams where read events are disabled). See `isLocalUnreadCountEnabled`.
-    if (!this.getClient().options.isLocalUnreadCountEnabled && !this.hasReadEvents()) {
+    if (
+      !this.getClient().options.isLocalUnreadCountEnabled &&
+      !channelHasReadEvents(this)
+    ) {
       return false;
     }
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1250,13 +1250,13 @@ export class Channel {
   /**
    * markReadLocally - Resets this user's unread count locally, without any backend call. Intended for
    * channels that have read events disabled (e.g. livestreams) when the client is created with the
-   * `isLocalUnreadCountEnabled` option. Dispatches a dedicated, client-only `message.local_read` event
+   * `isLocalUnreadCountEnabled` option. Dispatches a dedicated, client-only `message.read_locally` event
    * that runs through the same `_handleChannelEvent` read logic as a real `message.read` (minus the
    * delivery-report network sync), so the read-state update lives in one place. When offline support
    * is enabled, the offline DB persists the reset for read-events-disabled channels, so the local
    * count stays consistent across app restarts.
    *
-   * @return {Event | undefined} The dispatched `message.local_read` event, or `undefined` if there is no connected user.
+   * @return {Event | undefined} The dispatched `message.read_locally` event, or `undefined` if there is no connected user.
    */
   markReadLocally() {
     const client = this.getClient();
@@ -1269,7 +1269,7 @@ export class Channel {
       created_at: new Date().toISOString(),
       last_read_message_id: this.lastMessage()?.id,
       team: this.data?.team,
-      type: 'message.local_read',
+      type: 'message.read_locally',
       user: client.user,
     };
     client.dispatchEvent(event);
@@ -2007,11 +2007,11 @@ export class Channel {
           delete channelState.typing[event.user.id];
         }
         break;
-      // `message.local_read` is the client-only event dispatched by `markReadLocally()` when read
+      // `message.read_locally` is the client-only event dispatched by `markReadLocally()` when read
       // events are disabled (e.g. livestreams with `isLocalUnreadCountEnabled`). It reuses the exact
       // `message.read` state logic so the read-state update lives in one place — only the
       // delivery-report network sync below is skipped for it.
-      case 'message.local_read':
+      case 'message.read_locally':
       case 'message.read':
         if (event.user?.id && event.created_at) {
           const previousReadState = channelState.read[event.user.id];

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1255,6 +1255,8 @@ export class Channel {
    * delivery-report network sync), so the read-state update lives in one place. When offline support
    * is enabled, the offline DB persists the reset for read-events-disabled channels, so the local
    * count stays consistent across app restarts.
+   *
+   * @return {Event | undefined} The dispatched `message.local_read` event, or `undefined` if there is no connected user.
    */
   markReadLocally() {
     const client = this.getClient();
@@ -1271,6 +1273,8 @@ export class Channel {
       user: client.user,
     };
     client.dispatchEvent(event);
+
+    return event;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -467,7 +467,7 @@ export class StreamChat {
       warmUp: false,
       recoverStateOnReconnect: true,
       disableCache: false,
-      enableLocalUnreadCount: false,
+      isLocalUnreadCountEnabled: false,
       wsUrlParams: new URLSearchParams({}),
       ...inputOptions,
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -467,6 +467,7 @@ export class StreamChat {
       warmUp: false,
       recoverStateOnReconnect: true,
       disableCache: false,
+      enableLocalUnreadCount: false,
       wsUrlParams: new URLSearchParams({}),
       ...inputOptions,
     };

--- a/src/events.ts
+++ b/src/events.ts
@@ -63,7 +63,7 @@ export const EVENT_MAP = {
   'ai_indicator.clear': true,
 
   // local events
-  'message.local_read': true,
+  'message.read_locally': true,
   'channels.queried': true,
   'offline_reactions.queried': true,
   'connection.changed': true,

--- a/src/events.ts
+++ b/src/events.ts
@@ -63,6 +63,7 @@ export const EVENT_MAP = {
   'ai_indicator.clear': true,
 
   // local events
+  'message.local_read': true,
   'channels.queried': true,
   'offline_reactions.queried': true,
   'connection.changed': true,

--- a/src/messageDelivery/MessageDeliveryReporter.ts
+++ b/src/messageDelivery/MessageDeliveryReporter.ts
@@ -10,7 +10,7 @@ import type {
   MarkReadOptions,
 } from '../types';
 import { type APIErrorResponse } from '../types';
-import { throttle } from '../utils';
+import { throttle, userHasReadReceipts } from '../utils';
 import { isAPIError, isErrorRetryable } from '../errors';
 
 const MAX_DELIVERED_MESSAGE_COUNT_IN_PAYLOAD = 100 as const;
@@ -279,6 +279,8 @@ export class MessageDeliveryReporter {
    * @param options
    */
   public markRead = async (collection: Channel | Thread, options?: MarkReadOptions) => {
+    if (!userHasReadReceipts(this.client)) return null;
+
     let result: EventAPIResponse | null = null;
     if (isChannel(collection)) {
       result = await collection.markAsReadRequest(options);

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -609,9 +609,14 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
         if (cid && client.user && client.user.id !== user?.id) {
           const userId = client.user.id;
           const channel = client.activeChannels[cid];
-          // Skip persisting read state for channels without read events (e.g. livestreams): the
-          // unread count there is client-local and must never be written to the offline DB.
-          if (channel && channel.hasReadEvents()) {
+          // Persist the current user's read state for channels that track reads server-side. When the
+          // client opted into a local unread count, also persist it for read-events-disabled channels
+          // (e.g. livestreams) so the client-local count survives a cold start. The server never sends
+          // a read for those, so state.read[userId] may be absent here; fall back accordingly and rely
+          // on countUnread() (the aggregate the local count maintains) for the value.
+          const tracksReadLocally =
+            !channel?.hasReadEvents() && !!client.options.enableLocalUnreadCount;
+          if (channel && (channel.hasReadEvents() || tracksReadLocally)) {
             const ownReads = channel.state.read[userId];
             const unreadCount = channel.countUnread();
             const upsertReadsQueries = await this.upsertReads({
@@ -619,8 +624,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
               execute: false,
               reads: [
                 {
-                  last_read: ownReads.last_read.toISOString() as string,
-                  last_read_message_id: ownReads.last_read_message_id,
+                  last_read: (ownReads?.last_read ?? new Date(0)).toISOString() as string,
+                  last_read_message_id: ownReads?.last_read_message_id,
                   unread_messages: unreadCount,
                   user: client.user,
                 },
@@ -871,11 +876,15 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
 
       let finalQueries = [...truncateQueries];
 
-      // Only persist read state for channels with read events. For read-events-disabled channels
-      // (e.g. livestreams) the unread count is client-local and must not be written to the offline DB.
+      // Persist read state for channels that track reads server-side. When the client opted into a
+      // local unread count, also persist it for read-events-disabled channels (e.g. livestreams) so
+      // the client-local count survives a cold start. state.read[userId] may be absent for those, so
+      // fall back accordingly.
       const userId = ownUser.id;
       const activeChannel = this.client.activeChannels[cid];
-      if (activeChannel?.hasReadEvents()) {
+      const tracksReadLocally =
+        !activeChannel?.hasReadEvents() && !!this.client.options.enableLocalUnreadCount;
+      if (activeChannel && (activeChannel.hasReadEvents() || tracksReadLocally)) {
         const ownReads = activeChannel.state.read[userId];
 
         let unreadCount = 0;
@@ -888,8 +897,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
           execute: false,
           reads: [
             {
-              last_read: ownReads.last_read.toString() as string,
-              last_read_message_id: ownReads.last_read_message_id,
+              last_read: (ownReads?.last_read ?? new Date(0)).toString() as string,
+              last_read_message_id: ownReads?.last_read_message_id,
               unread_messages: unreadCount,
               user: ownUser,
             },
@@ -1024,6 +1033,21 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
 
     if (type === 'message.read' || type === 'notification.mark_read') {
       return this.handleRead({ event, unreadMessages: 0, execute });
+    }
+
+    // `message.local_read` is the client-only reset dispatched by `Channel.markReadLocally()`. Only
+    // persist it for read-events-disabled channels with the local unread count opted in (the only
+    // situation it is ever dispatched), so it can never touch channels that track reads server-side.
+    if (type === 'message.local_read') {
+      const localChannel = event.cid ? this.client.activeChannels[event.cid] : undefined;
+      if (
+        localChannel &&
+        !localChannel.hasReadEvents() &&
+        this.client.options.enableLocalUnreadCount
+      ) {
+        return this.handleRead({ event, unreadMessages: 0, execute });
+      }
+      return [];
     }
 
     if (type === 'notification.mark_unread') {

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -609,7 +609,9 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
         if (cid && client.user && client.user.id !== user?.id) {
           const userId = client.user.id;
           const channel = client.activeChannels[cid];
-          if (channel) {
+          // Skip persisting read state for channels without read events (e.g. livestreams): the
+          // unread count there is client-local and must never be written to the offline DB.
+          if (channel && channel.hasReadEvents()) {
             const ownReads = channel.state.read[userId];
             const unreadCount = channel.countUnread();
             const upsertReadsQueries = await this.upsertReads({
@@ -867,31 +869,34 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
         execute: false,
       });
 
+      let finalQueries = [...truncateQueries];
+
+      // Only persist read state for channels with read events. For read-events-disabled channels
+      // (e.g. livestreams) the unread count is client-local and must not be written to the offline DB.
       const userId = ownUser.id;
       const activeChannel = this.client.activeChannels[cid];
-      const ownReads = activeChannel.state.read[userId];
+      if (activeChannel?.hasReadEvents()) {
+        const ownReads = activeChannel.state.read[userId];
 
-      let unreadCount = 0;
+        let unreadCount = 0;
+        if (truncated_at) {
+          unreadCount = activeChannel.countUnread(new Date(truncated_at));
+        }
 
-      if (truncated_at) {
-        const truncatedAt = new Date(truncated_at);
-        unreadCount = activeChannel.countUnread(truncatedAt);
+        const upsertReadQueries = await this.upsertReads({
+          cid,
+          execute: false,
+          reads: [
+            {
+              last_read: ownReads.last_read.toString() as string,
+              last_read_message_id: ownReads.last_read_message_id,
+              unread_messages: unreadCount,
+              user: ownUser,
+            },
+          ],
+        });
+        finalQueries = [...finalQueries, ...upsertReadQueries];
       }
-
-      const upsertReadQueries = await this.upsertReads({
-        cid,
-        execute: false,
-        reads: [
-          {
-            last_read: ownReads.last_read.toString() as string,
-            last_read_message_id: ownReads.last_read_message_id,
-            unread_messages: unreadCount,
-            user: ownUser,
-          },
-        ],
-      });
-
-      const finalQueries = [...truncateQueries, ...upsertReadQueries];
 
       if (execute) {
         await this.executeSqlBatch(finalQueries);

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -615,7 +615,7 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
           // a read for those, so state.read[userId] may be absent here; fall back accordingly and rely
           // on countUnread() (the aggregate the local count maintains) for the value.
           const tracksReadLocally =
-            !channel?.hasReadEvents() && !!client.options.enableLocalUnreadCount;
+            !channel?.hasReadEvents() && !!client.options.isLocalUnreadCountEnabled;
           if (channel && (channel.hasReadEvents() || tracksReadLocally)) {
             const ownReads = channel.state.read[userId];
             const unreadCount = channel.countUnread();
@@ -883,7 +883,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       const userId = ownUser.id;
       const activeChannel = this.client.activeChannels[cid];
       const tracksReadLocally =
-        !activeChannel?.hasReadEvents() && !!this.client.options.enableLocalUnreadCount;
+        !activeChannel?.hasReadEvents() &&
+        !!this.client.options.isLocalUnreadCountEnabled;
       if (activeChannel && (activeChannel.hasReadEvents() || tracksReadLocally)) {
         const ownReads = activeChannel.state.read[userId];
 
@@ -1043,7 +1044,7 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       if (
         localChannel &&
         !localChannel.hasReadEvents() &&
-        this.client.options.enableLocalUnreadCount
+        this.client.options.isLocalUnreadCountEnabled
       ) {
         return this.handleRead({ event, unreadMessages: 0, execute });
       }

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -18,7 +18,11 @@ import type { StreamChat } from '../client';
 import type { AxiosError } from 'axios';
 import { OfflineDBSyncManager } from './offline_sync_manager';
 import { StateStore } from '../store';
-import { localMessageToNewMessagePayload, runDetached } from '../utils';
+import {
+  channelHasReadEvents,
+  localMessageToNewMessagePayload,
+  runDetached,
+} from '../utils';
 import { isMessageUpdateReplayable } from './util';
 
 /**
@@ -614,9 +618,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
           // (e.g. livestreams) so the client-local count survives a cold start. The server never sends
           // a read for those, so state.read[userId] may be absent here; fall back accordingly and rely
           // on countUnread() (the aggregate the local count maintains) for the value.
+          const readEventsEnabled = channel ? channelHasReadEvents(channel) : true;
           const tracksReadLocally =
-            !channel?.hasReadEvents() && !!client.options.isLocalUnreadCountEnabled;
-          if (channel && (channel.hasReadEvents() || tracksReadLocally)) {
+            !readEventsEnabled && !!client.options.isLocalUnreadCountEnabled;
+          if (channel && (readEventsEnabled || tracksReadLocally)) {
             const ownReads = channel.state.read[userId];
             const unreadCount = channel.countUnread();
             const upsertReadsQueries = await this.upsertReads({
@@ -882,10 +887,12 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       // fall back accordingly.
       const userId = ownUser.id;
       const activeChannel = this.client.activeChannels[cid];
+      const readEventsEnabled = activeChannel
+        ? channelHasReadEvents(activeChannel)
+        : true;
       const tracksReadLocally =
-        !activeChannel?.hasReadEvents() &&
-        !!this.client.options.isLocalUnreadCountEnabled;
-      if (activeChannel && (activeChannel.hasReadEvents() || tracksReadLocally)) {
+        !readEventsEnabled && !!this.client.options.isLocalUnreadCountEnabled;
+      if (activeChannel && (readEventsEnabled || tracksReadLocally)) {
         const ownReads = activeChannel.state.read[userId];
 
         let unreadCount = 0;
@@ -1043,7 +1050,7 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       const localChannel = event.cid ? this.client.activeChannels[event.cid] : undefined;
       if (
         localChannel &&
-        !localChannel.hasReadEvents() &&
+        !channelHasReadEvents(localChannel) &&
         this.client.options.isLocalUnreadCountEnabled
       ) {
         return this.handleRead({ event, unreadMessages: 0, execute });

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1036,10 +1036,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       return this.handleRead({ event, unreadMessages: 0, execute });
     }
 
-    // `message.local_read` is the client-only reset dispatched by `Channel.markReadLocally()`. Only
+    // `message.read_locally` is the client-only reset dispatched by `Channel.markReadLocally()`. Only
     // persist it for read-events-disabled channels with the local unread count opted in (the only
     // situation it is ever dispatched), so it can never touch channels that track reads server-side.
-    if (type === 'message.local_read') {
+    if (type === 'message.read_locally') {
       const localChannel = event.cid ? this.client.activeChannels[event.cid] : undefined;
       if (
         localChannel &&

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -20,6 +20,7 @@ import { OfflineDBSyncManager } from './offline_sync_manager';
 import { StateStore } from '../store';
 import {
   channelHasReadEvents,
+  channelTracksReadLocally,
   localMessageToNewMessagePayload,
   runDetached,
 } from '../utils';
@@ -618,10 +619,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
           // (e.g. livestreams) so the client-local count survives a cold start. The server never sends
           // a read for those, so state.read[userId] may be absent here; fall back accordingly and rely
           // on countUnread() (the aggregate the local count maintains) for the value.
-          const readEventsEnabled = channel ? channelHasReadEvents(channel) : true;
-          const tracksReadLocally =
-            !readEventsEnabled && !!client.options.isLocalUnreadCountEnabled;
-          if (channel && (readEventsEnabled || tracksReadLocally)) {
+          const tracksReadLocally = channelTracksReadLocally(channel);
+          if (channel && (channelHasReadEvents(channel) || tracksReadLocally)) {
             const ownReads = channel.state.read[userId];
             const unreadCount = channel.countUnread();
             const upsertReadsQueries = await this.upsertReads({
@@ -887,12 +886,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
       // fall back accordingly.
       const userId = ownUser.id;
       const activeChannel = this.client.activeChannels[cid];
-      const readEventsEnabled = activeChannel
-        ? channelHasReadEvents(activeChannel)
-        : true;
-      const tracksReadLocally =
-        !readEventsEnabled && !!this.client.options.isLocalUnreadCountEnabled;
-      if (activeChannel && (readEventsEnabled || tracksReadLocally)) {
+      const tracksReadLocally = channelTracksReadLocally(activeChannel);
+      if (activeChannel && (channelHasReadEvents(activeChannel) || tracksReadLocally)) {
         const ownReads = activeChannel.state.read[userId];
 
         let unreadCount = 0;
@@ -1048,11 +1043,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     // situation it is ever dispatched), so it can never touch channels that track reads server-side.
     if (type === 'message.read_locally') {
       const localChannel = event.cid ? this.client.activeChannels[event.cid] : undefined;
-      if (
-        localChannel &&
-        !channelHasReadEvents(localChannel) &&
-        this.client.options.isLocalUnreadCountEnabled
-      ) {
+      // channelTracksReadLocally returns false when localChannel is undefined, so no extra guard.
+      if (channelTracksReadLocally(localChannel)) {
         return this.handleRead({ event, unreadMessages: 0, execute });
       }
       return [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1552,7 +1552,7 @@ export type StreamChatOptions = AxiosRequestConfig & {
   /**
    * When true, maintains a client-local unread count on channels that have read events disabled
    * (e.g. livestreams). The count increments on incoming messages and is reset via
-   * `channel.markReadLocally()`. It is never sent to the backend or persisted to the offline DB.
+   * `channel.markReadLocally()`. It is never sent to the backend, but is persisted to the offline DB.
    */
   isLocalUnreadCountEnabled?: boolean;
   /** experimental feature, please contact support if you want this feature enabled for you */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1554,7 +1554,7 @@ export type StreamChatOptions = AxiosRequestConfig & {
    * (e.g. livestreams). The count increments on incoming messages and is reset via
    * `channel.markReadLocally()`. It is never sent to the backend or persisted to the offline DB.
    */
-  enableLocalUnreadCount?: boolean;
+  isLocalUnreadCountEnabled?: boolean;
   /** experimental feature, please contact support if you want this feature enabled for you */
   enableWSFallback?: boolean;
   logger?: Logger;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1549,6 +1549,12 @@ export type StreamChatOptions = AxiosRequestConfig & {
    */
   disableCache?: boolean;
   enableInsights?: boolean;
+  /**
+   * When true, maintains a client-local unread count on channels that have read events disabled
+   * (e.g. livestreams). The count increments on incoming messages and is reset via
+   * `channel.markReadLocally()`. It is never sent to the backend or persisted to the offline DB.
+   */
+  enableLocalUnreadCount?: boolean;
   /** experimental feature, please contact support if you want this feature enabled for you */
   enableWSFallback?: boolean;
   logger?: Logger;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,6 +110,22 @@ export function isOwnUserBaseProperty(property: string) {
   return ownUserBaseProperties[property as keyof OwnUserBase];
 }
 
+/**
+ * channelHasReadEvents - Whether read events are enabled for the current user on a channel.
+ */
+export const channelHasReadEvents = (channel: Channel) =>
+  !(
+    Array.isArray(channel.data?.own_capabilities) &&
+    !channel.data.own_capabilities.includes('read-events')
+  );
+
+/**
+ * userHasReadReceipts - Whether the current user allows read receipts, per their privacy settings.
+ * Read receipts are treated as enabled unless the user has explicitly disabled them.
+ */
+export const userHasReadReceipts = (client: StreamChat) =>
+  client.user?.privacy_settings?.read_receipts?.enabled ?? true;
+
 export function addFileToFormData(
   uri: string | NodeJS.ReadableStream | Buffer | File,
   name?: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,11 +113,17 @@ export function isOwnUserBaseProperty(property: string) {
 /**
  * channelHasReadEvents - Whether read events are enabled for the current user on a channel.
  */
-export const channelHasReadEvents = (channel: Channel) =>
-  !(
-    Array.isArray(channel.data?.own_capabilities) &&
-    !channel.data.own_capabilities.includes('read-events')
-  );
+export const channelHasReadEvents = (channel?: Channel) => {
+  const ownCapabilities = channel?.data?.own_capabilities;
+  return !(Array.isArray(ownCapabilities) && !ownCapabilities.includes('read-events'));
+};
+
+/**
+ * channelTracksReadLocally - Whether a channel maintains a client local unread count.
+ */
+export const channelTracksReadLocally = (channel?: Channel) =>
+  !channelHasReadEvents(channel) &&
+  !!channel?.getClient().options.isLocalUnreadCountEnabled;
 
 /**
  * userHasReadReceipts - Whether the current user allows read receipts, per their privacy settings.

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -283,7 +283,7 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		const onLocalRead = vi.fn();
 		channel.on('message.local_read', onLocalRead);
 
-		channel.markReadLocally();
+		const returned = channel.markReadLocally();
 
 		expect(channel.countUnread()).to.be.equal(0);
 		expect(channel.state.read[user.id].unread_messages).to.be.equal(0);
@@ -299,6 +299,25 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		expect(event.user.id).to.be.equal(user.id);
 		expect(event.last_read_message_id).to.be.equal(lastMsg.id);
 		expect(event.created_at).to.be.a('string');
+
+		// markReadLocally returns the same dispatched event so callers (e.g. the RN SDK) can sync
+		// their own unread UI from that read info instead of re-deriving it.
+		expect(returned).to.equal(event);
+		expect(returned.last_read_message_id).to.be.equal(lastMsg.id);
+		expect(returned.created_at).to.be.a('string');
+	});
+
+	it('markReadLocally returns undefined and dispatches nothing when there is no connected user', function () {
+		const { client, channel } = setupChannel({ isLocalUnreadCountEnabled: true });
+		client.user = undefined;
+		client.userID = undefined;
+		const onLocalRead = vi.fn();
+		channel.on('message.local_read', onLocalRead);
+
+		const returned = channel.markReadLocally();
+
+		expect(returned).to.be.undefined;
+		expect(onLocalRead.mock.calls.length).to.be.equal(0);
 	});
 
 	it('markReadLocally resets the count and creates the own read row when none exists yet (fresh livestream)', function () {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -211,6 +211,97 @@ describe('Channel count unread', function () {
 	});
 });
 
+describe('Channel localized unread count (enableLocalUnreadCount)', function () {
+	const user = { id: 'user' };
+	const otherUser = { id: 'other-user' };
+
+	// own_capabilities without 'read-events' models a channel with read events disabled (livestream).
+	const setupChannel = ({ enableLocalUnreadCount }) => {
+		const client = new StreamChat('apiKey', { enableLocalUnreadCount });
+		client.user = user;
+		client.userID = user.id;
+		client.userMuteStatus = () => false;
+		const channel = client.channel('messaging', 'live-id');
+		channel.initialized = true;
+		channel.data = { ...channel.data, own_capabilities: [] };
+		return { client, channel };
+	};
+
+	it('_countMessageAsUnread returns true with read events off when the flag is set', function () {
+		const { channel } = setupChannel({ enableLocalUnreadCount: true });
+		expect(channel._countMessageAsUnread({ user: otherUser })).to.be.ok;
+	});
+
+	it('_countMessageAsUnread returns false with read events off when the flag is not set', function () {
+		const { channel } = setupChannel({ enableLocalUnreadCount: false });
+		expect(channel._countMessageAsUnread({ user: otherUser })).not.to.be.ok;
+	});
+
+	it('message.new increments the unread count with read events off when the flag is set', function () {
+		const { channel } = setupChannel({ enableLocalUnreadCount: true });
+		channel.state.unreadCount = 0;
+
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user: otherUser,
+			message: generateMsg({ user: otherUser }),
+		});
+		expect(channel.countUnread()).to.be.equal(1);
+
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user: otherUser,
+			message: generateMsg({ user: otherUser }),
+		});
+		expect(channel.countUnread()).to.be.equal(2);
+	});
+
+	it('message.new does not increment the unread count with read events off when the flag is not set', function () {
+		const { channel } = setupChannel({ enableLocalUnreadCount: false });
+		channel.state.unreadCount = 0;
+
+		channel._handleChannelEvent({
+			type: 'message.new',
+			user: otherUser,
+			message: generateMsg({ user: otherUser }),
+		});
+		expect(channel.countUnread()).to.be.equal(0);
+	});
+
+	it('markReadLocally resets the count and emits a message.read-shaped message.local_read event', function () {
+		const { client, channel } = setupChannel({ enableLocalUnreadCount: true });
+		const post = vi.spyOn(client, 'post').mockResolvedValue({});
+		const lastMsg = generateMsg({ user: otherUser });
+		channel.state.addMessagesSorted([lastMsg]);
+		channel.state.unreadCount = 5;
+		channel.state.read[user.id] = {
+			last_read: new Date('2020-01-01T00:00:00'),
+			unread_messages: 5,
+			user,
+		};
+
+		const onLocalRead = vi.fn();
+		channel.on('message.local_read', onLocalRead);
+
+		channel.markReadLocally();
+
+		expect(channel.countUnread()).to.be.equal(0);
+		expect(channel.state.read[user.id].unread_messages).to.be.equal(0);
+		expect(channel.state.read[user.id].last_read_message_id).to.be.equal(lastMsg.id);
+		expect(post.mock.calls.length).to.be.equal(0);
+
+		expect(onLocalRead.mock.calls.length).to.be.equal(1);
+		const event = onLocalRead.mock.calls[0][0];
+		expect(event.type).to.be.equal('message.local_read');
+		expect(event.cid).to.be.equal(channel.cid);
+		expect(event.channel_id).to.be.equal(channel.id);
+		expect(event.channel_type).to.be.equal(channel.type);
+		expect(event.user.id).to.be.equal(user.id);
+		expect(event.last_read_message_id).to.be.equal(lastMsg.id);
+		expect(event.created_at).to.be.a('string');
+	});
+});
+
 describe('Channel _handleChannelEvent', function () {
 	const user = { id: 'user' };
 	const otherUser = { id: 'other-user' };

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -300,6 +300,46 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		expect(event.last_read_message_id).to.be.equal(lastMsg.id);
 		expect(event.created_at).to.be.a('string');
 	});
+
+	it('markReadLocally resets the count and creates the own read row when none exists yet (fresh livestream)', function () {
+		const { client, channel } = setupChannel({ isLocalUnreadCountEnabled: true });
+		const post = vi.spyOn(client, 'post').mockResolvedValue({});
+		const lastMsg = generateMsg({ user: otherUser });
+		channel.state.addMessagesSorted([lastMsg]);
+		channel.state.unreadCount = 3;
+		delete channel.state.read[user.id];
+
+		channel.markReadLocally();
+
+		expect(channel.countUnread()).to.be.equal(0);
+		expect(channel.state.read[user.id]).to.be.ok;
+		expect(channel.state.read[user.id].unread_messages).to.be.equal(0);
+		expect(channel.state.read[user.id].last_read_message_id).to.be.equal(lastMsg.id);
+		expect(post.mock.calls.length).to.be.equal(0);
+	});
+});
+
+describe('Channel.hasReadEvents', function () {
+	const makeChannel = (own_capabilities) => {
+		const client = new StreamChat('apiKey');
+		client.user = { id: 'user' };
+		client.userID = 'user';
+		const channel = client.channel('messaging', 'cap-id');
+		channel.data = { ...channel.data, own_capabilities };
+		return channel;
+	};
+
+	it('returns true when own_capabilities includes read-events', function () {
+		expect(makeChannel(['read-events']).hasReadEvents()).to.equal(true);
+	});
+
+	it('returns false when own_capabilities is known and excludes read-events (e.g. livestream)', function () {
+		expect(makeChannel([]).hasReadEvents()).to.equal(false);
+	});
+
+	it('returns true (assumes read events on) when own_capabilities is unknown', function () {
+		expect(makeChannel(undefined).hasReadEvents()).to.equal(true);
+	});
 });
 
 describe('Channel _handleChannelEvent', function () {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -268,7 +268,7 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		expect(channel.countUnread()).to.be.equal(0);
 	});
 
-	it('markReadLocally resets the count and emits a message.read-shaped message.local_read event', function () {
+	it('markReadLocally resets the count and emits a message.read-shaped message.read_locally event', function () {
 		const { client, channel } = setupChannel({ isLocalUnreadCountEnabled: true });
 		const post = vi.spyOn(client, 'post').mockResolvedValue({});
 		const lastMsg = generateMsg({ user: otherUser });
@@ -281,7 +281,7 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		};
 
 		const onLocalRead = vi.fn();
-		channel.on('message.local_read', onLocalRead);
+		channel.on('message.read_locally', onLocalRead);
 
 		const returned = channel.markReadLocally();
 
@@ -292,7 +292,7 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 
 		expect(onLocalRead.mock.calls.length).to.be.equal(1);
 		const event = onLocalRead.mock.calls[0][0];
-		expect(event.type).to.be.equal('message.local_read');
+		expect(event.type).to.be.equal('message.read_locally');
 		expect(event.cid).to.be.equal(channel.cid);
 		expect(event.channel_id).to.be.equal(channel.id);
 		expect(event.channel_type).to.be.equal(channel.type);
@@ -312,7 +312,7 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 		client.user = undefined;
 		client.userID = undefined;
 		const onLocalRead = vi.fn();
-		channel.on('message.local_read', onLocalRead);
+		channel.on('message.read_locally', onLocalRead);
 
 		const returned = channel.markReadLocally();
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -211,13 +211,13 @@ describe('Channel count unread', function () {
 	});
 });
 
-describe('Channel localized unread count (enableLocalUnreadCount)', function () {
+describe('Channel localized unread count (isLocalUnreadCountEnabled)', function () {
 	const user = { id: 'user' };
 	const otherUser = { id: 'other-user' };
 
 	// own_capabilities without 'read-events' models a channel with read events disabled (livestream).
-	const setupChannel = ({ enableLocalUnreadCount }) => {
-		const client = new StreamChat('apiKey', { enableLocalUnreadCount });
+	const setupChannel = ({ isLocalUnreadCountEnabled }) => {
+		const client = new StreamChat('apiKey', { isLocalUnreadCountEnabled });
 		client.user = user;
 		client.userID = user.id;
 		client.userMuteStatus = () => false;
@@ -228,17 +228,17 @@ describe('Channel localized unread count (enableLocalUnreadCount)', function () 
 	};
 
 	it('_countMessageAsUnread returns true with read events off when the flag is set', function () {
-		const { channel } = setupChannel({ enableLocalUnreadCount: true });
+		const { channel } = setupChannel({ isLocalUnreadCountEnabled: true });
 		expect(channel._countMessageAsUnread({ user: otherUser })).to.be.ok;
 	});
 
 	it('_countMessageAsUnread returns false with read events off when the flag is not set', function () {
-		const { channel } = setupChannel({ enableLocalUnreadCount: false });
+		const { channel } = setupChannel({ isLocalUnreadCountEnabled: false });
 		expect(channel._countMessageAsUnread({ user: otherUser })).not.to.be.ok;
 	});
 
 	it('message.new increments the unread count with read events off when the flag is set', function () {
-		const { channel } = setupChannel({ enableLocalUnreadCount: true });
+		const { channel } = setupChannel({ isLocalUnreadCountEnabled: true });
 		channel.state.unreadCount = 0;
 
 		channel._handleChannelEvent({
@@ -257,7 +257,7 @@ describe('Channel localized unread count (enableLocalUnreadCount)', function () 
 	});
 
 	it('message.new does not increment the unread count with read events off when the flag is not set', function () {
-		const { channel } = setupChannel({ enableLocalUnreadCount: false });
+		const { channel } = setupChannel({ isLocalUnreadCountEnabled: false });
 		channel.state.unreadCount = 0;
 
 		channel._handleChannelEvent({
@@ -269,7 +269,7 @@ describe('Channel localized unread count (enableLocalUnreadCount)', function () 
 	});
 
 	it('markReadLocally resets the count and emits a message.read-shaped message.local_read event', function () {
-		const { client, channel } = setupChannel({ enableLocalUnreadCount: true });
+		const { client, channel } = setupChannel({ isLocalUnreadCountEnabled: true });
 		const post = vi.spyOn(client, 'post').mockResolvedValue({});
 		const lastMsg = generateMsg({ user: otherUser });
 		channel.state.addMessagesSorted([lastMsg]);

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -338,29 +338,6 @@ describe('Channel localized unread count (isLocalUnreadCountEnabled)', function 
 	});
 });
 
-describe('Channel.hasReadEvents', function () {
-	const makeChannel = (own_capabilities) => {
-		const client = new StreamChat('apiKey');
-		client.user = { id: 'user' };
-		client.userID = 'user';
-		const channel = client.channel('messaging', 'cap-id');
-		channel.data = { ...channel.data, own_capabilities };
-		return channel;
-	};
-
-	it('returns true when own_capabilities includes read-events', function () {
-		expect(makeChannel(['read-events']).hasReadEvents()).to.equal(true);
-	});
-
-	it('returns false when own_capabilities is known and excludes read-events (e.g. livestream)', function () {
-		expect(makeChannel([]).hasReadEvents()).to.equal(false);
-	});
-
-	it('returns true (assumes read events on) when own_capabilities is unknown', function () {
-		expect(makeChannel(undefined).hasReadEvents()).to.equal(true);
-	});
-});
-
 describe('Channel _handleChannelEvent', function () {
 	const user = { id: 'user' };
 	const otherUser = { id: 'other-user' };

--- a/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
+++ b/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
@@ -30,7 +30,9 @@ describe('MessageDeliveryReporter', () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     client = getClientWithUser(ownUser);
-    (client as any).user.privacy_settings.delivery_receipts.enabled = undefined;
+    // Rebuild privacy_settings on each run — `client.user` is the shared `ownUser` reference, so a
+    // fresh object keeps tests isolated (e.g. read_receipts set in one test can't leak into others).
+    (client as any).user.privacy_settings = { delivery_receipts: { enabled: undefined } };
 
     channel = client.channel(channelType, channelId);
     channel.initialized = true;
@@ -291,6 +293,18 @@ describe('MessageDeliveryReporter', () => {
         },
       ],
     });
+  });
+
+  it('does not send a read when the user disabled read receipts', async () => {
+    (client as any).user.privacy_settings = { read_receipts: { enabled: false } };
+    const markAsReadRequestSpy = vi
+      .spyOn(channel, 'markAsReadRequest')
+      .mockResolvedValue({} as any);
+
+    const result = await channel.markRead();
+
+    expect(markAsReadRequestSpy).not.toHaveBeenCalled();
+    expect(result).toBeNull();
   });
 
   it('removes the pending delivery candidate upon channel.markRead', async () => {

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -515,6 +515,23 @@ describe('OfflineSupportApi', () => {
           expect(result).toEqual(mockQueries);
         });
 
+        it('should not call upsertReads when the channel has read events disabled', async () => {
+          const noReadEventsResponse = generateChannel({
+            channel: { id: 'no-read-events', own_capabilities: [], type: 'messaging' },
+            read: [generateReadResponse({ user: client.user })],
+          } as ChannelAPIResponse);
+          client.hydrateActiveChannels([noReadEventsResponse]);
+
+          const result = await offlineDb.handleNewMessage({
+            event: { ...baseEvent, cid: noReadEventsResponse.channel.cid },
+            execute: false,
+          });
+
+          expect(offlineDb.upsertMessages).toHaveBeenCalled();
+          expect(offlineDb.upsertReads).not.toHaveBeenCalled();
+          expect(result).toEqual(mockUpsertMessagesQueries);
+        });
+
         it('should not call upsertReads if event.user is the same as client user', async () => {
           const eventWithSameUser = { ...baseEvent, user: client.user };
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -532,8 +532,8 @@ describe('OfflineSupportApi', () => {
           expect(result).toEqual(mockUpsertMessagesQueries);
         });
 
-        it('should call upsertReads for a read-events-disabled channel when enableLocalUnreadCount is on', async () => {
-          client.options.enableLocalUnreadCount = true;
+        it('should call upsertReads for a read-events-disabled channel when isLocalUnreadCountEnabled is on', async () => {
+          client.options.isLocalUnreadCountEnabled = true;
           // No `read` for the channel on purpose: the server omits it for read-events-disabled
           // channels, so the own-read row is absent and the persist must fall back gracefully.
           const localUnreadResponse = generateChannel({
@@ -1700,8 +1700,8 @@ describe('OfflineSupportApi', () => {
         });
 
         describe('message.local_read', () => {
-          it('routes to handleRead for a read-events-disabled channel when enableLocalUnreadCount is on', async () => {
-            client.options.enableLocalUnreadCount = true;
+          it('routes to handleRead for a read-events-disabled channel when isLocalUnreadCountEnabled is on', async () => {
+            client.options.isLocalUnreadCountEnabled = true;
             const localChannelResponse = generateChannel({
               channel: { id: 'local-read', own_capabilities: [], type: 'messaging' },
             } as unknown as ChannelAPIResponse);
@@ -1723,7 +1723,7 @@ describe('OfflineSupportApi', () => {
           });
 
           it('is a no-op when the channel has read events enabled', async () => {
-            client.options.enableLocalUnreadCount = true;
+            client.options.isLocalUnreadCountEnabled = true;
             const readEventsResponse = generateChannel({
               channel: {
                 id: 'read-events-on',
@@ -1744,7 +1744,7 @@ describe('OfflineSupportApi', () => {
             expect(result).toEqual([]);
           });
 
-          it('is a no-op when enableLocalUnreadCount is off', async () => {
+          it('is a no-op when isLocalUnreadCountEnabled is off', async () => {
             const localChannelResponse = generateChannel({
               channel: { id: 'local-read-off', own_capabilities: [], type: 'messaging' },
             } as ChannelAPIResponse);

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1753,7 +1753,7 @@ describe('OfflineSupportApi', () => {
           expect(offlineDb.deleteChannel).not.toHaveBeenCalled();
         });
 
-        describe('message.local_read', () => {
+        describe('message.read_locally', () => {
           it('routes to handleRead for a read-events-disabled channel when isLocalUnreadCountEnabled is on', async () => {
             client.options.isLocalUnreadCountEnabled = true;
             const localChannelResponse = generateChannel({
@@ -1762,7 +1762,7 @@ describe('OfflineSupportApi', () => {
             client.hydrateActiveChannels([localChannelResponse]);
             const event = {
               ...dummyEvent,
-              type: 'message.local_read',
+              type: 'message.read_locally',
               cid: localChannelResponse.channel.cid,
             } as Event;
 
@@ -1788,7 +1788,7 @@ describe('OfflineSupportApi', () => {
             client.hydrateActiveChannels([readEventsResponse]);
             const event = {
               ...dummyEvent,
-              type: 'message.local_read',
+              type: 'message.read_locally',
               cid: readEventsResponse.channel.cid,
             } as Event;
 
@@ -1805,7 +1805,7 @@ describe('OfflineSupportApi', () => {
             client.hydrateActiveChannels([localChannelResponse]);
             const event = {
               ...dummyEvent,
-              type: 'message.local_read',
+              type: 'message.read_locally',
               cid: localChannelResponse.channel.cid,
             } as Event;
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -532,6 +532,35 @@ describe('OfflineSupportApi', () => {
           expect(result).toEqual(mockUpsertMessagesQueries);
         });
 
+        it('should call upsertReads for a read-events-disabled channel when enableLocalUnreadCount is on', async () => {
+          client.options.enableLocalUnreadCount = true;
+          // No `read` for the channel on purpose: the server omits it for read-events-disabled
+          // channels, so the own-read row is absent and the persist must fall back gracefully.
+          const localUnreadResponse = generateChannel({
+            channel: { id: 'local-unread', own_capabilities: [], type: 'messaging' },
+          } as unknown as ChannelAPIResponse);
+          client.hydrateActiveChannels([localUnreadResponse]);
+
+          const result = await offlineDb.handleNewMessage({
+            event: { ...baseEvent, cid: localUnreadResponse.channel.cid },
+            execute: false,
+          });
+
+          expect(offlineDb.upsertMessages).toHaveBeenCalled();
+          expect(offlineDb.upsertReads).toHaveBeenCalledWith(
+            expect.objectContaining({
+              cid: localUnreadResponse.channel.cid,
+              reads: expect.arrayContaining([
+                expect.objectContaining({
+                  unread_messages: expect.any(Number),
+                  user: client.user,
+                }),
+              ]),
+            }),
+          );
+          expect(result).toEqual(mockQueries);
+        });
+
         it('should not call upsertReads if event.user is the same as client user', async () => {
           const eventWithSameUser = { ...baseEvent, user: client.user };
 
@@ -1668,6 +1697,69 @@ describe('OfflineSupportApi', () => {
           const result = await offlineDb.handleEvent({ event });
           expect(result).toEqual([]);
           expect(offlineDb.deleteChannel).not.toHaveBeenCalled();
+        });
+
+        describe('message.local_read', () => {
+          it('routes to handleRead for a read-events-disabled channel when enableLocalUnreadCount is on', async () => {
+            client.options.enableLocalUnreadCount = true;
+            const localChannelResponse = generateChannel({
+              channel: { id: 'local-read', own_capabilities: [], type: 'messaging' },
+            } as unknown as ChannelAPIResponse);
+            client.hydrateActiveChannels([localChannelResponse]);
+            const event = {
+              ...dummyEvent,
+              type: 'message.local_read',
+              cid: localChannelResponse.channel.cid,
+            } as Event;
+
+            const result = await offlineDb.handleEvent({ event });
+
+            expect(offlineDb.handleRead).toHaveBeenCalledWith({
+              event,
+              unreadMessages: 0,
+              execute: true,
+            });
+            expect(result).toEqual(['read']);
+          });
+
+          it('is a no-op when the channel has read events enabled', async () => {
+            client.options.enableLocalUnreadCount = true;
+            const readEventsResponse = generateChannel({
+              channel: {
+                id: 'read-events-on',
+                own_capabilities: ['read-events'],
+                type: 'messaging',
+              },
+            } as ChannelAPIResponse);
+            client.hydrateActiveChannels([readEventsResponse]);
+            const event = {
+              ...dummyEvent,
+              type: 'message.local_read',
+              cid: readEventsResponse.channel.cid,
+            } as Event;
+
+            const result = await offlineDb.handleEvent({ event });
+
+            expect(offlineDb.handleRead).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+          });
+
+          it('is a no-op when enableLocalUnreadCount is off', async () => {
+            const localChannelResponse = generateChannel({
+              channel: { id: 'local-read-off', own_capabilities: [], type: 'messaging' },
+            } as ChannelAPIResponse);
+            client.hydrateActiveChannels([localChannelResponse]);
+            const event = {
+              ...dummyEvent,
+              type: 'message.local_read',
+              cid: localChannelResponse.channel.cid,
+            } as Event;
+
+            const result = await offlineDb.handleEvent({ event });
+
+            expect(offlineDb.handleRead).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+          });
         });
       });
     });

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1397,6 +1397,60 @@ describe('OfflineSupportApi', () => {
           ]);
           expect(result).toEqual(['DELETE * FROM messages', 'UPDATE * IN reads']);
         });
+
+        it('persists the local unread count on truncate for a read-events-disabled channel when isLocalUnreadCountEnabled is on', async () => {
+          client.options.isLocalUnreadCountEnabled = true;
+          // read-events-disabled channel with no own-read row (the server omits it for these channels),
+          // so this also exercises the defensive last_read fallback.
+          const localChannelResponse = generateChannel({
+            channel: { id: 'local-truncate', own_capabilities: [], type: 'messaging' },
+          } as unknown as ChannelAPIResponse);
+          client.hydrateActiveChannels([localChannelResponse]);
+          const event = {
+            ...truncatedEvent,
+            channel: {
+              cid: localChannelResponse.channel.cid,
+              truncated_at: '2025-05-20T10:00:00Z',
+            } as ChannelResponse,
+          };
+          vi.spyOn(
+            client.activeChannels[localChannelResponse.channel.cid],
+            'countUnread',
+          ).mockReturnValue(3);
+
+          await offlineDb.handleChannelTruncatedEvent({ event, execute: false });
+
+          expect(offlineDb.deleteMessagesForChannel).toHaveBeenCalled();
+          expect(offlineDb.upsertReads).toHaveBeenCalledWith(
+            expect.objectContaining({
+              cid: localChannelResponse.channel.cid,
+              reads: [expect.objectContaining({ unread_messages: 3, user: client.user })],
+            }),
+          );
+        });
+
+        it('does not persist read state on truncate for a read-events-disabled channel when isLocalUnreadCountEnabled is off', async () => {
+          const localChannelResponse = generateChannel({
+            channel: {
+              id: 'local-truncate-off',
+              own_capabilities: [],
+              type: 'messaging',
+            },
+          } as ChannelAPIResponse);
+          client.hydrateActiveChannels([localChannelResponse]);
+          const event = {
+            ...truncatedEvent,
+            channel: {
+              cid: localChannelResponse.channel.cid,
+              truncated_at: '2025-05-20T10:00:00Z',
+            } as ChannelResponse,
+          };
+
+          await offlineDb.handleChannelTruncatedEvent({ event, execute: false });
+
+          expect(offlineDb.deleteMessagesForChannel).toHaveBeenCalled();
+          expect(offlineDb.upsertReads).not.toHaveBeenCalled();
+        });
       });
 
       describe('handleDraftEvent', () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -12,6 +12,8 @@ import {
   getAndWatchChannel,
   addToMessageList,
   findIndexInSortedArray,
+  channelHasReadEvents,
+  userHasReadReceipts,
   formatMessage,
   generateChannelTempCid,
   shouldConsiderArchivedChannels,
@@ -1169,5 +1171,54 @@ describe('sleep', () => {
     vi.advanceTimersByTime(1000);
     await waitPromise;
     expect(resolved).toBe(true);
+  });
+});
+
+describe('channelHasReadEvents', () => {
+  const makeChannel = (own_capabilities?: string[]) => {
+    const client = new StreamChat('apiKey');
+    client.user = { id: 'user' };
+    client.userID = 'user';
+    const channel = client.channel('messaging', 'cap-id');
+    channel.data = { own_capabilities };
+    return channel;
+  };
+
+  it('returns true when own_capabilities includes read-events', () => {
+    expect(channelHasReadEvents(makeChannel(['read-events']))).toBe(true);
+  });
+
+  it('returns false when own_capabilities is known and excludes read-events (e.g. livestream)', () => {
+    expect(channelHasReadEvents(makeChannel([]))).toBe(false);
+  });
+
+  it('returns true (assumes read events on) when own_capabilities is unknown', () => {
+    expect(channelHasReadEvents(makeChannel(undefined))).toBe(true);
+  });
+});
+
+describe('userHasReadReceipts', () => {
+  const makeClient = (readReceiptsEnabled?: boolean) => {
+    const client = new StreamChat('apiKey');
+    client.user = {
+      id: 'user',
+      privacy_settings:
+        readReceiptsEnabled === undefined
+          ? undefined
+          : { read_receipts: { enabled: readReceiptsEnabled } },
+    };
+    return client;
+  };
+
+  it('returns true when read receipts are enabled', () => {
+    expect(userHasReadReceipts(makeClient(true))).toBe(true);
+  });
+
+  it('returns false when read receipts are explicitly disabled', () => {
+    expect(userHasReadReceipts(makeClient(false))).toBe(false);
+  });
+
+  it('returns true (assumes enabled) when privacy settings are unset', () => {
+    expect(userHasReadReceipts(makeClient(undefined))).toBe(true);
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -13,6 +13,7 @@ import {
   addToMessageList,
   findIndexInSortedArray,
   channelHasReadEvents,
+  channelTracksReadLocally,
   userHasReadReceipts,
   formatMessage,
   generateChannelTempCid,
@@ -1194,6 +1195,55 @@ describe('channelHasReadEvents', () => {
 
   it('returns true (assumes read events on) when own_capabilities is unknown', () => {
     expect(channelHasReadEvents(makeChannel(undefined))).toBe(true);
+  });
+
+  it('returns true when the channel is undefined', () => {
+    expect(channelHasReadEvents(undefined)).toBe(true);
+  });
+});
+
+describe('channelTracksReadLocally', () => {
+  const setup = ({
+    isLocalUnreadCountEnabled,
+    own_capabilities,
+  }: {
+    isLocalUnreadCountEnabled?: boolean;
+    own_capabilities?: string[];
+  }) => {
+    const client = new StreamChat('apiKey', { isLocalUnreadCountEnabled });
+    client.user = { id: 'user' };
+    client.userID = 'user';
+    const channel = client.channel('messaging', 'cap-id');
+    channel.data = { own_capabilities };
+    return { client, channel };
+  };
+
+  it('returns true when read events are disabled and local unread count is enabled', () => {
+    const { channel } = setup({
+      isLocalUnreadCountEnabled: true,
+      own_capabilities: [],
+    });
+    expect(channelTracksReadLocally(channel)).toBe(true);
+  });
+
+  it('returns false when the channel has read events', () => {
+    const { channel } = setup({
+      isLocalUnreadCountEnabled: true,
+      own_capabilities: ['read-events'],
+    });
+    expect(channelTracksReadLocally(channel)).toBe(false);
+  });
+
+  it('returns false when local unread count is disabled', () => {
+    const { channel } = setup({
+      isLocalUnreadCountEnabled: false,
+      own_capabilities: [],
+    });
+    expect(channelTracksReadLocally(channel)).toBe(false);
+  });
+
+  it('returns false when the channel is undefined', () => {
+    expect(channelTracksReadLocally(undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Spec: https://stream-wiki.notion.site/Local-Unread-Count-specification-38b6a5d7f9f68073a5e1c73298fe0d71                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                        
Adds an optin, client side unread count for channels that have read events disabled (e.g. livestreams). Those channels normally don't track unread at all and so `_countMessageAsUnread` bails out whenever `own_capabilities` lacks `read-events`, so integrators have no "N new messages" affordance to show while scrolled up.
                                                                                                                                                                                                                                                                                                                        
With the new `isLocalUnreadCountEnabled` client option (default `false`), the SDK maintains a purely local unread count for those channels. It increments on incoming messages and is reset via the new `channel.markReadLocally()` method, which dispatches a client only `message.local_read` event. That event reuses the exact `message.read` state logic in `_handleChannelEvent` (so read state updates stay in one place) but skips `syncDeliveredCandidates()`, so the count is never sent to the backend. `hasReadEvents()` centralizes the capability check.                                                                                       
                                                                                                                                                                                                                                                                                                                        
When offline support is enabled, the local read/unread state is persisted for channels with disabled `read-events` so the count survives a cold start. The offline DB handles `message.local_read` (guarded so it can only affect channels with disabled `read-events` channels with the option on) and falls back gracefully when `state.read[userId]` is absent, since the server never sends a read for these channels.                                                                                                                                
                                                                                                                                                                                                                                                                                                                        
Behavior is fully gated behind the flag, so default off means no change for existing integrations.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                        
## Changelog                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                        
- Add `isLocalUnreadCountEnabled` client option for a client side unread count on channels with disabled `read-events` (e.g. livestreams)                                                                                                                                                                                        
- Add `Channel.markReadLocally()` to reset the local unread count with no backend call                                                                                                                                                                                                                                    
- Add `Channel.hasReadEvents()` helper                                                                                                                                                                                                                                                                                    
- Add client only `message.local_read` event                                                                                                                                                                                                                                                                              
- Persist local unread state to the offline DB so it survives app restarts             
