### PR TITLE
fix: evict channel from activeChannels when the current user is removed

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1641,6 +1641,27 @@ export class StreamChat {
       });
     }
 
+    // When the current user is removed from a channel the server delivers a
+    // `notification.removed_from_channel` event (only to the removed user — it is
+    // the authoritative signal that this client lost access). Mirror the
+    // channel.deleted eviction so we stop tracking the channel: drop it from
+    // `activeChannels` and disconnect it. Without this, `recoverState()` would
+    // re-watch it on reconnect (it re-watches every cid still in `activeChannels`)
+    // and later channel events would keep being delivered. See
+    // GetStream/stream-chat-react#2599. Channel type is intentionally not checked —
+    // the event itself, not the channel, drives the decision.
+    // Unlike the deletion path above, we intentionally do NOT call
+    // `deleteAllChannelReference(cid)`: the channel still exists for its remaining
+    // members, only this client lost access, so we just stop tracking it locally.
+    if (event.type === 'notification.removed_from_channel' && event.cid) {
+      const { cid } = event;
+      this.activeChannels[cid]?._disconnect();
+
+      postListenerCallbacks.push(() => {
+        delete this.activeChannels[cid];
+      });
+    }
+
     return postListenerCallbacks;
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1641,18 +1641,10 @@ export class StreamChat {
       });
     }
 
-    // When the current user is removed from a channel the server delivers a
-    // `notification.removed_from_channel` event (only to the removed user — it is
-    // the authoritative signal that this client lost access). Mirror the
-    // channel.deleted eviction so we stop tracking the channel: drop it from
-    // `activeChannels` and disconnect it. Without this, `recoverState()` would
-    // re-watch it on reconnect (it re-watches every cid still in `activeChannels`)
-    // and later channel events would keep being delivered. See
-    // GetStream/stream-chat-react#2599. Channel type is intentionally not checked —
-    // the event itself, not the channel, drives the decision.
-    // Unlike the deletion path above, we intentionally do NOT call
-    // `deleteAllChannelReference(cid)`: the channel still exists for its remaining
-    // members, only this client lost access, so we just stop tracking it locally.
+    // Current user removed from a channel: evict it like channel.deleted so
+    // recoverState won't re-watch it and no further events reach it (#2599).
+    // Type-agnostic. We skip deleteAllChannelReference (unlike deletion) since
+    // the channel still exists for its remaining members.
     if (event.type === 'notification.removed_from_channel' && event.cid) {
       const { cid } = event;
       this.activeChannels[cid]?._disconnect();

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1911,3 +1911,139 @@ describe('markChannelsDelivered', () => {
 		);
 	});
 });
