### PR TITLE
fix: prevent reload if ThreadManager has never been activated

### DIFF
--- a/src/thread_manager.ts
+++ b/src/thread_manager.ts
@@ -10,6 +10,7 @@ const DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION = 1000;
 const MAX_QUERY_THREADS_LIMIT = 25;
 export const THREAD_MANAGER_INITIAL_STATE = {
   active: false,
+  wasActivatedAtLeastOnce: false,
   isThreadOrderStale: false,
   threads: [],
   unreadThreadCount: 0,
@@ -25,6 +26,12 @@ export const THREAD_MANAGER_INITIAL_STATE = {
 
 export type ThreadManagerState = {
   active: boolean;
+  /**
+   * Whether the thread manager has been activated at least once in the current
+   * session (i.e. `activate()` was called). Used to avoid requerying threads
+   * on connection recovery for consumers that never actually activate the manager.
+   */
+  wasActivatedAtLeastOnce: boolean;
   isThreadOrderStale: boolean;
   lastConnectionDropAt: Date | null;
   pagination: ThreadManagerPagination;
@@ -90,7 +97,7 @@ export class ThreadManager extends WithSubscriptions {
   };
 
   public activate = () => {
-    this.state.partialNext({ active: true });
+    this.state.partialNext({ active: true, wasActivatedAtLeastOnce: true });
   };
 
   public deactivate = () => {
@@ -197,8 +204,9 @@ export class ThreadManager extends WithSubscriptions {
 
     const throttledHandleConnectionRecovered = throttle(
       () => {
-        const { lastConnectionDropAt } = this.state.getLatestValue();
-        if (!lastConnectionDropAt) return;
+        const { lastConnectionDropAt, wasActivatedAtLeastOnce } =
+          this.state.getLatestValue();
+        if (!lastConnectionDropAt || !wasActivatedAtLeastOnce) return;
         this.reload({ force: true });
       },
       DEFAULT_CONNECTION_RECOVERY_THROTTLE_DURATION,

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1401,11 +1401,9 @@ describe('Threads 2.0', () => {
           online: false,
         });
 
-        // the drop is still recorded...
         const { lastConnectionDropAt } = threadManager.state.getLatestValue();
         expect(lastConnectionDropAt).to.be.a('date');
 
-        // ...but recovery must not trigger a thread query for a list nobody uses.
         client.dispatchEvent({ type: 'connection.recovered' });
         clock.runAll();
 

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1356,9 +1356,12 @@ describe('Threads 2.0', () => {
         });
       });
 
-      it('reloads after connection drop', () => {
+      it('reloads after connection drop if the thread list was activated at least once', () => {
         const thread = createTestThread();
-        threadManager.state.partialNext({ threads: [thread] });
+        threadManager.state.partialNext({
+          threads: [thread],
+          wasActivatedAtLeastOnce: true,
+        });
         threadManager.registerSubscriptions();
         const stub = sinon.stub(client, 'queryThreads').resolves({
           threads: [],
@@ -1378,6 +1381,35 @@ describe('Threads 2.0', () => {
         clock.runAll();
 
         expect(stub.calledOnce).to.be.true;
+
+        threadManager.unregisterSubscriptions();
+        clock.restore();
+      });
+
+      it('does not reload after connection drop if the thread list was never activated', () => {
+        const thread = createTestThread();
+        threadManager.state.partialNext({ threads: [thread] });
+        threadManager.registerSubscriptions();
+        const stub = sinon.stub(client, 'queryThreads').resolves({
+          threads: [],
+          next: undefined,
+        });
+        const clock = sinon.useFakeTimers();
+
+        client.dispatchEvent({
+          type: 'connection.changed',
+          online: false,
+        });
+
+        // the drop is still recorded...
+        const { lastConnectionDropAt } = threadManager.state.getLatestValue();
+        expect(lastConnectionDropAt).to.be.a('date');
+
+        // ...but recovery must not trigger a thread query for a list nobody uses.
+        client.dispatchEvent({ type: 'connection.recovered' });
+        clock.runAll();
+
+        expect(stub.called).to.be.false;
 
         threadManager.unregisterSubscriptions();
         clock.restore();


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Fixes [this issue](https://getstream.slack.com/archives/C02GBL5M1BK/p1782247679872819).

Even though it's benign, it is entirely possible that `ThreadManager.reload()` can be invoked specifically when connection is recovered without actually using threads or having ever loaded the `ThreadList`.

Since the actual query is also gated behind `activate()` invocations, we can use this approach to see if it's been activated at least once. The `active` state can unfortunately not be used as we'll often actually want to reload threads in the background, even while the `ThreadManager` might not necessarily be active.

## Changelog

-
