### PR TITLE
chore: add release-v10 rc prerelease branch to semantic-release config

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,8 +10,8 @@
       "range": "8.x"
     },
     {
-      "name": "rc",
-      "prerelease": true
+      "name": "release-v10",
+      "prerelease": "rc"
     }
   ],
   "plugins": [


### PR DESCRIPTION
Configure release-v10 as an rc prerelease branch (10.0.0-rc.x, dist-tag rc), replacing the generic rc branch entry.

