### PR TITLE
ci(release): pin npm registry and drop stale version lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -129,10 +129,7 @@
     "lint": "yarn run prettier && yarn run eslint",
     "lint-fix": "yarn run prettier-fix && yarn run eslint-fix",
     "fix-staged": "lint-staged --config .lintstagedrc.fix.json --concurrent 1",
-    "prepare": "yarn run build",
-    "preversion": "yarn && yarn lint && yarn test-unit",
-    "version": "git add yarn.lock",
-    "postversion": "git push && git push --tags && npm publish"
+    "prepare": "yarn run build"
   },
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## What

Fixes the `release-v8` semantic-release run that fails during `@semantic-release/npm`'s prepare step with `npm error need auth ... https://registry.yarnpkg.com` (`ENEEDAUTH`).

## Root cause

`@semantic-release/npm`'s prepare step runs `npm version <next>` to stamp the version into `package.json`. `npm version` fires the npm **lifecycle scripts**, and `release-v8` still carries the pre-semantic-release manual-release scripts:

```json
"preversion":  "yarn && yarn lint && yarn test-unit",
"version":     "git add yarn.lock",
"postversion": "git push && git push --tags && npm publish"
```

So `postversion` runs a bare `npm publish` in the middle of semantic-release's prepare. Under Yarn 1 (which `release-v8` uses) that publish inherits `npm_config_registry=https://registry.yarnpkg.com` (Yarn 1 injects it into every subprocess), so it targets the Yarn mirror, where the auth semantic-release set up does not apply, and dies with `ENEEDAUTH`.

`master` does not hit this: it has no `version`/`postversion` scripts, and Yarn Berry does not inject `npm_config_registry`, so `npm publish` uses the default `registry.npmjs.org`.

## Changes

- Remove the `preversion` / `version` / `postversion` scripts from `package.json`. semantic-release owns versioning, tagging, and publishing now (`@semantic-release/npm` + `@semantic-release/git`); these scripts are dead relics that only fire a rogue publish. They are not used by `initiate_release.yml` either (that flow uses `npm run changelog`, not `npm version`).
- Add a root `.npmrc` pinning `registry=https://registry.npmjs.org/`. Yarn 1 reads this and propagates it to subprocesses, so any `npm publish` targets the public registry regardless of Yarn's injected env. This is the registry override; it only affects resolution, not the lockfile (existing `resolved` URLs in `yarn.lock` are honored by `--frozen-lockfile`).

With `postversion` gone, semantic-release's own publish (which already passed OIDC token exchange against the npm registry in `verifyConditions`) is the only publish, and it targets `registry.npmjs.org` correctly.

## Heads up: partial state on release-v8 from the failed run

The failed run got far enough that `@semantic-release/git`'s prepare committed `chore(release): 8.61.0 [skip ci]` (a CHANGELOG.md entry) to `release-v8` before the npm prepare crashed. But:

- no `v8.61.0` git tag was pushed, and
- `8.61.0` was never published to npm.

So `8.61.0` is still "unreleased" as far as semantic-release is concerned, and the next run will target `8.61.0` again. Because the CHANGELOG already contains an `8.61.0` section, the next run's `@semantic-release/changelog` will prepend a second `8.61.0` block. It is cosmetic and does not block the release, but if you want a clean changelog, revert the `chore(release): 8.61.0` commit (or drop that section) before re-running. Happy to do that in a follow-up if you want.

## After merge

Re-dispatch the `Release` workflow from `release-v8` (a dry run first is a good check).
