### PR TITLE
fix: clean up thread state remnants v10

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2369,12 +2369,18 @@ export class Channel {
         if (event.message) {
           this._extendEventWithOwnReactions(event);
           const formattedMessage = formatMessage(event.message);
+          const isThreadReply =
+            !!event.message.parent_id && !event.message.show_in_channel;
           if (event.hard_delete) {
             channelState.removeMessage(event.message);
-            this.messagePaginator.removeItem({ id: event.message.id });
+            if (!isThreadReply) {
+              this.messagePaginator.removeItem({ id: event.message.id });
+            }
           } else {
             channelState.addMessageSorted(event.message, false, false);
-            this.messagePaginator.ingestItem(formattedMessage);
+            if (!isThreadReply) {
+              this.messagePaginator.ingestItem(formattedMessage);
+            }
           }
           this.messagePaginator.reflectQuotedMessageUpdate(formattedMessage);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,12 +25,7 @@ export * from './segment';
 export * from './signing';
 export * from './store';
 export { Thread } from './thread';
-export type {
-  ThreadState,
-  ThreadReadState,
-  ThreadRepliesPagination,
-  ThreadUserReadState,
-} from './thread';
+export type { ThreadState, ThreadReadState, ThreadUserReadState } from './thread';
 export * from './thread_manager';
 export * from './token_manager';
 export * from './types';

--- a/src/messageDelivery/MessageDeliveryReporter.ts
+++ b/src/messageDelivery/MessageDeliveryReporter.ts
@@ -140,7 +140,7 @@ export class MessageDeliveryReporter {
       lastDeliveredAt = ownReadState?.last_delivered_at;
       key = collection.cid;
     } else if (isThread(collection)) {
-      latestMessages = collection.state.getLatestValue().replies;
+      latestMessages = collection.messagePaginator.state.getLatestValue().items ?? [];
       const ownReadState =
         collection.state.getLatestValue().read[ownUserId] ?? ({} as ThreadUserReadState);
       lastReadAt = ownReadState?.lastReadAt;

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -1,5 +1,5 @@
 import { StateStore } from './store';
-import { addToMessageList, findIndexInSortedArray, formatMessage } from './utils';
+import { formatMessage } from './utils';
 import type {
   AscDesc,
   DraftResponse,
@@ -50,7 +50,6 @@ export type ThreadState = {
   parentMessage: LocalMessage;
   participants: ThreadResponse['thread_participants'];
   read: ThreadReadState;
-  replies: Array<LocalMessage>;
   replyCount: number;
   title: string;
   updatedAt: Date | null;
@@ -183,7 +182,6 @@ export class Thread extends WithSubscriptions {
             ? getPlaceholderReadResponse(client.userID)
             : threadData.read,
         ),
-        replies: threadData.latest_replies.map(formatMessage),
         // Use the parent message's reply_count, not the top-level threadData.reply_count. The
         // thread endpoints (getThread/queryThreads) return a top level reply_count that EXCLUDES
         // soft-deleted replies, while parent_message.reply_count (and the channel's own copy)
@@ -229,7 +227,6 @@ export class Thread extends WithSubscriptions {
         parentMessage: formattedParentMessage,
         participants: [],
         read: formatReadState(getPlaceholderReadResponse(client.userID)),
-        replies: [],
         replyCount: parentMessage.reply_count ?? 0,
         title: '',
         updatedAt: parentMessage.updated_at ? new Date(parentMessage.updated_at) : null,
@@ -395,11 +392,12 @@ export class Thread extends WithSubscriptions {
       participants,
       read,
       replyCount,
-      replies,
       updatedAt,
     } = thread.state.getLatestValue();
 
-    // Preserve pending replies and append them to the updated list of replies
+    // Preserve pending (failed) replies so they survive the hydrate. The messagePaginator is now
+    // the sole reply source, so we merge the incoming newest page into it and re-ingest the
+    // pending replies (mirrors the previous state.replies concat behavior).
     const pendingReplies = Array.from(this.failedRepliesMap.values());
 
     this.state.partialNext({
@@ -412,12 +410,14 @@ export class Thread extends WithSubscriptions {
       read,
       replyCount,
       pagination,
-      replies: pendingReplies.length ? replies.concat(pendingReplies) : replies,
       updatedAt,
       isStateStale: false,
     });
 
-    this.messagePaginator.mergeNewestPage(replies);
+    this.messagePaginator.mergeNewestPage(
+      thread.messagePaginator.state.getLatestValue().items ?? [],
+    );
+    pendingReplies.forEach((reply) => this.messagePaginator.ingestItem(reply));
   };
 
   public registerSubscriptions = () => {
@@ -665,39 +665,18 @@ export class Thread extends WithSubscriptions {
 
   // todo: can be removed with the next breaking change and use MessagePaginator only
   public deleteReplyLocally = ({ message }: { message: MessageResponse }) => {
-    // Keep the reply messagePaginator (the reply list source) in sync. removeItem is a no-op when
-    // the reply isn't loaded, so it's safe to run unconditionally — even when the legacy
-    // state.replies removal below bails because the reply isn't in that list.
+    // The reply messagePaginator is the reply list source. removeItem is a no-op when the reply
+    // isn't loaded, so it's safe to run unconditionally.
     this.messagePaginator.removeItem({ id: message.id });
-
-    const { replies } = this.state.getLatestValue();
-
-    const index = findIndexInSortedArray({
-      needle: formatMessage(message),
-      sortedArray: replies,
-      sortDirection: 'ascending',
-      selectValueToCompare: (reply) => reply.created_at.getTime(),
-      selectKey: (reply) => reply.id,
-    });
-
-    if (replies[index]?.id !== message.id) {
-      return;
-    }
-
-    const updatedReplies = [...replies];
-    updatedReplies.splice(index, 1);
-
-    this.state.partialNext({
-      replies: updatedReplies,
-    });
   };
 
   // todo: can be removed with the next breaking change and use MessagePaginator only
   public upsertReplyLocally = ({
     message,
-    timestampChanged = false,
   }: {
     message: MessageResponse | LocalMessage;
+    // Accepted for backward compatibility but no longer used — the messagePaginator repositions
+    // by created_at on ingest, so a changed timestamp is handled without an explicit flag.
     timestampChanged?: boolean;
   }) => {
     if (message.parent_id !== this.id) {
@@ -714,12 +693,7 @@ export class Thread extends WithSubscriptions {
       this.failedRepliesMap.delete(message.id);
     }
 
-    this.state.next((current) => ({
-      ...current,
-      replies: addToMessageList(current.replies, formattedMessage, timestampChanged),
-    }));
-
-    // Keep the reply messagePaginator (the reply list source) in sync with the same upsert.
+    // The reply messagePaginator is the reply list source.
     this.messagePaginator.ingestItem(formattedMessage);
   };
 
@@ -792,9 +766,7 @@ export class Thread extends WithSubscriptions {
   /**
    * Updates a message with optimistic local state update.
    *
-   * NOTE: This updates message state via `messagePaginator` only. If you still rely on
-   * `Thread.state.replies` as UI source of truth, make sure it is wired to paginator updates
-   * (or keep upserting separately until migration is complete).
+   * The update flows through `messagePaginator`, which is the sole reply source.
    */
   async updateMessageWithLocalUpdate(params: UpdateMessageWithStateUpdateParams) {
     await this.messageOperations.update(
@@ -855,10 +827,10 @@ export class Thread extends WithSubscriptions {
   // todo: can be removed with the next breaking change and use MessagePaginator only
   private loadPage = async (count: number) => {
     const { pagination } = this.state.getLatestValue();
-    const [loadingKey, cursorKey, insertionMethodKey] =
+    const [loadingKey, cursorKey] =
       count > 0
-        ? (['isLoadingNext', 'nextCursor', 'push'] as const)
-        : (['isLoadingPrev', 'prevCursor', 'unshift'] as const);
+        ? (['isLoadingNext', 'nextCursor'] as const)
+        : (['isLoadingPrev', 'prevCursor'] as const);
 
     if (pagination[loadingKey] || pagination[cursorKey] === null) return;
 
@@ -872,25 +844,16 @@ export class Thread extends WithSubscriptions {
       const replies = data.messages.map(formatMessage);
       const maybeNextCursor = replies.at(count > 0 ? -1 : 0)?.id ?? null;
 
-      this.state.next((current) => {
-        let nextReplies = current.replies;
-
-        // prevent re-creating array if there's nothing to add to the current one
-        if (replies.length > 0) {
-          nextReplies = [...current.replies];
-          nextReplies[insertionMethodKey](...replies);
-        }
-
-        return {
-          ...current,
-          replies: nextReplies,
-          pagination: {
-            ...current.pagination,
-            [cursorKey]: data.messages.length < limit ? null : maybeNextCursor,
-            [loadingKey]: false,
-          },
-        };
-      });
+      // Legacy pagination cursor bookkeeping only. Loading replies into the reply list is the
+      // messagePaginator's job (toTail/toHead); this deprecated path just advances its own cursor.
+      this.state.next((current) => ({
+        ...current,
+        pagination: {
+          ...current.pagination,
+          [cursorKey]: data.messages.length < limit ? null : maybeNextCursor,
+          [loadingKey]: false,
+        },
+      }));
     } catch (error) {
       this.client.logger('error', (error as Error).message);
       this.state.next((current) => ({

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -7,7 +7,6 @@ import type {
   EventTypes,
   LocalMessage,
   MarkReadOptions,
-  MessagePaginationOptions,
   MessageResponse,
   ReadResponse,
   ThreadResponse,
@@ -26,10 +25,6 @@ import { MessageOperations } from './messageOperations';
 import { WithSubscriptions } from './utils/WithSubscriptions';
 import { MessagePaginator } from './pagination';
 
-type QueryRepliesOptions = {
-  sort?: { created_at: AscDesc }[];
-} & MessagePaginationOptions & { user?: UserResponse; user_id?: string };
-
 export type ThreadState = {
   /**
    * Determines if the thread is currently opened and on-screen. When the thread is active,
@@ -42,7 +37,6 @@ export type ThreadState = {
   deletedAt: Date | null;
   isLoading: boolean;
   isStateStale: boolean;
-  pagination: ThreadRepliesPagination;
   /**
    * Thread is identified by and has a one-to-one relation with its parent message.
    * We use parent message id as a thread id.
@@ -53,13 +47,6 @@ export type ThreadState = {
   replyCount: number;
   title: string;
   updatedAt: Date | null;
-};
-
-export type ThreadRepliesPagination = {
-  isLoadingNext: boolean;
-  isLoadingPrev: boolean;
-  nextCursor: string | null;
-  prevCursor: string | null;
 };
 
 export type ThreadUserReadState = {
@@ -174,7 +161,6 @@ export class Thread extends WithSubscriptions {
         createdAt: new Date(threadData.created_at),
         // rest
         deletedAt: threadData.deleted_at ? new Date(threadData.deleted_at) : null,
-        pagination: repliesPaginationFromInitialThread(threadData),
         parentMessage: formatMessage(threadData.parent_message),
         participants: threadData.thread_participants,
         read: formatReadState(
@@ -218,12 +204,6 @@ export class Thread extends WithSubscriptions {
         deletedAt: formattedParentMessage.deleted_at,
         isLoading: false,
         isStateStale: false,
-        pagination: {
-          isLoadingNext: false,
-          isLoadingPrev: false,
-          nextCursor: null,
-          prevCursor: null,
-        },
         parentMessage: formattedParentMessage,
         participants: [],
         read: formatReadState(getPlaceholderReadResponse(client.userID)),
@@ -387,7 +367,6 @@ export class Thread extends WithSubscriptions {
       custom,
       title,
       deletedAt,
-      pagination,
       parentMessage,
       participants,
       read,
@@ -409,7 +388,6 @@ export class Thread extends WithSubscriptions {
       participants,
       read,
       replyCount,
-      pagination,
       updatedAt,
       isStateStale: false,
     });
@@ -808,63 +786,6 @@ export class Thread extends WithSubscriptions {
    */
   public markAsRead = ({ force = false }: { force?: boolean } = {}) =>
     this.markRead({ force });
-
-  // todo: can be removed with the next breaking change and use MessagePaginator only
-  public queryReplies = ({
-    limit = DEFAULT_PAGE_LIMIT,
-    sort = DEFAULT_SORT,
-    ...otherOptions
-  }: QueryRepliesOptions = {}) =>
-    this.channel.getReplies(this.id, { limit, ...otherOptions }, sort);
-
-  // todo: can be removed with the next breaking change and use MessagePaginator only
-  public loadNextPage = ({ limit = DEFAULT_PAGE_LIMIT }: { limit?: number } = {}) =>
-    this.loadPage(limit);
-
-  // todo: can be removed with the next breaking change and use MessagePaginator only
-  public loadPrevPage = ({ limit = DEFAULT_PAGE_LIMIT }: { limit?: number } = {}) =>
-    this.loadPage(-limit);
-  // todo: can be removed with the next breaking change and use MessagePaginator only
-  private loadPage = async (count: number) => {
-    const { pagination } = this.state.getLatestValue();
-    const [loadingKey, cursorKey] =
-      count > 0
-        ? (['isLoadingNext', 'nextCursor'] as const)
-        : (['isLoadingPrev', 'prevCursor'] as const);
-
-    if (pagination[loadingKey] || pagination[cursorKey] === null) return;
-
-    const queryOptions = { [count > 0 ? 'id_gt' : 'id_lt']: pagination[cursorKey] };
-    const limit = Math.abs(count);
-
-    this.state.partialNext({ pagination: { ...pagination, [loadingKey]: true } });
-
-    try {
-      const data = await this.queryReplies({ ...queryOptions, limit });
-      const replies = data.messages.map(formatMessage);
-      const maybeNextCursor = replies.at(count > 0 ? -1 : 0)?.id ?? null;
-
-      // Legacy pagination cursor bookkeeping only. Loading replies into the reply list is the
-      // messagePaginator's job (toTail/toHead); this deprecated path just advances its own cursor.
-      this.state.next((current) => ({
-        ...current,
-        pagination: {
-          ...current.pagination,
-          [cursorKey]: data.messages.length < limit ? null : maybeNextCursor,
-          [loadingKey]: false,
-        },
-      }));
-    } catch (error) {
-      this.client.logger('error', (error as Error).message);
-      this.state.next((current) => ({
-        ...current,
-        pagination: {
-          ...current.pagination,
-          [loadingKey]: false,
-        },
-      }));
-    }
-  };
 }
 
 type MessageThreadParticipant = NonNullable<
@@ -912,22 +833,6 @@ const getPlaceholderReadResponse = (currentUserId?: string): ReadResponse[] =>
         },
       ]
     : [];
-
-const repliesPaginationFromInitialThread = (
-  thread: ThreadResponse,
-): ThreadRepliesPagination => {
-  const latestRepliesContainsAllReplies =
-    thread.latest_replies.length === thread.reply_count;
-
-  return {
-    nextCursor: null,
-    prevCursor: latestRepliesContainsAllReplies
-      ? null
-      : (thread.latest_replies.at(0)?.id ?? null),
-    isLoadingNext: false,
-    isLoadingPrev: false,
-  };
-};
 
 const ownUnreadCountSelector =
   (currentUserId: string | undefined) => (state: ThreadState) =>

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -184,7 +184,12 @@ export class Thread extends WithSubscriptions {
             : threadData.read,
         ),
         replies: threadData.latest_replies.map(formatMessage),
-        replyCount: threadData.reply_count ?? 0,
+        // Use the parent message's reply_count, not the top-level threadData.reply_count. The
+        // thread endpoints (getThread/queryThreads) return a top level reply_count that EXCLUDES
+        // soft-deleted replies, while parent_message.reply_count (and the channel's own copy)
+        // INCLUDE them so the top level value renders fewer replies than the channel badge shows.
+        // parent_message.reply_count is the authoritative, channel consistent count.
+        replyCount: threadData.parent_message.reply_count ?? 0,
         updatedAt: threadData.updated_at ? new Date(threadData.updated_at) : null,
         title: threadData.title,
         custom: constructCustomDataObject(threadData),
@@ -520,10 +525,7 @@ export class Thread extends WithSubscriptions {
       }
 
       const isOwnMessage = event.message.user?.id === this.client.userID;
-      const { active, read, replies } = this.state.getLatestValue();
-      const hasReplyAlready =
-        replies.some((reply) => reply.id === event.message?.id) ||
-        !!this.messagePaginator.getItem(event.message.id);
+      const { active, read } = this.state.getLatestValue();
 
       this.messagePaginator.ingestItem(formatMessage(event.message));
       this.upsertReplyLocally({
@@ -532,10 +534,6 @@ export class Thread extends WithSubscriptions {
         // so the actual timestamp might differ in the event
         timestampChanged: isOwnMessage,
       });
-
-      if (!hasReplyAlready) {
-        this.incrementReplyCountLocally();
-      }
 
       if (active) {
         this.throttledMarkRead();
@@ -622,9 +620,11 @@ export class Thread extends WithSubscriptions {
       if (event.message.parent_id === this.id) {
         if (event.hard_delete) {
           this.deleteReplyLocally({ message: event.message });
+          this.messagePaginator.removeItem({ id: event.message.id });
         } else {
           // Handle soft delete (updates deleted_at timestamp)
           this.upsertReplyLocally({ message: event.message });
+          this.messagePaginator.ingestItem(formattedMessage);
         }
       }
 
@@ -650,12 +650,11 @@ export class Thread extends WithSubscriptions {
         this.client.on(eventType, (event) => {
           if (event.message) {
             this.updateParentMessageOrReplyLocally(event.message);
-            if (
-              ['reaction.new', 'reaction.deleted', 'reaction.updated'].includes(
-                eventType,
-              ) &&
-              event.message.parent_id === this.id
-            ) {
+            // A reply edited / undeleted / reacted-to by anyone (including other users, via the WS
+            // event rather than a local optimistic op) must reflect in the reply messagePaginator,
+            // which backs the reply list. ingestItem updates an already-loaded reply in place and
+            // safely no-ops / queues to a logical interval for an unloaded one.
+            if (event.message.parent_id === this.id) {
               this.messagePaginator.ingestItem(formatMessage(event.message));
             }
             this.messagePaginator.reflectQuotedMessageUpdate(

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -527,7 +527,6 @@ export class Thread extends WithSubscriptions {
       const isOwnMessage = event.message.user?.id === this.client.userID;
       const { active, read } = this.state.getLatestValue();
 
-      this.messagePaginator.ingestItem(formatMessage(event.message));
       this.upsertReplyLocally({
         message: event.message,
         // Message from current user could have been added optimistically,
@@ -620,11 +619,9 @@ export class Thread extends WithSubscriptions {
       if (event.message.parent_id === this.id) {
         if (event.hard_delete) {
           this.deleteReplyLocally({ message: event.message });
-          this.messagePaginator.removeItem({ id: event.message.id });
         } else {
           // Handle soft delete (updates deleted_at timestamp)
           this.upsertReplyLocally({ message: event.message });
-          this.messagePaginator.ingestItem(formattedMessage);
         }
       }
 
@@ -650,13 +647,6 @@ export class Thread extends WithSubscriptions {
         this.client.on(eventType, (event) => {
           if (event.message) {
             this.updateParentMessageOrReplyLocally(event.message);
-            // A reply edited / undeleted / reacted-to by anyone (including other users, via the WS
-            // event rather than a local optimistic op) must reflect in the reply messagePaginator,
-            // which backs the reply list. ingestItem updates an already-loaded reply in place and
-            // safely no-ops / queues to a logical interval for an unloaded one.
-            if (event.message.parent_id === this.id) {
-              this.messagePaginator.ingestItem(formatMessage(event.message));
-            }
             this.messagePaginator.reflectQuotedMessageUpdate(
               formatMessage(event.message),
             );
@@ -675,6 +665,11 @@ export class Thread extends WithSubscriptions {
 
   // todo: can be removed with the next breaking change and use MessagePaginator only
   public deleteReplyLocally = ({ message }: { message: MessageResponse }) => {
+    // Keep the reply messagePaginator (the reply list source) in sync. removeItem is a no-op when
+    // the reply isn't loaded, so it's safe to run unconditionally — even when the legacy
+    // state.replies removal below bails because the reply isn't in that list.
+    this.messagePaginator.removeItem({ id: message.id });
+
     const { replies } = this.state.getLatestValue();
 
     const index = findIndexInSortedArray({
@@ -723,6 +718,9 @@ export class Thread extends WithSubscriptions {
       ...current,
       replies: addToMessageList(current.replies, formattedMessage, timestampChanged),
     }));
+
+    // Keep the reply messagePaginator (the reply list source) in sync with the same upsert.
+    this.messagePaginator.ingestItem(formattedMessage);
   };
 
   // todo: can be removed with the next breaking change and use MessagePaginator only

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -890,6 +890,45 @@ describe('Channel _handleChannelEvent', function () {
 		expect(itemFromPaginator?.deleted_at?.toISOString()).to.equal(deletedAt);
 	});
 
+	it('message.deleted (soft) ignores thread replies in messagePaginator', function () {
+		const parentMessage = generateMsg({ id: 'thread-parent-id-on-delete' });
+		const threadReply = generateMsg({
+			id: 'thread-reply-id-on-delete',
+			parent_id: parentMessage.id,
+		});
+
+		channel.messagePaginator.ingestItem(parentMessage);
+		channel._handleChannelEvent({
+			type: 'message.deleted',
+			user: { id: 'id' },
+			message: { ...threadReply, deleted_at: new Date().toISOString() },
+		});
+
+		// A pure thread reply must never leak a "deleted" placeholder into the channel list.
+		expect(channel.messagePaginator.getItem(threadReply.id)).to.be.undefined;
+	});
+
+	it('message.deleted (hard) ignores thread replies in messagePaginator', function () {
+		const parentMessage = generateMsg({ id: 'thread-parent-id-on-hard-delete' });
+		const threadReply = generateMsg({
+			id: 'thread-reply-id-on-hard-delete',
+			parent_id: parentMessage.id,
+		});
+
+		channel.messagePaginator.ingestItem(parentMessage);
+		channel._handleChannelEvent({
+			type: 'message.deleted',
+			user: { id: 'id' },
+			hard_delete: true,
+			message: threadReply,
+		});
+
+		expect(channel.messagePaginator.getItem(parentMessage.id)?.id).to.equal(
+			parentMessage.id,
+		);
+		expect(channel.messagePaginator.getItem(threadReply.id)).to.be.undefined;
+	});
+
 	it('message.deleted syncs quoted_message references in messagePaginator', function () {
 		const quotedMessage = generateMsg({
 			id: 'quoted-message-id-on-delete',

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -178,8 +178,6 @@ describe('Threads 2.0', () => {
       expect(repliesOf(thread)).to.deep.equal([]);
       expect(state.participants).to.deep.equal([]);
       expect(state.custom).to.deep.equal({});
-      expect(state.pagination.prevCursor).to.be.null;
-      expect(state.pagination.nextCursor).to.be.null;
       expect(state.read).to.have.keys([TEST_USER_ID]);
       expect(thread.messagePaginator.sort).to.deep.equal([{ created_at: -1 }]);
       expect(thread.messagePaginator.requestSort).to.deep.equal([{ created_at: -1 }]);
@@ -398,30 +396,6 @@ describe('Threads 2.0', () => {
           expect(stateAfter.participants).to.equal(hydrationState.participants);
         });
 
-        it('copies pagination state during hydration', () => {
-          const thread = createMinimalThread();
-          const hydrationThread = createTestThread({
-            latest_replies: [
-              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
-            ],
-            reply_count: 3,
-          });
-
-          hydrationThread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: 'next-cursor',
-            },
-          }));
-
-          thread.hydrateState(hydrationThread);
-
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.pagination.prevCursor).to.not.be.null;
-          expect(stateAfter.pagination.nextCursor).to.equal('next-cursor');
-        });
-
         it('retains failed replies after hydration', () => {
           const thread = createTestThread();
           const hydrationThread = createTestThread({
@@ -484,35 +458,6 @@ describe('Threads 2.0', () => {
       });
 
       describe('reload', () => {
-        it('bootstraps pagination for minimally initialized threads', async () => {
-          const minimalThread = createMinimalThread();
-          const hydratedThread = createTestThread({
-            latest_replies: [
-              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
-            ],
-            reply_count: 3,
-          });
-          hydratedThread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: 'next-cursor',
-            },
-          }));
-
-          sinon.stub(client, 'getThread').resolves(hydratedThread);
-
-          const stateBefore = minimalThread.state.getLatestValue();
-          expect(stateBefore.pagination.prevCursor).to.be.null;
-          expect(stateBefore.pagination.nextCursor).to.be.null;
-
-          await minimalThread.reload();
-
-          const stateAfter = minimalThread.state.getLatestValue();
-          expect(stateAfter.pagination.prevCursor).to.not.be.null;
-          expect(stateAfter.pagination.nextCursor).to.equal('next-cursor');
-        });
-
         it('sizes getThread reply_limit to the loaded reply count, falling back to pageSize when unloaded', async () => {
           const stub = sinon.stub(client, 'getThread').resolves(createTestThread());
 
@@ -611,202 +556,48 @@ describe('Threads 2.0', () => {
         });
       });
 
-      describe('loadPage', () => {
-        it('sets up pagination on initialization (all replies included in response)', () => {
-          const thread = createTestThread({
-            latest_replies: [generateMsg() as MessageResponse],
-            reply_count: 1,
-          });
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.prevCursor).to.be.null;
-          expect(state.pagination.nextCursor).to.be.null;
+      // Reply pagination now flows through the instance's messagePaginator (toTail = older,
+      // toHead = newer) — the replacement for the removed Thread.loadNextPage/loadPrevPage. The
+      // paginator's own suite covers the query-shape/cursor mechanics; these assert the end-to-end
+      // wiring through a real Thread (seeded from latest_replies) which the paginator suite doesn't.
+      describe('reply pagination (messagePaginator)', () => {
+        it('loads older replies via toTail() and scopes the request to the thread parent', async () => {
+          // Seeded newest window with older replies still to load (reply_count > loaded).
+          const newest = makeReply({ created_at: '2020-01-03T00:00:00.000Z' });
+          const thread = createTestThread({ latest_replies: [newest], reply_count: 3 });
+          expect(thread.messagePaginator.state.getLatestValue().hasMoreTail).to.be.true;
+
+          const older = makeReply({ created_at: '2020-01-02T00:00:00.000Z' });
+          const getRepliesStub = sinon
+            .stub(thread.channel, 'getReplies')
+            .resolves({ messages: [older], duration: '' } as unknown as ReturnType<
+              Channel['getReplies']
+            >);
+
+          await thread.messagePaginator.toTail();
+
+          // The fetched older reply is now in the rendered reply list...
+          expect(repliesOf(thread).map((reply) => reply.id)).to.include(older.id);
+          // ...and the request was made against this thread's parent (the replies endpoint).
+          expect(getRepliesStub.calledOnce).to.be.true;
+          expect(getRepliesStub.firstCall.args[0]).to.equal(thread.id);
         });
 
-        it('sets up pagination on initialization (not all replies included in response)', () => {
-          const firstMessage = generateMsg() as MessageResponse;
-          const lastMessage = generateMsg() as MessageResponse;
-          const thread = createTestThread({
-            latest_replies: [firstMessage, lastMessage],
-            reply_count: 3,
-          });
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.prevCursor).not.to.be.null;
-          expect(state.pagination.nextCursor).to.be.null;
-        });
+        it('clears hasMoreTail once toTail() reaches the start of the reply list', async () => {
+          const newest = makeReply({ created_at: '2020-01-03T00:00:00.000Z' });
+          const thread = createTestThread({ latest_replies: [newest], reply_count: 2 });
+          expect(thread.messagePaginator.state.getLatestValue().hasMoreTail).to.be.true;
 
-        it('updates pagination after loading next page (end reached)', async () => {
-          const thread = createTestThread({
-            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
-            reply_count: 3,
-          });
-          thread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: 'cursor',
-            },
-          }));
-          sinon.stub(thread, 'queryReplies').resolves({
-            messages: [generateMsg()] as MessageResponse[],
-            duration: '',
-          });
-
-          await thread.loadNextPage({ limit: 2 });
-
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.nextCursor).to.be.null;
-        });
-
-        it('updates pagination after loading next page (end not reached)', async () => {
-          const thread = createTestThread({
-            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
-            reply_count: 4,
-          });
-          thread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: 'cursor',
-            },
-          }));
-          const lastMessage = generateMsg() as MessageResponse;
-          sinon.stub(thread, 'queryReplies').resolves({
-            messages: [generateMsg(), lastMessage] as MessageResponse[],
-            duration: '',
-          });
-
-          await thread.loadNextPage({ limit: 2 });
-
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.nextCursor).to.equal(lastMessage.id);
-        });
-
-        it('forms correct request when loading next page', async () => {
-          const firstMessage = generateMsg() as MessageResponse;
-          const lastMessage = generateMsg() as MessageResponse;
-          const thread = createTestThread({
-            latest_replies: [firstMessage, lastMessage],
-            reply_count: 3,
-          });
-          thread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: lastMessage.id,
-            },
-          }));
-          const queryRepliesStub = sinon
-            .stub(thread, 'queryReplies')
-            .resolves({ messages: [], duration: '' });
-
-          await thread.loadNextPage({ limit: 42 });
-
-          expect(
-            queryRepliesStub.calledOnceWith({
-              id_gt: lastMessage.id,
-              limit: 42,
-            }),
-          ).to.be.true;
-        });
-
-        it('updates pagination after loading previous page (end reached)', async () => {
-          const thread = createTestThread({
-            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
-            reply_count: 3,
-          });
-          sinon.stub(thread, 'queryReplies').resolves({
-            messages: [generateMsg()] as MessageResponse[],
-            duration: '',
-          });
-
-          await thread.loadPrevPage({ limit: 2 });
-
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.prevCursor).to.be.null;
-        });
-
-        it('updates pagination after loading previous page (end not reached)', async () => {
-          const thread = createTestThread({
-            latest_replies: [generateMsg(), generateMsg()] as MessageResponse[],
-            reply_count: 4,
-          });
-          const firstMessage = generateMsg() as MessageResponse;
-          sinon.stub(thread, 'queryReplies').resolves({
-            messages: [firstMessage, generateMsg()] as MessageResponse[],
-            duration: '',
-          });
-
-          await thread.loadPrevPage({ limit: 2 });
-
-          const state = thread.state.getLatestValue();
-          expect(state.pagination.prevCursor).to.equal(firstMessage.id);
-        });
-
-        it('forms correct request when loading previous page', async () => {
-          const firstMessage = generateMsg() as MessageResponse;
-          const lastMessage = generateMsg() as MessageResponse;
-          const thread = createTestThread({
-            latest_replies: [firstMessage, lastMessage],
-            reply_count: 3,
-          });
-          const queryRepliesStub = sinon
-            .stub(thread, 'queryReplies')
-            .resolves({ messages: [], duration: '' });
-
-          await thread.loadPrevPage({ limit: 42 });
-
-          expect(
-            queryRepliesStub.calledOnceWith({
-              id_lt: firstMessage.id,
-              limit: 42,
-            }),
-          ).to.be.true;
-        });
-
-        // loadNextPage/loadPrevPage are a legacy, deprecated cursor-only path — loading replies into
-        // the rendered list is the messagePaginator's job now (toTail/toHead). These assert only the
-        // remaining behavior: advancing the legacy pagination cursor.
-        it('advances the next-page cursor when loading the next page', async () => {
-          const initialMessages = [makeReply(), makeReply()];
-          const nextMessages = [makeReply(), makeReply()];
-          const thread = createTestThread({
-            latest_replies: initialMessages,
-            reply_count: 4,
-          });
-          thread.state.next((current) => ({
-            ...current,
-            pagination: {
-              ...current.pagination,
-              nextCursor: initialMessages[1].id,
-            },
-          }));
+          const older = makeReply({ created_at: '2020-01-02T00:00:00.000Z' });
           sinon
-            .stub(thread, 'queryReplies')
-            .resolves({ messages: nextMessages, duration: '' });
+            .stub(thread.channel, 'getReplies')
+            .resolves({ messages: [older], duration: '' } as unknown as ReturnType<
+              Channel['getReplies']
+            >);
 
-          await thread.loadNextPage({ limit: 2 });
+          await thread.messagePaginator.toTail();
 
-          expect(thread.state.getLatestValue().pagination.nextCursor).to.equal(
-            nextMessages[1].id,
-          );
-        });
-
-        it('advances the previous-page cursor when loading the previous page', async () => {
-          const prevMessages = [makeReply(), makeReply()];
-          const initialMessages = [makeReply(), makeReply()];
-          const thread = createTestThread({
-            latest_replies: initialMessages,
-            reply_count: 4,
-          });
-          sinon
-            .stub(thread, 'queryReplies')
-            .resolves({ messages: prevMessages, duration: '' });
-
-          await thread.loadPrevPage({ limit: 2 });
-
-          expect(thread.state.getLatestValue().pagination.prevCursor).to.equal(
-            prevMessages[0].id,
-          );
+          expect(thread.messagePaginator.state.getLatestValue().hasMoreTail).to.be.false;
         });
       });
     });

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -68,6 +68,20 @@ describe('Threads 2.0', () => {
     });
   }
 
+  // The messagePaginator is the sole reply source (Thread.state.replies was removed).
+  const repliesOf = (thread: Thread) =>
+    thread.messagePaginator.state.getLatestValue().items ?? [];
+
+  // A realistic reply carries a cid + parent_id so it passes the reply paginator's client-side
+  // filter ({ cid, parent_id }) and shows up in messagePaginator.state.items (the rendered list).
+  // Without cid, ingestItem indexes the message but the filter excludes it from state.items.
+  const makeReply = (overrides: Partial<MessageResponse> = {}) =>
+    generateMsg({
+      cid: channel.cid,
+      parent_id: parentMessageResponse.id,
+      ...overrides,
+    }) as MessageResponse;
+
   beforeEach(() => {
     client = new StreamChat('apiKey');
     client._setUser({ id: TEST_USER_ID });
@@ -161,7 +175,7 @@ describe('Threads 2.0', () => {
       expect(thread.id).to.equal(parentMessageResponse.id);
       expect(thread.channel.cid).to.equal(channel.cid);
       expect(state.parentMessage.id).to.equal(parentMessageResponse.id);
-      expect(state.replies).to.deep.equal([]);
+      expect(repliesOf(thread)).to.deep.equal([]);
       expect(state.participants).to.deep.equal([]);
       expect(state.custom).to.deep.equal({});
       expect(state.pagination.prevCursor).to.be.null;
@@ -209,52 +223,47 @@ describe('Threads 2.0', () => {
 
         it('inserts a new message that belongs to the associated thread', () => {
           const thread = createTestThread();
-          const message = generateMsg({ parent_id: thread.id }) as MessageResponse;
-          const stateBefore = thread.state.getLatestValue();
-          expect(stateBefore.replies).to.have.lengthOf(0);
+          const message = makeReply({ parent_id: thread.id });
+          expect(repliesOf(thread)).to.have.lengthOf(0);
 
           thread.upsertReplyLocally({ message });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(1);
-          expect(stateAfter.replies[0].id).to.equal(message.id);
+          const replies = repliesOf(thread);
+          expect(replies).to.have.lengthOf(1);
+          expect(replies[0].id).to.equal(message.id);
         });
 
         it('updates existing message', () => {
-          const message = generateMsg({
-            parent_id: parentMessageResponse.id,
-            text: 'aaa',
-          }) as MessageResponse;
-          const thread = createTestThread({ latest_replies: [message] });
+          const message = makeReply({ text: 'aaa' });
+          const thread = createTestThread({ latest_replies: [message], reply_count: 1 });
           const udpatedMessage = { ...message, text: 'bbb' };
 
-          const stateBefore = thread.state.getLatestValue();
-          expect(stateBefore.replies).to.have.lengthOf(1);
-          expect(stateBefore.replies[0].id).to.equal(message.id);
-          expect(stateBefore.replies[0].text).to.not.equal(udpatedMessage.text);
+          const repliesBefore = repliesOf(thread);
+          expect(repliesBefore).to.have.lengthOf(1);
+          expect(repliesBefore[0].id).to.equal(message.id);
+          expect(repliesBefore[0].text).to.not.equal(udpatedMessage.text);
 
           thread.upsertReplyLocally({ message: udpatedMessage });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(1);
-          expect(stateAfter.replies[0].text).to.equal(udpatedMessage.text);
+          const repliesAfter = repliesOf(thread);
+          expect(repliesAfter).to.have.lengthOf(1);
+          expect(repliesAfter[0].text).to.equal(udpatedMessage.text);
         });
 
         it('updates optimistically added message', () => {
-          const optimisticMessage = generateMsg({
-            parent_id: parentMessageResponse.id,
+          const optimisticMessage = makeReply({
             text: 'aaa',
             created_at: '2020-01-01T00:00:00Z',
-          }) as MessageResponse;
+          });
 
-          const message = generateMsg({
-            parent_id: parentMessageResponse.id,
+          const message = makeReply({
             text: 'bbb',
             created_at: '2020-01-01T00:00:10Z',
-          }) as MessageResponse;
+          });
 
           const thread = createTestThread({
             latest_replies: [optimisticMessage, message],
+            reply_count: 2,
           });
           const updatedMessage: MessageResponse = {
             ...optimisticMessage,
@@ -262,19 +271,20 @@ describe('Threads 2.0', () => {
             created_at: '2020-01-01T00:00:20Z',
           };
 
-          const stateBefore = thread.state.getLatestValue();
-          expect(stateBefore.replies).to.have.lengthOf(2);
-          expect(stateBefore.replies[0].id).to.equal(optimisticMessage.id);
-          expect(stateBefore.replies[0].text).to.equal('aaa');
-          expect(stateBefore.replies[1].id).to.equal(message.id);
+          const repliesBefore = repliesOf(thread);
+          expect(repliesBefore).to.have.lengthOf(2);
+          expect(repliesBefore[0].id).to.equal(optimisticMessage.id);
+          expect(repliesBefore[0].text).to.equal('aaa');
+          expect(repliesBefore[1].id).to.equal(message.id);
 
           thread.upsertReplyLocally({ message: updatedMessage, timestampChanged: true });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(2);
-          expect(stateAfter.replies[0].id).to.equal(message.id);
-          expect(stateAfter.replies[1].id).to.equal(optimisticMessage.id);
-          expect(stateAfter.replies[1].text).to.equal('ccc');
+          // Updating the optimistic reply with a newer created_at repositions it after `message`.
+          const repliesAfter = repliesOf(thread);
+          expect(repliesAfter).to.have.lengthOf(2);
+          expect(repliesAfter[0].id).to.equal(message.id);
+          expect(repliesAfter[1].id).to.equal(optimisticMessage.id);
+          expect(repliesAfter[1].text).to.equal('ccc');
         });
       });
 
@@ -384,7 +394,6 @@ describe('Threads 2.0', () => {
 
           // compare non-primitive values only
           expect(stateAfter.read).to.equal(hydrationState.read);
-          expect(stateAfter.replies).to.equal(hydrationState.replies);
           expect(stateAfter.parentMessage).to.equal(hydrationState.parentMessage);
           expect(stateAfter.participants).to.equal(hydrationState.participants);
         });
@@ -416,22 +425,17 @@ describe('Threads 2.0', () => {
         it('retains failed replies after hydration', () => {
           const thread = createTestThread();
           const hydrationThread = createTestThread({
-            latest_replies: [
-              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
-            ],
+            latest_replies: [makeReply()],
+            reply_count: 1,
           });
 
-          const failedMessage = generateMsg({
-            status: 'failed',
-            parent_id: parentMessageResponse.id,
-          }) as MessageResponse;
+          const failedMessage = makeReply({ status: 'failed' });
           thread.upsertReplyLocally({ message: failedMessage });
 
           thread.hydrateState(hydrationThread);
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(2);
-          expect(stateAfter.replies[1].id).to.equal(failedMessage.id);
+          // The failed reply survives the hydrate (it is re-ingested into the paginator).
+          expect(repliesOf(thread).map((reply) => reply.id)).to.include(failedMessage.id);
         });
 
         it('merges the incoming newest reply window into the reply paginator', () => {
@@ -550,8 +554,8 @@ describe('Threads 2.0', () => {
           );
           const thread = createTestThread({ latest_replies: messages });
 
-          const stateBefore = thread.state.getLatestValue();
-          expect(stateBefore.replies).to.have.lengthOf(5);
+          const repliesBefore = repliesOf(thread);
+          expect(repliesBefore).to.have.lengthOf(5);
 
           const messageToDelete = generateMsg({
             created_at: messages[2].created_at,
@@ -560,11 +564,11 @@ describe('Threads 2.0', () => {
 
           thread.deleteReplyLocally({ message: messageToDelete });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.not.equal(stateBefore.replies);
-          expect(stateAfter.replies).to.have.lengthOf(4);
-          expect(stateAfter.replies.find((reply) => reply.id === messageToDelete.id)).to
-            .be.undefined;
+          const repliesAfter = repliesOf(thread);
+          expect(repliesAfter).to.not.equal(repliesBefore);
+          expect(repliesAfter).to.have.lengthOf(4);
+          expect(repliesAfter.find((reply) => reply.id === messageToDelete.id)).to.be
+            .undefined;
         });
       });
 
@@ -759,9 +763,12 @@ describe('Threads 2.0', () => {
           ).to.be.true;
         });
 
-        it('appends messages when loading next page', async () => {
-          const initialMessages = [generateMsg(), generateMsg()] as MessageResponse[];
-          const nextMessages = [generateMsg(), generateMsg()] as MessageResponse[];
+        // loadNextPage/loadPrevPage are a legacy, deprecated cursor-only path — loading replies into
+        // the rendered list is the messagePaginator's job now (toTail/toHead). These assert only the
+        // remaining behavior: advancing the legacy pagination cursor.
+        it('advances the next-page cursor when loading the next page', async () => {
+          const initialMessages = [makeReply(), makeReply()];
+          const nextMessages = [makeReply(), makeReply()];
           const thread = createTestThread({
             latest_replies: initialMessages,
             reply_count: 4,
@@ -779,17 +786,14 @@ describe('Threads 2.0', () => {
 
           await thread.loadNextPage({ limit: 2 });
 
-          const stateAfter = thread.state.getLatestValue();
-          const expectedMessageOrder = [...initialMessages, ...nextMessages]
-            .map(({ id }) => id)
-            .join(', ');
-          const actualMessageOrder = stateAfter.replies.map(({ id }) => id).join(', ');
-          expect(actualMessageOrder).to.equal(expectedMessageOrder);
+          expect(thread.state.getLatestValue().pagination.nextCursor).to.equal(
+            nextMessages[1].id,
+          );
         });
 
-        it('prepends messages when loading previous page', async () => {
-          const initialMessages = [generateMsg(), generateMsg()] as MessageResponse[];
-          const prevMessages = [generateMsg(), generateMsg()] as MessageResponse[];
+        it('advances the previous-page cursor when loading the previous page', async () => {
+          const prevMessages = [makeReply(), makeReply()];
+          const initialMessages = [makeReply(), makeReply()];
           const thread = createTestThread({
             latest_replies: initialMessages,
             reply_count: 4,
@@ -800,12 +804,9 @@ describe('Threads 2.0', () => {
 
           await thread.loadPrevPage({ limit: 2 });
 
-          const stateAfter = thread.state.getLatestValue();
-          const expectedMessageOrder = [...prevMessages, ...initialMessages]
-            .map(({ id }) => id)
-            .join(', ');
-          const actualMessageOrder = stateAfter.replies.map(({ id }) => id).join(', ');
-          expect(actualMessageOrder).to.equal(expectedMessageOrder);
+          expect(thread.state.getLatestValue().pagination.prevCursor).to.equal(
+            prevMessages[0].id,
+          );
         });
       });
     });
@@ -857,15 +858,20 @@ describe('Threads 2.0', () => {
       });
 
       it('reloads stale state when thread is active', async () => {
-        const thread = createTestThread();
+        const initialReply = makeReply({ created_at: '2020-03-01T00:00:00.000Z' });
+        const thread = createTestThread({
+          latest_replies: [initialReply],
+          reply_count: 1,
+        });
         thread.registerSubscriptions();
 
-        const stateBefore = thread.state.getLatestValue();
-        const stubbedGetThread = sinon
-          .stub(client, 'getThread')
-          .resolves(
-            createTestThread({ latest_replies: [generateMsg() as MessageResponse] }),
-          );
+        const reloadedReply = makeReply({ created_at: '2020-03-01T00:00:01.000Z' });
+        const stubbedGetThread = sinon.stub(client, 'getThread').resolves(
+          createTestThread({
+            latest_replies: [initialReply, reloadedReply],
+            reply_count: 2,
+          }),
+        );
 
         thread.state.partialNext({ isStateStale: true });
 
@@ -876,8 +882,7 @@ describe('Threads 2.0', () => {
 
         expect(stubbedGetThread.calledOnce).to.be.true;
         await stubbedGetThread.firstCall.returnValue;
-        const stateAfter = thread.state.getLatestValue();
-        expect(stateAfter.replies).not.to.equal(stateBefore.replies);
+        expect(repliesOf(thread).map((reply) => reply.id)).to.include(reloadedReply.id);
 
         thread.unregisterSubscriptions();
       });
@@ -1205,20 +1210,14 @@ describe('Threads 2.0', () => {
           });
           thread.registerSubscriptions();
 
-          const newMessage = generateMsg({
-            parent_id: thread.id,
-            user: { id: 'bob' },
-          }) as MessageResponse;
+          const newMessage = makeReply({ user: { id: 'bob' } });
           client.dispatchEvent({
             type: 'message.new',
             message: newMessage,
             user: { id: 'bob' },
           });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.length(1);
-          expect(stateAfter.replies.find((reply) => reply.id === newMessage.id)).not.to.be
-            .undefined;
+          expect(repliesOf(thread).map((reply) => reply.id)).to.include(newMessage.id);
           expect(thread.ownUnreadCount).to.equal(1);
 
           thread.unregisterSubscriptions();
@@ -1305,7 +1304,8 @@ describe('Threads 2.0', () => {
 
         it('handles receiving a reply that was previously optimistically added', () => {
           const thread = createTestThread({
-            latest_replies: [generateMsg() as MessageResponse],
+            latest_replies: [makeReply()],
+            reply_count: 1,
             read: [
               {
                 user: { id: TEST_USER_ID },
@@ -1314,14 +1314,10 @@ describe('Threads 2.0', () => {
               },
             ],
           });
-          const message = generateMsg({
-            parent_id: thread.id,
-            user: { id: TEST_USER_ID },
-          }) as MessageResponse;
+          const message = makeReply({ user: { id: TEST_USER_ID } });
           thread.upsertReplyLocally({ message });
 
-          const stateBefore = thread.state.getLatestValue();
-          expect(stateBefore.replies).to.have.length(2);
+          expect(repliesOf(thread)).to.have.length(2);
           expect(thread.ownUnreadCount).to.equal(0);
 
           client.dispatchEvent({
@@ -1330,8 +1326,8 @@ describe('Threads 2.0', () => {
             user: { id: TEST_USER_ID },
           });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.length(2);
+          // Receiving the same reply over the WS must not duplicate it.
+          expect(repliesOf(thread)).to.have.length(2);
           expect(thread.ownUnreadCount).to.equal(0);
         });
       });
@@ -1414,10 +1410,10 @@ describe('Threads 2.0', () => {
             message: messageToDelete,
           });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(4);
-          expect(stateAfter.replies.find((reply) => reply.id === messageToDelete.id)).to
-            .be.undefined;
+          const replies = repliesOf(thread);
+          expect(replies).to.have.lengthOf(4);
+          expect(replies.find((reply) => reply.id === messageToDelete.id)).to.be
+            .undefined;
 
           thread.unregisterSubscriptions();
         });
@@ -1425,15 +1421,10 @@ describe('Threads 2.0', () => {
         it('updates deleted_at property of the reply if it was soft deleted', () => {
           const createdAt = new Date().getTime();
           // five messages "created" second apart
-          const messages = Array.from(
-            { length: 5 },
-            (_, i) =>
-              generateMsg({
-                parent_id: parentMessageResponse.id,
-                created_at: new Date(createdAt + 1000 * i).toISOString(),
-              }) as MessageResponse,
+          const messages = Array.from({ length: 5 }, (_, i) =>
+            makeReply({ created_at: new Date(createdAt + 1000 * i).toISOString() }),
           );
-          const thread = createTestThread({ latest_replies: messages });
+          const thread = createTestThread({ latest_replies: messages, reply_count: 5 });
           thread.registerSubscriptions();
 
           const messageToDelete = messages[2];
@@ -1450,15 +1441,14 @@ describe('Threads 2.0', () => {
             },
           });
 
-          const stateAfter = thread.state.getLatestValue();
-          expect(stateAfter.replies).to.have.lengthOf(5);
-          expect(stateAfter.replies[2].id).to.equal(messageToDelete.id);
-          expect(stateAfter.replies[2]).to.not.equal(messageToDelete);
-          expect(stateAfter.replies[2].deleted_at).to.be.a('date');
-          expect(stateAfter.replies[2].deleted_at!.toISOString()).to.equal(
-            deletedAt.toISOString(),
-          );
-          expect(stateAfter.replies[2].type).to.equal('deleted');
+          // Soft delete routes through upsertReplyLocally, so the reply is retained (marked) in place.
+          const replies = repliesOf(thread);
+          expect(replies).to.have.lengthOf(5);
+          expect(replies[2].id).to.equal(messageToDelete.id);
+          expect(replies[2]).to.not.equal(messageToDelete);
+          expect(replies[2].deleted_at).to.be.a('date');
+          expect(replies[2].deleted_at!.toISOString()).to.equal(deletedAt.toISOString());
+          expect(replies[2].type).to.equal('deleted');
 
           thread.unregisterSubscriptions();
         });

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -1224,7 +1224,7 @@ describe('Threads 2.0', () => {
           thread.unregisterSubscriptions();
         });
 
-        it('increments local reply_count on new reply', () => {
+        it('tracks reply_count from the authoritative parent update, not a local increment on new reply', () => {
           const thread = createTestThread({
             reply_count: 0,
             read: [
@@ -1242,9 +1242,20 @@ describe('Threads 2.0', () => {
             user: { id: 'bob' },
           }) as MessageResponse;
 
+          // A received reply must NOT locally bump replyCount. The count is kept authoritative by
+          // the parent's server-driven reply_count (below); a local increment double-counted
+          // received replies on top of that re-sync (see subscribeNewReplies).
           client.dispatchEvent({
             type: 'message.new',
             message: newMessage,
+            user: { id: 'bob' },
+          });
+          expect(thread.state.getLatestValue().replyCount).to.equal(0);
+
+          // The server delivers the authoritative reply_count via the parent's message.updated.
+          client.dispatchEvent({
+            type: 'message.updated',
+            message: { ...parentMessageResponse, reply_count: 1 } as MessageResponse,
             user: { id: 'bob' },
           });
 
@@ -1255,7 +1266,7 @@ describe('Threads 2.0', () => {
           thread.unregisterSubscriptions();
         });
 
-        it('does not increment local reply_count for duplicate message.new events', () => {
+        it('does not change local reply_count on message.new (parent-message-driven, so duplicates are harmless)', () => {
           const existingReply = generateMsg({
             parent_id: parentMessageResponse.id,
             user: { id: 'bob' },
@@ -1263,6 +1274,7 @@ describe('Threads 2.0', () => {
           const thread = createTestThread({
             latest_replies: [existingReply],
             reply_count: 1,
+            parentMessageOverrides: { reply_count: 1 },
             read: [
               {
                 user: { id: TEST_USER_ID },
@@ -1273,14 +1285,11 @@ describe('Threads 2.0', () => {
           });
           thread.registerSubscriptions();
 
-          thread.state.next((current) => ({
-            ...current,
-            parentMessage: {
-              ...current.parentMessage,
-              reply_count: 1,
-            },
-          }));
+          // reply_count is sourced from the parent message, so it starts at 1.
+          expect(thread.state.getLatestValue().replyCount).to.equal(1);
 
+          // A message.new (here a duplicate of an already-loaded reply) must not locally change the
+          // count — the authoritative reply_count comes from the parent message, so this is a no-op.
           client.dispatchEvent({
             type: 'message.new',
             message: existingReply,


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

 
Finishes the v10 thread state cleanup: `Thread.messagePaginator` is promoted to the single source of truth for a thread's replies and the legacy parallel reply/pagination state is removed.                           
                                                                                                                                                                                                               
Fixes                                                                                                                                                                                                          
                                                                                                                                                                                                               
- Correct thread reply count. Source `replyCount` from `parent_message.reply_count`  instead of the thread endpoints' top level `reply_count`, which excludes soft deleted (this is a backend issue that I'll report separately)
replies and rendered a count lower than the channel           
- Edited/deleted replies from other users now reflect in the thread. WS `message.updated/message.deleted` for replies route through `upsertReplyLocally`/`deleteReplyLocally`, which now embed the `messagePaginator`  
sync (`ingestItem`/`removeItem`) so every reply writer keeps the paginator consistent                                        
- Deleting a thread reply no longer leaks a "deleted" placeholder into the main channel message list. `channel.ts`'s `message.deleted` handler now skips the channel `messagePaginator` for pure thread replies (`parent_id && !show_in_channel`), matching what `message.new`/`message.updated` already do (perhaps a better fix would be to filter these in a more generic way, but we can do that later)
                                                                                                                                                                                                               
Breaking - legacy remnants removed                                                                                                                                                                             
                                                                                                                                                                                                               
- Removed `Thread.state.replies` - the `messagePaginator` is the sole reply source 
- Removed the dead reply pagination surface: `Thread.loadNextPage()`, `Thread.loadPrevPage()`, `Thread.queryReplies()`, `ThreadState.pagination` and the exported `ThreadRepliesPagination` type. They were unused and duplicated `messagePaginator.toTail()`/`.toHead()`
  - Migration: use `thread.messagePaginator.toTail()`/`.toHead()` for reply pagination; read `thread.messagePaginator.state` instead of `thread.state.pagination`  

## Changelog

-
