### PR TITLE
perf: introduce event sync limit for offline db

### DIFF
--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -40,9 +40,24 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
   public syncManager: OfflineDBSyncManager;
   public state: StateStore<OfflineDBState>;
 
-  constructor({ client }: { client: StreamChat }) {
+  constructor({
+    client,
+    syncMaxEventCount,
+  }: {
+    client: StreamChat;
+    /**
+     * Optional positive cap forwarded to the {@link OfflineDBSyncManager}, which
+     * owns sync. `undefined` or any non-positive value means "no limit". See
+     * {@link OfflineDBSyncManager.syncMaxEventCount}.
+     */
+    syncMaxEventCount?: number;
+  }) {
     this.client = client;
-    this.syncManager = new OfflineDBSyncManager({ client, offlineDb: this });
+    this.syncManager = new OfflineDBSyncManager({
+      client,
+      offlineDb: this,
+      syncMaxEventCount,
+    });
     this.state = new StateStore<OfflineDBState>({
       initialized: false,
       userId: this.client.userID,

--- a/src/offline-support/offline_sync_manager.ts
+++ b/src/offline-support/offline_sync_manager.ts
@@ -20,16 +20,29 @@ export class OfflineDBSyncManager {
     new Map();
   private client: StreamChat;
   private offlineDb: AbstractOfflineDB;
+  /**
+   * Optional positive cap on the number of events a single `/sync` response may
+   * contain before this manager skips event replay into local storage and relies
+   * on the reconnect-time channel refresh (queryChannels + `channel.watch()`) to
+   * bring visible surfaces up to date.
+   *
+   * `undefined` or any non-positive value means "no limit" and event replay always
+   * runs with whatever maximum the server decides to return.
+   */
+  public readonly syncMaxEventCount?: number;
 
   constructor({
     client,
     offlineDb,
+    syncMaxEventCount,
   }: {
     client: StreamChat;
     offlineDb: AbstractOfflineDB;
+    syncMaxEventCount?: number;
   }) {
     this.client = client;
     this.offlineDb = offlineDb;
+    this.syncMaxEventCount = syncMaxEventCount;
   }
 
   /**
@@ -173,14 +186,29 @@ export class OfflineDBSyncManager {
           await this.offlineDb.resetDB();
         } else {
           const result = await this.client.sync(cids, lastSyncedAtDate.toISOString());
-          const queryPromises = result.events.map((event) =>
-            this.offlineDb.handleEvent({ event, execute: false }),
-          );
-          const queriesArray = await Promise.all(queryPromises);
-          const queries = queriesArray.flat() as ExecuteBatchDBQueriesType;
 
-          if (queries.length) {
-            await this.offlineDb.executeSqlBatch(queries);
+          // Opt-in positive cap owned by this manager; undefined/non-positive = no limit.
+          const { syncMaxEventCount } = this;
+          const exceedsLimit =
+            typeof syncMaxEventCount === 'number' &&
+            syncMaxEventCount > 0 &&
+            result.events.length > syncMaxEventCount;
+          if (exceedsLimit) {
+            this.client.logger(
+              'warn',
+              `Skipping sync event replay: received ${result.events.length} events, which exceeds the configured limit of ${syncMaxEventCount}. Visible channels are refreshed on reconnect instead.`,
+              { tags: ['sync', 'offline'] },
+            );
+          } else {
+            const queryPromises = result.events.map((event) =>
+              this.offlineDb.handleEvent({ event, execute: false }),
+            );
+            const queriesArray = await Promise.all(queryPromises);
+            const queries = queriesArray.flat() as ExecuteBatchDBQueriesType;
+
+            if (queries.length) {
+              await this.offlineDb.executeSqlBatch(queries);
+            }
           }
         }
       }

--- a/test/unit/offline-support/MockOfflineDB.ts
+++ b/test/unit/offline-support/MockOfflineDB.ts
@@ -2,8 +2,14 @@ import { AbstractOfflineDB, StreamChat } from '../../../src';
 import { vi } from 'vitest';
 
 export class MockOfflineDB extends AbstractOfflineDB {
-  constructor({ client }: { client: StreamChat }) {
-    super({ client });
+  constructor({
+    client,
+    syncMaxEventCount,
+  }: {
+    client: StreamChat;
+    syncMaxEventCount?: number;
+  }) {
+    super({ client, syncMaxEventCount });
   }
 
   upsertCidsForQuery = vi.fn();

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -185,6 +185,106 @@ describe('OfflineSupportApi', () => {
     });
   });
 
+  describe('sync event replay policy', () => {
+    const CID = 'messaging:1';
+
+    const setupSync = ({
+      syncMaxEventCount,
+      eventCount,
+    }: {
+      syncMaxEventCount?: number;
+      eventCount: number;
+    }) => {
+      const offlineDb = new MockOfflineDB({ client, syncMaxEventCount });
+      offlineDb.getAllChannelCids.mockResolvedValue([CID]);
+      // Recent lastSyncedAt => within the 30 day window => enters the /sync branch.
+      offlineDb.getLastSyncedAt.mockResolvedValue(new Date().toISOString());
+      offlineDb.executeSqlBatch.mockResolvedValue(undefined);
+      offlineDb.upsertUserSyncStatus.mockResolvedValue(undefined);
+
+      const events = Array.from(
+        { length: eventCount },
+        () => ({ type: 'message.new', cid: CID }) as Event,
+      );
+      const syncSpy = vi
+        .spyOn(client, 'sync')
+        .mockResolvedValue({ events } as unknown as Awaited<
+          ReturnType<StreamChat['sync']>
+        >);
+      // handleEvent returns a query so the under-limit path reaches executeSqlBatch.
+      const handleEventSpy = vi
+        .spyOn(offlineDb, 'handleEvent')
+        .mockResolvedValue([{ sql: 'MOCK_QUERY', args: [] }]);
+
+      return { offlineDb, syncSpy, handleEventSpy };
+    };
+
+    // sync() is private; drive it directly for a focused unit test.
+    const runSync = (offlineDb: MockOfflineDB) =>
+      (offlineDb.syncManager as unknown as { sync: () => Promise<void> }).sync();
+
+    it('leaves the sync manager syncMaxEventCount undefined (no limit) when not provided', () => {
+      const offlineDb = new MockOfflineDB({ client });
+      expect(offlineDb.syncManager.syncMaxEventCount).toBeUndefined();
+    });
+
+    it('replays every event when no limit is set, even for a large payload', async () => {
+      const { offlineDb, handleEventSpy } = setupSync({ eventCount: 500 });
+
+      await runSync(offlineDb);
+
+      expect(handleEventSpy).toHaveBeenCalledTimes(500);
+      expect(offlineDb.executeSqlBatch).toHaveBeenCalledOnce();
+      expect(offlineDb.upsertUserSyncStatus).toHaveBeenCalledOnce();
+      expect(offlineDb.resetDB).not.toHaveBeenCalled();
+    });
+
+    it('treats a non-positive limit as no limit (still replays)', async () => {
+      const { offlineDb, handleEventSpy } = setupSync({
+        syncMaxEventCount: 0,
+        eventCount: 5,
+      });
+
+      await runSync(offlineDb);
+
+      expect(handleEventSpy).toHaveBeenCalledTimes(5);
+      expect(offlineDb.executeSqlBatch).toHaveBeenCalledOnce();
+    });
+
+    it('replays events into the DB when the payload is at or below the limit', async () => {
+      const { offlineDb, handleEventSpy } = setupSync({
+        syncMaxEventCount: 3,
+        eventCount: 3,
+      });
+
+      await runSync(offlineDb);
+
+      expect(handleEventSpy).toHaveBeenCalledTimes(3);
+      expect(offlineDb.executeSqlBatch).toHaveBeenCalledOnce();
+      // Timestamp is still advanced, and the DB is not reset.
+      expect(offlineDb.upsertUserSyncStatus).toHaveBeenCalledOnce();
+      expect(offlineDb.resetDB).not.toHaveBeenCalled();
+    });
+
+    it('skips event replay when the payload exceeds the limit but still advances the timestamp', async () => {
+      const { offlineDb, handleEventSpy } = setupSync({
+        syncMaxEventCount: 3,
+        eventCount: 4,
+      });
+
+      await runSync(offlineDb);
+
+      // Replay is skipped entirely: no per-event handling, no batch write.
+      expect(handleEventSpy).not.toHaveBeenCalled();
+      expect(offlineDb.executeSqlBatch).not.toHaveBeenCalled();
+      // The last-sync timestamp is still advanced so the same oversized payload
+      // is not re-fetched and skipped on every subsequent sync.
+      expect(offlineDb.upsertUserSyncStatus).toHaveBeenCalledOnce();
+      // Skipping is NOT a reset — inactive channels wait for a future query.
+      expect(offlineDb.resetDB).not.toHaveBeenCalled();
+    });
+  });
+
   describe('queries and query utilities', () => {
     let offlineDb: MockOfflineDB;
 


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Implements the missing parts of [this spec](https://app.notion.com/p/stream-wiki/Sync-events-limit-3666a5d7f9f6801f97ecc1461fc62049).

## Changelog

-