+
+// Regression coverage for GetStream/stream-chat-react#2599.
+// When the current user is removed from a channel the server sends a
+// `notification.removed_from_channel` event. Previously the client only evicted
+// channels from `activeChannels` on deletion, so a removed-from channel lingered:
+// later `message.new` / `notification.message_new` events were still delivered to
+// it, and on reconnect `recoverState()` re-watched it (because it re-watches every
+// cid still in `activeChannels`), re-promoting it in downstream lists.
+describe('activeChannels eviction when the current user is removed (#2599)', () => {
+	let client;
+	const currentUserId = 'current-user';
+
+	beforeEach(async () => {
+		client = await getClientWithUser({ id: currentUserId });
+	});
+
+	const removedFromChannelEvent = (channel) => ({
+		type: 'notification.removed_from_channel',
+		cid: channel.cid,
+		channel_type: channel.type,
+		channel_id: channel.id,
+	});
+
+	it('evicts the channel from activeChannels and disconnects it on notification.removed_from_channel', () => {
+		const channel = client.channel('messaging', 'ch-removed');
+		const disconnectSpy = vi.spyOn(channel, '_disconnect');
+		expect(client.activeChannels[channel.cid]).to.equal(channel);
+
+		client.dispatchEvent(removedFromChannelEvent(channel));
+
+		expect(disconnectSpy).toHaveBeenCalledTimes(1);
+		expect(client.activeChannels[channel.cid]).to.be.undefined;
+	});
+
+	it('evicts regardless of channel type (does not special-case the channel type)', () => {
+		const channels = [
+			client.channel('livestream', 'stream-1'),
+			client.channel('team', 'team-1'),
+			client.channel('gaming', 'game-1'),
+		];
+		channels.forEach((channel) => {
+			expect(client.activeChannels[channel.cid]).to.equal(channel);
+		});
+
+		channels.forEach((channel) => {
+			client.dispatchEvent(removedFromChannelEvent(channel));
+		});
+
+		channels.forEach((channel) => {
+			expect(client.activeChannels[channel.cid]).to.be.undefined;
+		});
+	});
+
+	it('stops routing channel events (message.new) to the channel once it is evicted', () => {
+		const channel = client.channel('messaging', 'ch-events');
+		const handleChannelEventSpy = vi.spyOn(channel, '_handleChannelEvent');
+		const messageNewEvent = {
+			type: 'message.new',
+			cid: channel.cid,
+			channel_type: channel.type,
+			channel_id: channel.id,
+			message: generateMsg(),
+		};
+
+		// Before removal the event is routed to the channel.
+		client.dispatchEvent(messageNewEvent);
+		expect(handleChannelEventSpy).toHaveBeenCalledTimes(1);
+
+		client.dispatchEvent(removedFromChannelEvent(channel));
+		handleChannelEventSpy.mockClear();
+
+		// After removal the same event is no longer routed to the (evicted) channel —
+		// this is the downstream symptom from #2599 (a removed channel kept receiving
+		// new messages and got re-promoted in the ChannelList).
+		client.dispatchEvent(messageNewEvent);
+		expect(handleChannelEventSpy).not.toHaveBeenCalled();
+		expect(client.activeChannels[channel.cid]).to.be.undefined;
+	});
+
+	it('does not re-watch the evicted channel on recoverState', async () => {
+		const removed = client.channel('messaging', 'removed');
+		const kept = client.channel('messaging', 'kept');
+		const queryChannelsStub = vi.spyOn(client, 'queryChannels').mockResolvedValue([]);
+
+		client.dispatchEvent(removedFromChannelEvent(removed));
+
+		await client.recoverState();
+
+		expect(queryChannelsStub).toHaveBeenCalledTimes(1);
+		const [filters] = queryChannelsStub.mock.calls[0];
+		expect(filters.cid.$in).to.contain(kept.cid);
+		expect(filters.cid.$in).not.to.contain(removed.cid);
+	});
+
+	it('does not evict when another user is removed (member.removed for a different user)', () => {
+		const channel = client.channel('messaging', 'ch-other-member');
+		const disconnectSpy = vi.spyOn(channel, '_disconnect');
+
+		client.dispatchEvent({
+			type: 'member.removed',
+			cid: channel.cid,
+			channel_type: channel.type,
+			channel_id: channel.id,
+			user: { id: 'some-other-user' },
+			member: { user_id: 'some-other-user', user: { id: 'some-other-user' } },
+		});
+
+		expect(disconnectSpy).not.toHaveBeenCalled();
+		expect(client.activeChannels[channel.cid]).to.equal(channel);
+	});
+
+	it('still evicts on channel.deleted and notification.channel_deleted (no regression)', () => {
+		const deleted = client.channel('messaging', 'deleted-1');
+		const notifDeleted = client.channel('messaging', 'deleted-2');
+		const deletedDisconnect = vi.spyOn(deleted, '_disconnect');
+		const notifDeletedDisconnect = vi.spyOn(notifDeleted, '_disconnect');
+
+		client.dispatchEvent({
+			type: 'channel.deleted',
+			cid: deleted.cid,
+			channel_type: deleted.type,
+			channel_id: deleted.id,
+		});
+		client.dispatchEvent({
+			type: 'notification.channel_deleted',
+			cid: notifDeleted.cid,
+			channel_type: notifDeleted.type,
+			channel_id: notifDeleted.id,
+		});
+
+		expect(deletedDisconnect).toHaveBeenCalledTimes(1);
+		expect(notifDeletedDisconnect).toHaveBeenCalledTimes(1);
+		expect(client.activeChannels[deleted.cid]).to.be.undefined;
+		expect(client.activeChannels[notifDeleted.cid]).to.be.undefined;
+	});
+});


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

### What

When the **current user** is removed from a channel, the client now evicts that channel from `client.activeChannels`: it calls `channel._disconnect()` and deletes the entry, mirroring the existing `channel.deleted` / `notification.channel_deleted` eviction in `StreamChat._handleClientEvent`.

