### PR TITLE
fix(types): add missing API response fields reported by scheduled type tests

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -167,6 +167,7 @@ export type AppSettingsAPIResponse = APIResponse & {
     moderation_dashboard_preferences?: Record<string, unknown> | null;
     moderation_audio_call_moderation_enabled?: boolean;
     moderation_enabled?: boolean;
+    moderation_flood_rules_enabled?: boolean;
     moderation_llm_configurability_enabled?: boolean;
     moderation_multitenant_blocklist_enabled?: boolean;
     moderation_video_call_moderation_enabled?: boolean;
@@ -319,6 +320,8 @@ export type QueryFutureChannelBansOptions = {
 
 export type BlockListResponse = BlockList & {
   created_at?: string;
+  id?: string;
+  owner_user_id?: string;
   type?: string;
   updated_at?: string;
 };
@@ -1045,6 +1048,8 @@ export type UserResponse = CustomUserData & {
   anon?: boolean;
   banned?: boolean;
   blocked_user_ids?: string[];
+  /** Set on the user of a read event, marking when they last read the event's channel. */
+  channel_last_read_at?: string;
   created_at?: string;
   deactivated_at?: string;
   deleted_at?: string;
@@ -2588,6 +2593,7 @@ export type BlockList = {
   is_confusable_folding_enabled?: boolean;
   is_leet_check_enabled?: boolean;
   is_plural_check_enabled?: boolean;
+  is_substring_matching_enabled?: boolean;
 };
 
 export type ChannelConfig = ChannelConfigFields &
@@ -3098,6 +3104,8 @@ export type PermissionAPIObject = {
   level?: string;
   name?: string;
   owner?: boolean;
+  /** Resource type that defines ownership for this permission's action, e.g. 'Channel' for CreateMessage. */
+  owner_resource?: string;
   same_team?: boolean;
   tags?: string[];
 };


### PR DESCRIPTION
## Problem

The weekly [Scheduled tests](https://github.com/GetStream/stream-chat-js/actions/runs/31374813455) run failed. `yarn test-types` hits the live API, dumps real responses into `test/typescript/data.ts`, and typechecks them against `src/types.ts`.

All **1551 errors were `TS2353`** (excess property), collapsing to a handful of backend fields missing from our hand-written wire types. Nothing is broken in the SDK; this is type drift, which is exactly what this job exists to catch.

## Fields added

Cross-checked against `GetStream/protocol` spec **v235.6.0** (`chat-openapi-clientside.yaml` blob `1de5267b`, `chat-openapi.yaml` blob `885a1ca5`, both at `main` HEAD).

| Field | Type | Spec source |
| --- | --- | --- |
| `owner_resource` | `PermissionAPIObject` | serverside `Permission` (the endpoint is serverside-only, so it is correctly absent clientside) |
| `is_substring_matching_enabled` | `BlockList` | clientside `BlockListResponse`, `CreateBlockListRequest`, `UpdateBlockListRequest` — in the `required` list |
| `moderation_flood_rules_enabled` | `AppSettingsAPIResponse['app']` | serverside `App` (serverside-only endpoint) |
| `channel_last_read_at` | `UserResponse` | **not documented in either spec** — see below |

`PermissionAPIObject` is now an exact 11/11 match with the spec's `Permission`.

## Extra gap found while cross-checking

A property-level diff against the spec (not just the CI-flagged fields) surfaced `id` and `owner_user_id` on `BlockListResponse`. Both are documented but are not returned for the type-test app, so CI never flagged them. Added to `BlockListResponse` rather than `BlockList`, since the spec lists them on the response only, not on the create/update requests.

## Note for the protocol team

`channel_last_read_at` is not in either spec at v235.6.0. It arrives on `event.user` in the `message.read` event returned by `markRead`. In the clientside spec, `MessageReadEvent.user` is a `$ref` to `UserResponseCommonFields`, whose 18 properties are `avg_response_time, banned, blocked_user_ids, created_at, custom, deactivated_at, deleted_at, id, image, language, last_active, name, online, revoke_tokens_issued_before, role, teams, teams_role, updated_at` — no `channel_last_read_at`. So the spec trails the backend here. Typed as an optional ISO timestamp `string` to match sibling fields; worth documenting upstream.

Deliberately left alone: `BlockList.validate` exists here but not in the spec (likely legacy, removing it would be breaking), and `UserResponse` has no nested `custom` because v9 flattens custom data through `CustomUserData` module augmentation by design.

## Verification

`yarn types`, `yarn lint` and `yarn test` (75 files, 3028 passed, 1 skipped) all pass locally.

`yarn test-types` cannot run on a PR — it needs live API credentials and only runs on the weekly cron or `workflow_dispatch`. Dispatching Scheduled tests against this branch to confirm end to end.