The new branch keys off the **event** (`notification.removed_from_channel`), not the channel — it fires only for the removed user and is the server's authoritative signal that *this client* lost access. Eviction therefore happens **regardless of channel type**.

### Why (downstream symptom: GetStream/stream-chat-react#2599)

In `stream-chat-react`, a `ChannelList` kept re-adding a channel after the current user was removed from it. The React layer removes the channel on `notification.removed_from_channel`, but it reappeared whenever a later `message.new` / `notification.message_new` arrived, or after a websocket reconnect.

Root cause was here in core, not in React:

1. `Channel.stopWatching()` only POSTs `/stop-watching`; it does not remove the channel from `activeChannels`.
2. The client only evicted from `activeChannels` on channel **deletion** — there was no equivalent for membership **removal**.
3. On reconnect, `recoverState()` (default `recoverStateOnReconnect: true`) re-watches **every** channel still in `activeChannels` — including ones the user was removed from — so events resume and downstream lists re-promote the channel.

With this change the channel is no longer tracked after removal, so `recoverState()` won't re-watch it and no further channel events are delivered.

### How

A new branch in `StreamChat._handleClientEvent`, immediately after the deletion branch it mirrors:

```ts
if (event.type === 'notification.removed_from_channel' && event.cid) {
  const { cid } = event;
  this.activeChannels[cid]?._disconnect();
  postListenerCallbacks.push(() => {
    delete this.activeChannels[cid];
  });
}
```

Notes on the design:

- **Channel type is not gated** — the event is the per-user authoritative signal; channel type (messaging/livestream/team/…) is an implementation detail and must not gate this.
- **`member.removed` is intentionally not handled.** It fires for *any* member leaving a channel you watch, so evicting on it blindly would be wrong. The per-user signal is `notification.removed_from_channel` (delivered only to the removed user). A test asserts another user's `member.removed` does **not** evict. If we later confirm the removed user reliably also receives `member.removed`, it could be added behind an `event.member?.user?.id === this.userID` check.
- **Does not call `deleteAllChannelReference(cid)`** (which the deletion path does). The channel still exists for its remaining members; only this client lost access, so we just stop tracking it locally. An inline comment documents this intentional divergence.
- **Backward compatibility:** previously a removed-from channel lingered in `activeChannels`. The `_disconnect()` + delete affects any consumer still holding the instance — but the existing `channel.deleted` path already does exactly this, so consumers already tolerate it; this makes removal consistent with deletion. The lingering was effectively a bug, hence a `fix:` (patch) per Conventional Commits + semantic-release. Target release: **stream-chat 9.48.1**.

### Tests (failing → passing)

New describe block `activeChannels eviction when the current user is removed (#2599)` in `test/unit/client.test.js`, written test-first (the eviction assertions failed before the fix — `_disconnect` called 0×, channel still present, `recoverState` still included the removed cid):

- `notification.removed_from_channel` evicts the channel and calls `_disconnect()`.
- Eviction happens for **any** channel type (`livestream`, `team`, `gaming`) — type is not special-cased.
- After eviction, a subsequent `message.new` is no longer routed to the channel (the exact downstream symptom).
- After eviction, `recoverState()` does **not** include the evicted cid in the `queryChannels` recovery filter.
- Another user's `member.removed` does **not** evict (guard).
- `channel.deleted` and `notification.channel_deleted` still evict (no regression).

`yarn lint`, `yarn types`, and the full `yarn test` suite are green.

### Downstream coordination

Once released (targeting **stream-chat 9.48.1**), `stream-chat-react` can bump its `stream-chat` dependency. Its existing `ChannelList` removal-on-`notification.removed_from_channel` plus this core eviction together make removal durable. Context: `stream-chat-react` PR #3227 dropped a React-only `stopWatching`-based attempt at #2599 because it wasn't durable — this core gap is why.

## Changelog

- Evict a channel from `client.activeChannels` (disconnect + delete) when the current user is removed from it (`notification.removed_from_channel`), mirroring the existing channel-deletion eviction. Prevents the channel from being re-watched by `recoverState()` on reconnect and from receiving further events after removal. Fixes GetStream/stream-chat-react#2599.
