### PR TITLE
fix: regenerate api layer (fix generated filter types)

### DIFF
--- a/src/gen/chat/ChannelApi.ts
+++ b/src/gen/chat/ChannelApi.ts
@@ -58,6 +58,11 @@ export class ChannelApi {
     messages_limit?: number;
     members_limit?: number;
     watchers_limit?: number;
+    messages_id_lt?: string;
+    messages_id_lte?: string;
+    messages_id_gt?: string;
+    messages_id_gte?: string;
+    messages_id_around?: string;
   }): Promise<StreamResponse<ChannelStateResponse>> {
     if (!this.id) {
       throw new Error(

--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -482,12 +482,22 @@ export class ChatApi {
     messages_limit?: number;
     members_limit?: number;
     watchers_limit?: number;
+    messages_id_lt?: string;
+    messages_id_lte?: string;
+    messages_id_gt?: string;
+    messages_id_gte?: string;
+    messages_id_around?: string;
   }): Promise<StreamResponse<ChannelStateResponse>> {
     const queryParams = {
       state: request?.state,
       messages_limit: request?.messages_limit,
       members_limit: request?.members_limit,
       watchers_limit: request?.watchers_limit,
+      messages_id_lt: request?.messages_id_lt,
+      messages_id_lte: request?.messages_id_lte,
+      messages_id_gt: request?.messages_id_gt,
+      messages_id_gte: request?.messages_id_gte,
+      messages_id_around: request?.messages_id_around,
     };
     const pathParams = {
       type: request?.type,

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -15,20 +15,34 @@ export type Filters<
 > = QueryFilters<{
   [Property in keyof FCHelper<FilterConditions>]:
     | RequireOnlyOne<{
-        [Operator in FCHelper<FilterConditions>[Property]['operators']]: Operator extends
-          | '$in'
-          | '$nin'
-          ? Array<FCHelper<FilterConditions>[Property]['type']>
-          : Operator extends '$exists'
-            ? boolean
-            : Operator extends '$eq' | '$ne'
-              ? FCHelper<FilterConditions>[Property]['type'] | null
-              : FCHelper<FilterConditions>[Property]['type'];
+        [Operator in FCHelper<FilterConditions>[Property]['operators']]: FilterValue<
+          FCHelper<FilterConditions>[Property],
+          Operator
+        >;
       }>
     | ('$eq' extends FCHelper<FilterConditions>[Property]['operators']
-        ? FCHelper<FilterConditions>[Property]['type'] | null
+        ? FilterValue<FCHelper<FilterConditions>[Property], '$eq'>
         : never);
 }>;
+
+// The value an operator takes on one filter key. `valueTypes` carries the
+// per-operator overrides the spec publishes and is checked first, so an override
+// also suppresses the `| null` the $eq/$ne rule would otherwise add — the backend
+// rejects null wherever an override applies. Everything else follows the two
+// universal rules ($in/$nin take an array of the key's type, $exists takes a
+// boolean) and finally the key's own type.
+export type FilterValue<
+  Entry extends { type: any },
+  Operator extends string,
+> = Entry extends { valueTypes: Record<Operator, infer V> }
+  ? V
+  : Operator extends '$in' | '$nin'
+    ? Array<Entry['type']>
+    : Operator extends '$exists'
+      ? boolean
+      : Operator extends '$eq' | '$ne'
+        ? Entry['type'] | null
+        : Entry['type'];
 
 export type FCHelper<
   FilterConditions extends Record<string, { type: any; operators: string }>,
@@ -8507,6 +8521,7 @@ export interface QueryChannelsRequest {
     filter_tags: {
       type: string;
       operators: '$eq' | '$in';
+      valueTypes: { $eq: Array<string> };
     };
 
     frozen: {
@@ -8607,6 +8622,7 @@ export interface QueryChannelsRequest {
     members: {
       type: string;
       operators: '$eq' | '$in' | '$nin';
+      valueTypes: { $eq: Array<string> };
     };
 
     message_count: {
@@ -11166,6 +11182,7 @@ export interface SearchPayload {
     filter_tags: {
       type: string;
       operators: '$eq' | '$in';
+      valueTypes: { $eq: Array<string> };
     };
 
     frozen: {
@@ -11266,6 +11283,7 @@ export interface SearchPayload {
     members: {
       type: string;
       operators: '$eq' | '$in' | '$nin';
+      valueTypes: { $eq: Array<string> };
     };
 
     message_count: {

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -8110,156 +8110,57 @@ export interface QueryAppealsRequest {
   filter?: Filters<{
     appeal_reason: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     decided_by: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     decision_reason: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     entity_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     entity_type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     review_queue_item_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     status: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     user_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 }
@@ -8284,16 +8185,7 @@ export interface QueryBannedUsersPayload {
   filter_conditions: Filters<{
     banned_by_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     channel_cid: {
@@ -8303,16 +8195,7 @@ export interface QueryBannedUsersPayload {
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     reason: {
@@ -8325,23 +8208,12 @@ export interface QueryBannedUsersPayload {
         | '$gte'
         | '$in'
         | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+        | '$lte';
     };
 
     user_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 
@@ -8452,44 +8324,17 @@ export interface QueryChannelsRequest {
 
     cid: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_by_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -8504,7 +8349,6 @@ export interface QueryChannelsRequest {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
@@ -8526,16 +8370,7 @@ export interface QueryChannelsRequest {
 
     frozen: {
       type: boolean;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     has_unread: {
@@ -8550,16 +8385,7 @@ export interface QueryChannelsRequest {
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     invite: {
@@ -8574,69 +8400,33 @@ export interface QueryChannelsRequest {
 
     last_message_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     last_updated: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     'member.user.name': {
       type: string;
-      operators: '$autocomplete' | '$eq' | '$ne';
+      operators: '$autocomplete' | '$eq';
     };
 
     member_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     members: {
       type: string;
-      operators: '$eq' | '$in' | '$nin';
+      operators: '$eq' | '$in';
       valueTypes: { $eq: Array<string> };
     };
 
     message_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     muted: {
@@ -8655,8 +8445,6 @@ export interface QueryChannelsRequest {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$ne'
-        | '$nin'
         | '$q';
     };
 
@@ -8667,44 +8455,17 @@ export interface QueryChannelsRequest {
 
     team: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 
@@ -8847,16 +8608,7 @@ export interface QueryMembersPayload {
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -8871,22 +8623,12 @@ export interface QueryMembersPayload {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     invite: {
@@ -8896,7 +8638,7 @@ export interface QueryMembersPayload {
 
     is_moderator: {
       type: boolean;
-      operators: '$eq' | '$ne';
+      operators: '$eq';
     };
 
     joined: {
@@ -8906,12 +8648,12 @@ export interface QueryMembersPayload {
 
     last_active: {
       type: Date | string;
-      operators: '$eq' | '$gt' | '$gte' | '$lt' | '$lte' | '$ne';
+      operators: '$eq' | '$gt' | '$gte' | '$lt' | '$lte';
     };
 
     name: {
       type: string;
-      operators: '$autocomplete' | '$eq' | '$in' | '$ne' | '$nin' | '$q';
+      operators: '$autocomplete' | '$eq' | '$in' | '$q';
     };
 
     notifications_muted: {
@@ -8921,21 +8663,12 @@ export interface QueryMembersPayload {
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     'user.email': {
       type: string;
-      operators: '$autocomplete' | '$eq' | '$in' | '$ne' | '$nin' | '$q';
+      operators: '$autocomplete' | '$eq' | '$in' | '$q';
     };
 
     'user.nd_deactivated': {
@@ -8945,16 +8678,7 @@ export interface QueryMembersPayload {
 
     user_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 
@@ -9108,16 +8832,7 @@ export interface QueryModerationConfigsRequest {
   filter?: Filters<{
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     key: {
@@ -9130,37 +8845,17 @@ export interface QueryModerationConfigsRequest {
         | '$gte'
         | '$in'
         | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+        | '$lte';
     };
 
     team: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 }
@@ -9279,7 +8974,6 @@ export interface QueryPollsRequest {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
@@ -9295,7 +8989,7 @@ export interface QueryPollsRequest {
 
     max_votes_allowed: {
       type: number;
-      operators: '$eq' | '$gt' | '$gte' | '$lt' | '$lte' | '$ne';
+      operators: '$eq' | '$gt' | '$gte' | '$lt' | '$lte';
     };
 
     name: {
@@ -9349,16 +9043,7 @@ export interface QueryReactionsRequest {
   filter?: Filters<{
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     type: {
@@ -9500,30 +9185,12 @@ export interface QueryReviewQueueRequest {
 
     archived_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     bounce_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     category: {
@@ -9543,44 +9210,17 @@ export interface QueryReviewQueueRequest {
 
     completed_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     config_key: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -9595,7 +9235,6 @@ export interface QueryReviewQueueRequest {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
@@ -9606,58 +9245,22 @@ export interface QueryReviewQueueRequest {
 
     entity_creator_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     entity_creator_name: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     entity_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     entity_type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     escalated: {
@@ -9667,30 +9270,12 @@ export interface QueryReviewQueueRequest {
 
     escalated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     escalated_by: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     escalation_priority: {
@@ -9735,16 +9320,7 @@ export interface QueryReviewQueueRequest {
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     label: {
@@ -9759,16 +9335,7 @@ export interface QueryReviewQueueRequest {
 
     latest_moderator_action: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     queue_type: {
@@ -9798,44 +9365,17 @@ export interface QueryReviewQueueRequest {
 
     reviewed_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     severity: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     status: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     teams: {
@@ -9845,30 +9385,12 @@ export interface QueryReviewQueueRequest {
 
     type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     user_report_reason: {
@@ -9980,7 +9502,6 @@ export interface QueryThreadsRequest {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
@@ -10049,16 +9570,7 @@ export interface QueryUsersPayload {
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -10071,8 +9583,7 @@ export interface QueryUsersPayload {
         | '$gte'
         | '$in'
         | '$lt'
-        | '$lte'
-        | '$nin';
+        | '$lte';
     };
 
     email: {
@@ -10097,21 +9608,12 @@ export interface QueryUsersPayload {
 
     language: {
       type: string;
-      operators: '$eq' | '$ne';
+      operators: '$eq';
     };
 
     last_active: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     name: {
@@ -10124,23 +9626,12 @@ export interface QueryUsersPayload {
         | '$gte'
         | '$in'
         | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+        | '$lte';
     };
 
     role: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     shadow_banned: {
@@ -10155,16 +9646,7 @@ export interface QueryUsersPayload {
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     username: {
@@ -11113,44 +10595,17 @@ export interface SearchPayload {
 
     cid: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_by_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -11165,7 +10620,6 @@ export interface SearchPayload {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$nin'
         | '$q';
     };
 
@@ -11187,16 +10641,7 @@ export interface SearchPayload {
 
     frozen: {
       type: boolean;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     has_unread: {
@@ -11211,16 +10656,7 @@ export interface SearchPayload {
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     invite: {
@@ -11235,69 +10671,33 @@ export interface SearchPayload {
 
     last_message_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     last_updated: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     'member.user.name': {
       type: string;
-      operators: '$autocomplete' | '$eq' | '$ne';
+      operators: '$autocomplete' | '$eq';
     };
 
     member_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     members: {
       type: string;
-      operators: '$eq' | '$in' | '$nin';
+      operators: '$eq' | '$in';
       valueTypes: { $eq: Array<string> };
     };
 
     message_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     muted: {
@@ -11316,8 +10716,6 @@ export interface SearchPayload {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$ne'
-        | '$nin'
         | '$q';
     };
 
@@ -11328,44 +10726,17 @@ export interface SearchPayload {
 
     team: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
   }>;
 
@@ -11414,30 +10785,12 @@ export interface SearchPayload {
 
     cid: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     created_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     custom: {
@@ -11447,16 +10800,7 @@ export interface SearchPayload {
 
     id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     'mentioned_users.id': {
@@ -11466,16 +10810,7 @@ export interface SearchPayload {
 
     parent_id: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     pinned: {
@@ -11485,16 +10820,7 @@ export interface SearchPayload {
 
     reply_count: {
       type: number;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     text: {
@@ -11509,47 +10835,27 @@ export interface SearchPayload {
         | '$in'
         | '$lt'
         | '$lte'
-        | '$ne'
-        | '$nin'
         | '$q';
     };
 
     type: {
       type: string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     updated_at: {
       type: Date | string;
-      operators:
-        | '$eq'
-        | '$exists'
-        | '$gt'
-        | '$gte'
-        | '$in'
-        | '$lt'
-        | '$lte'
-        | '$ne'
-        | '$nin';
+      operators: '$eq' | '$exists' | '$gt' | '$gte' | '$in' | '$lt' | '$lte';
     };
 
     'user.id': {
       type: string;
-      operators: '$eq' | '$in' | '$ne' | '$nin';
+      operators: '$eq' | '$in';
     };
 
     user_id: {
       type: string;
-      operators: '$eq' | '$in' | '$ne' | '$nin';
+      operators: '$eq' | '$in';
     };
   }>;
 

--- a/src/gen/models/index.ts
+++ b/src/gen/models/index.ts
@@ -342,8 +342,14 @@ export interface ActionLogResponse {
 
   review_queue_item?: ReviewQueueItemResponse;
 
+  /**
+   * User response object
+   */
   target_user?: UserResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -537,6 +543,9 @@ export interface AppealItemResponse {
 
   original_moderation_action?: ActionLogResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -634,6 +643,9 @@ export interface AutomodDetailsResponse {
 
   message_details?: FlagMessageDetailsResponse;
 
+  /**
+   * Result of the message moderation
+   */
   result?: MessageModerationResult;
 }
 
@@ -750,8 +762,14 @@ export interface BanInfoResponse {
 
   channel?: ChannelMetadata;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -805,6 +823,9 @@ export interface BanRequest {
    */
   timeout?: number;
 
+  /**
+   * User request object
+   */
   banned_by?: UserRequest;
 }
 
@@ -817,10 +838,19 @@ export interface BanResponse {
 
   shadow?: boolean;
 
+  /**
+   * User response object
+   */
   banned_by?: UserResponse;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -953,8 +983,14 @@ export interface BlockedUserResponse {
    */
   user_id: string;
 
+  /**
+   * User response object
+   */
   blocked_user: UserResponse;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 }
 
@@ -1009,14 +1045,29 @@ export interface BulkActionAppealsRequest {
    */
   appeal_ids: Array<string>;
 
+  /**
+   * Configuration for mark reviewed action
+   */
   mark_reviewed?: MarkReviewedRequestPayload;
 
+  /**
+   * Configuration for rejecting an appeal
+   */
   reject_appeal?: RejectAppealRequestPayload;
 
+  /**
+   * Configuration for restore action
+   */
   restore?: RestoreActionRequestPayload;
 
+  /**
+   * Configuration for unban moderation action
+   */
   unban?: UnbanActionRequestPayload;
 
+  /**
+   * Configuration for unblock action
+   */
   unblock?: UnblockActionRequestPayload;
 }
 
@@ -1266,6 +1317,9 @@ export interface ChannelConfigWithInfo {
 
   blocklists?: Array<BlockListOptions>;
 
+  /**
+   * Sets thresholds for AI moderation
+   */
   automod_thresholds?: Thresholds;
 
   chat_preferences?: ChatPreferences;
@@ -1289,6 +1343,9 @@ export interface ChannelContextResponse {
    */
   type: string;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 }
 
@@ -1298,6 +1355,9 @@ export interface ChannelCreatedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -1347,6 +1407,9 @@ export interface ChannelDeletedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -1469,6 +1532,9 @@ export interface ChannelHiddenEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -1545,8 +1611,14 @@ export interface ChannelInput {
 
   members?: Array<ChannelMemberRequest>;
 
+  /**
+   * Channel configuration overrides
+   */
   config_overrides?: ChannelConfigOverrides;
 
+  /**
+   * User request object
+   */
   created_by?: UserRequest;
 
   custom?: CustomChannelData;
@@ -1567,8 +1639,14 @@ export interface ChannelInputRequest {
 
   members?: Array<ChannelMemberRequest>;
 
+  /**
+   * Channel configuration overrides
+   */
   config_overrides?: ConfigOverridesRequest;
 
+  /**
+   * User request object
+   */
   created_by?: UserRequest;
 
   custom?: CustomChannelData;
@@ -1646,6 +1724,9 @@ export interface ChannelMemberRequest {
 
   custom?: CustomMemberData;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -1731,6 +1812,9 @@ export interface ChannelMemberResponse {
 
   deleted_messages?: Array<string>;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -1776,8 +1860,14 @@ export interface ChannelMute {
    */
   expires?: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -1962,8 +2052,14 @@ export interface ChannelResponse {
 
   config?: ChannelConfigWithInfo;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 
+  /**
+   * User response object
+   */
   truncated_by?: UserResponse;
 }
 
@@ -1992,6 +2088,9 @@ export interface ChannelStateResponse {
 
   watchers?: Array<UserResponse>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   draft?: DraftResponse;
@@ -2054,6 +2153,9 @@ export interface ChannelStateResponseFields {
    */
   watchers?: Array<UserResponse>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   draft?: DraftResponse;
@@ -2071,6 +2173,9 @@ export interface ChannelTruncatedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -2113,6 +2218,9 @@ export interface ChannelTruncatedEvent {
 
   channel_custom?: CustomChannelData;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   user?: UserResponseCommonFields;
@@ -2155,6 +2263,9 @@ export interface ChannelUpdatedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -2197,6 +2308,9 @@ export interface ChannelUpdatedEvent {
 
   channel_custom?: CustomChannelData;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   user?: UserResponseCommonFields;
@@ -2208,6 +2322,9 @@ export interface ChannelVisibleEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -2338,6 +2455,9 @@ export interface ChatMessageResponse {
 
   reaction_scores: Record<string, number>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   command?: string;
@@ -2380,6 +2500,9 @@ export interface ChatMessageResponse {
 
   moderation?: ChatModerationV2Response;
 
+  /**
+   * User response object
+   */
   pinned_by?: UserResponse;
 
   poll?: PollResponseData;
@@ -2478,6 +2601,9 @@ export interface ChatReactionGroupUserResponse {
 
   user_id: string;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -2496,6 +2622,9 @@ export interface ChatReactionResponse {
 
   custom: CustomReactionData;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 }
 
@@ -2514,6 +2643,9 @@ export interface ChatReminderResponseData {
 
   message?: ChatMessageResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -2800,6 +2932,9 @@ export interface CreateBlockListResponse {
    */
   duration: string;
 
+  /**
+   * Block list contains restricted words
+   */
   blocklist?: BlockListResponse;
 }
 
@@ -2832,6 +2967,9 @@ export interface CreateDeviceRequest {
 }
 
 export interface CreateDraftRequest {
+  /**
+   * Message data for creating or updating a message
+   */
   message: MessageRequest;
 }
 
@@ -2845,6 +2983,9 @@ export interface CreateDraftResponse {
 }
 
 export interface CreateGuestRequest {
+  /**
+   * User request object
+   */
   user: UserRequest;
 }
 
@@ -2859,6 +3000,9 @@ export interface CreateGuestResponse {
    */
   duration: string;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 }
 
@@ -3031,6 +3175,9 @@ export interface DeleteChannelResponse {
    */
   duration: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 }
 
@@ -3116,6 +3263,9 @@ export interface DeleteMessageResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 }
 
@@ -3153,6 +3303,9 @@ export interface DeleteReactionResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   reaction: ReactionResponse;
@@ -3386,14 +3539,26 @@ export interface DraftResponse {
 
   created_at: Date;
 
+  /**
+   * Contains the draft message content
+   */
   message: DraftPayloadResponse;
 
   parent_id?: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   parent_message?: MessageResponse;
 
+  /**
+   * Represents any chat message
+   */
   quoted_message?: MessageResponse;
 }
 
@@ -3571,6 +3736,9 @@ export interface EventResponse {
    */
   duration: string;
 
+  /**
+   * The discriminator object for all websocket events, it maps events' payload to the final type
+   */
   event: WSEvent;
 }
 
@@ -3589,6 +3757,9 @@ export interface FeedsBookmarkResponse {
 
   updated_at: Date;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   activity_id?: string;
@@ -3637,6 +3808,9 @@ export interface FeedsFeedResponse {
 
   updated_at: Date;
 
+  /**
+   * User response object
+   */
   created_by: UserResponse;
 
   deleted_at?: Date;
@@ -3792,6 +3966,9 @@ export interface FeedsReactionResponse {
 
   updated_at: Date;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   comment_id?: string;
@@ -3804,6 +3981,9 @@ export interface FeedsShareResponse {
 
   created_at: Date;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 }
 
@@ -3862,6 +4042,9 @@ export interface FeedsV3ActivityResponse {
 
   search_data: Record<string, any>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   deleted_at?: Date;
@@ -3940,6 +4123,9 @@ export interface FeedsV3CommentResponse {
 
   own_reactions: Array<FeedsReactionResponse>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   controversy_score?: number;
@@ -4234,8 +4420,14 @@ export interface FutureChannelBanResponse {
 
   shadow?: boolean;
 
+  /**
+   * User response object
+   */
   banned_by?: UserResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -4305,6 +4497,9 @@ export interface GetMessageResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageWithChannelResponse;
 
   pending_message_metadata?: Record<string, string>;
@@ -4815,6 +5010,9 @@ export interface MarkReadResponseEvent {
 
   team?: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   thread?: ThreadResponse;
@@ -4872,6 +5070,9 @@ export interface MemberAddedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -4926,6 +5127,9 @@ export interface MemberRemovedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -4980,6 +5184,9 @@ export interface MemberUpdatedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -5053,6 +5260,9 @@ export interface MessageActionResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -5091,6 +5301,9 @@ export interface MessageDeletedEvent {
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -5195,6 +5408,9 @@ export interface MessageDeliveredEvent {
    */
   team?: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   channel_custom?: CustomChannelData;
@@ -5221,14 +5437,26 @@ export interface MessageFlagResponse {
 
   details?: FlagDetailsResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   moderation_feedback?: FlagFeedbackResponse;
 
+  /**
+   * Result of the message moderation
+   */
   moderation_result?: MessageModerationResult;
 
+  /**
+   * User response object
+   */
   reviewed_by?: UserResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -5280,6 +5508,9 @@ export interface MessageModerationResult {
 
   ai_moderation_response?: ModerationResponse;
 
+  /**
+   * Sets thresholds for AI moderation
+   */
   moderation_thresholds?: Thresholds;
 }
 
@@ -5298,6 +5529,9 @@ export interface MessageNewEvent {
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -5356,6 +5590,9 @@ export interface MessageNewEvent {
    */
   thread_participants?: Array<UserResponseCommonFields>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   channel_custom?: CustomChannelData;
@@ -5478,6 +5715,9 @@ export interface MessageReadEvent {
    */
   team?: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   channel_custom?: CustomChannelData;
@@ -5682,6 +5922,9 @@ export interface MessageResponse {
    */
   reaction_scores: Record<string, number>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   /**
@@ -5766,10 +6009,16 @@ export interface MessageResponse {
 
   moderation?: ModerationV2Response;
 
+  /**
+   * User response object
+   */
   pinned_by?: UserResponse;
 
   poll?: PollResponseData;
 
+  /**
+   * Represents any chat message
+   */
   quoted_message?: MessageResponse;
 
   reaction_groups?: Record<string, ReactionGroupResponse>;
@@ -5789,6 +6038,9 @@ export interface MessageUndeletedEvent {
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -5847,6 +6099,9 @@ export interface MessageUpdatedEvent {
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -5986,6 +6241,9 @@ export interface MessageWithChannelResponse {
    */
   restricted_visibility: Array<string>;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomMessageData;
@@ -6000,6 +6258,9 @@ export interface MessageWithChannelResponse {
    */
   reaction_scores: Record<string, number>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   /**
@@ -6084,10 +6345,16 @@ export interface MessageWithChannelResponse {
 
   moderation?: ModerationV2Response;
 
+  /**
+   * User response object
+   */
   pinned_by?: UserResponse;
 
   poll?: PollResponseData;
 
+  /**
+   * Represents any chat message
+   */
   quoted_message?: MessageResponse;
 
   reaction_groups?: Record<string, ReactionGroupResponse>;
@@ -6179,6 +6446,9 @@ export interface ModerationCallResponse {
 
   team?: string;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 }
 
@@ -6203,6 +6473,9 @@ export interface ModerationCustomActionEvent {
    */
   action_options?: Record<string, any>;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -6231,10 +6504,16 @@ export interface ModerationFlagResponse {
 
   custom?: Record<string, any>;
 
+  /**
+   * Content payload for moderation
+   */
   moderation_payload?: ModerationPayloadResponse;
 
   review_queue_item?: ReviewQueueItemResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -6269,6 +6548,9 @@ export interface ModerationMarkReviewedEvent {
 
   received_at?: Date;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -6278,6 +6560,8 @@ export interface ModerationPayload {
   image_ordered_keys?: Array<string>;
 
   images?: Array<string>;
+
+  other_media?: Array<string>;
 
   text_ordered_keys?: Array<string>;
 
@@ -6307,6 +6591,11 @@ export interface ModerationPayloadResponse {
    * Image URLs to moderate
    */
   images?: Array<string>;
+
+  /**
+   * Media URLs from attachments outside the typed image/video/audio lists (custom attachment types such as GIF pickers)
+   */
+  other_media?: Array<string>;
 
   /**
    * Caller-supplied keys for texts (e.g. "title", "description"), index-aligned with texts[]
@@ -6448,6 +6737,9 @@ export interface NotificationAddedToChannelEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6494,6 +6786,9 @@ export interface NotificationChannelDeletedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6576,6 +6871,9 @@ export interface NotificationChannelTruncatedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6635,6 +6933,9 @@ export interface NotificationChannelTruncatedEvent {
 
   grouped_unread_channels?: Record<string, number>;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -6644,6 +6945,9 @@ export interface NotificationInviteAcceptedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6698,6 +7002,9 @@ export interface NotificationInviteRejectedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6752,6 +7059,9 @@ export interface NotificationInvitedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -6877,6 +7187,9 @@ export interface NotificationMarkReadEvent {
    */
   unread_threads?: number;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   channel_custom?: CustomChannelData;
@@ -6980,6 +7293,9 @@ export interface NotificationMarkUnreadEvent {
    */
   unread_threads?: number;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   channel_custom?: CustomChannelData;
@@ -7020,10 +7336,16 @@ export interface NotificationNewMessageEvent {
    */
   watcher_count: number;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -7081,6 +7403,9 @@ export interface NotificationRemovedFromChannelEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -7147,10 +7472,16 @@ export interface NotificationThreadMessageNewEvent {
    */
   watcher_count: number;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -7312,8 +7643,14 @@ export interface PendingMessageEvent {
 
   received_at?: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   /**
@@ -7321,16 +7658,28 @@ export interface PendingMessageEvent {
    */
   metadata?: Record<string, string>;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
 export interface PendingMessageResponse {
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   metadata?: Record<string, string>;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -7475,6 +7824,9 @@ export interface PollResponseData {
 
   max_votes_allowed?: number;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 }
 
@@ -7632,6 +7984,9 @@ export interface PollVoteResponseData {
 
   user_id?: string;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -9879,6 +10234,9 @@ export interface ReactionDeletedEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -9929,6 +10287,9 @@ export interface ReactionDeletedEvent {
 
   channel_custom?: CustomChannelData;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   reaction?: ReactionResponse;
@@ -9974,6 +10335,9 @@ export interface ReactionGroupUserResponse {
    */
   user_id: string;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -9983,6 +10347,9 @@ export interface ReactionNewEvent {
    */
   created_at: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
@@ -10033,6 +10400,9 @@ export interface ReactionNewEvent {
 
   channel_custom?: CustomChannelData;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   reaction?: ReactionResponse;
@@ -10100,6 +10470,9 @@ export interface ReactionResponse {
    */
   custom: CustomReactionData;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 }
 
@@ -10111,10 +10484,16 @@ export interface ReactionUpdatedEvent {
 
   message_id: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel: ChannelResponse;
 
   custom: CustomEventData;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   /**
@@ -10170,6 +10549,9 @@ export interface ReadStateResponse {
 
   unread_messages: number;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   last_delivered_at?: Date;
@@ -10310,10 +10692,19 @@ export interface ReminderResponseData {
 
   remind_at?: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -10500,6 +10891,9 @@ export interface ReviewQueueItemResponse {
 
   appeal?: AppealItemResponse;
 
+  /**
+   * User response object
+   */
   assigned_to?: UserResponse;
 
   call?: ModerationCallResponse;
@@ -10518,6 +10912,9 @@ export interface ReviewQueueItemResponse {
 
   message?: ChatMessageResponse;
 
+  /**
+   * Content payload for moderation
+   */
   moderation_payload?: ModerationPayloadResponse;
 
   reaction?: Reaction;
@@ -11214,6 +11611,9 @@ export interface SearchResultMessage {
 
   reaction_scores: Record<string, number>;
 
+  /**
+   * User response object
+   */
   user: UserResponse;
 
   command?: string;
@@ -11246,6 +11646,9 @@ export interface SearchResultMessage {
 
   thread_participants?: Array<UserResponse>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
   draft?: DraftResponse;
@@ -11258,10 +11661,16 @@ export interface SearchResultMessage {
 
   moderation?: ModerationV2Response;
 
+  /**
+   * User response object
+   */
   pinned_by?: UserResponse;
 
   poll?: PollResponseData;
 
+  /**
+   * Represents any chat message
+   */
   quoted_message?: MessageResponse;
 
   reaction_groups?: Record<string, ReactionGroupResponse>;
@@ -11316,6 +11725,9 @@ export interface SendEventRequest {
 }
 
 export interface SendMessageRequest {
+  /**
+   * Message data for creating or updating a message
+   */
   message: MessageRequest;
 
   /**
@@ -11341,8 +11753,14 @@ export interface SendMessageResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
+  /**
+   * Slim channel object: identity plus creator
+   */
   channel_context?: ChannelContextResponse;
 
   /**
@@ -11357,6 +11775,9 @@ export interface SendMessageResponse {
 }
 
 export interface SendReactionRequest {
+  /**
+   * Represents user reaction to a message
+   */
   reaction: ReactionRequest;
 
   /**
@@ -11376,6 +11797,9 @@ export interface SendReactionResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   reaction: ReactionResponse;
@@ -11446,8 +11870,14 @@ export interface SharedLocationResponse {
    */
   end_at?: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -11470,8 +11900,14 @@ export interface SharedLocationResponseData {
 
   end_at?: Date;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -11546,40 +11982,88 @@ export interface SubmitActionRequest {
    */
   item_id?: string;
 
+  /**
+   * Configuration for ban moderation action
+   */
   ban?: BanActionRequestPayload;
 
+  /**
+   * Configuration for block action
+   */
   block?: BlockActionRequestPayload;
 
   bypass?: BypassActionRequest;
 
+  /**
+   * Configuration for custom moderation action
+   */
   custom?: CustomActionRequestPayload;
 
+  /**
+   * Configuration for activity deletion action
+   */
   delete_activity?: DeleteActivityRequestPayload;
 
+  /**
+   * Configuration for comment deletion action
+   */
   delete_comment?: DeleteCommentRequestPayload;
 
+  /**
+   * Configuration for message deletion action
+   */
   delete_message?: DeleteMessageRequestPayload;
 
+  /**
+   * Configuration for reaction deletion action
+   */
   delete_reaction?: DeleteReactionRequestPayload;
 
+  /**
+   * Configuration for user deletion action
+   */
   delete_user?: DeleteUserRequestPayload;
 
+  /**
+   * Configuration for deleting all of a user's chat messages without banning them or deleting their account
+   */
   delete_user_messages?: DeleteUserMessagesRequestPayload;
 
+  /**
+   * Configuration for escalation action
+   */
   escalate?: EscalatePayload;
 
   flag?: FlagRequest;
 
+  /**
+   * Configuration for mark reviewed action
+   */
   mark_reviewed?: MarkReviewedRequestPayload;
 
+  /**
+   * Configuration for rejecting an appeal
+   */
   reject_appeal?: RejectAppealRequestPayload;
 
+  /**
+   * Configuration for restore action
+   */
   restore?: RestoreActionRequestPayload;
 
+  /**
+   * Configuration for shadow block action
+   */
   shadow_block?: ShadowBlockActionRequestPayload;
 
+  /**
+   * Configuration for unban moderation action
+   */
   unban?: UnbanActionRequestPayload;
 
+  /**
+   * Configuration for unblock action
+   */
   unblock?: UnblockActionRequestPayload;
 }
 
@@ -11692,6 +12176,9 @@ export interface ThreadParticipant {
    */
   user_id?: string;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 
@@ -11761,10 +12248,19 @@ export interface ThreadResponse {
    */
   thread_participants?: Array<ThreadParticipant>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 
+  /**
+   * Represents any chat message
+   */
   parent_message?: MessageResponse;
 }
 
@@ -11838,12 +12334,21 @@ export interface ThreadStateResponse {
    */
   thread_participants?: Array<ThreadParticipant>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * User response object
+   */
   created_by?: UserResponse;
 
   draft?: DraftResponse;
 
+  /**
+   * Represents any chat message
+   */
   parent_message?: MessageResponse;
 }
 
@@ -11961,6 +12466,9 @@ export interface TruncateChannelRequest {
    */
   member_ids?: Array<string>;
 
+  /**
+   * Message data for creating or updating a message
+   */
   message?: MessageRequest;
 }
 
@@ -11970,8 +12478,14 @@ export interface TruncateChannelResponse {
    */
   duration: string;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -12172,6 +12686,9 @@ export interface UpdateBlockListResponse {
    */
   duration: string;
 
+  /**
+   * Block list contains restricted words
+   */
   blocklist?: BlockListResponse;
 }
 
@@ -12192,6 +12709,9 @@ export interface UpdateChannelPartialResponse {
    */
   members: Array<ChannelMemberResponse>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 }
 
@@ -12268,6 +12788,9 @@ export interface UpdateChannelRequest {
 
   data?: ChannelInputRequest;
 
+  /**
+   * Message data for creating or updating a message
+   */
   message?: MessageRequest;
 }
 
@@ -12282,8 +12805,14 @@ export interface UpdateChannelResponse {
    */
   members: Array<ChannelMemberResponse>;
 
+  /**
+   * Represents channel in chat
+   */
   channel?: ChannelResponse;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 }
 
@@ -12349,6 +12878,9 @@ export interface UpdateMessagePartialResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message?: MessageResponse;
 
   /**
@@ -12358,6 +12890,9 @@ export interface UpdateMessagePartialResponse {
 }
 
 export interface UpdateMessageRequest {
+  /**
+   * Message data for creating or updating a message
+   */
   message: MessageRequest;
 
   /**
@@ -12374,6 +12909,9 @@ export interface UpdateMessageResponse {
    */
   duration: string;
 
+  /**
+   * Represents any chat message
+   */
   message: MessageResponse;
 
   pending_message_metadata?: Record<string, string>;
@@ -12686,6 +13224,9 @@ export interface UpsertActionConfigRequest {
 export interface UpsertActionConfigResponse {
   duration: string;
 
+  /**
+   * Configuration for a moderation action
+   */
   action_config?: ModerationActionConfigResponse;
 }
 
@@ -13145,8 +13686,14 @@ export interface UserMuteResponse {
 
   expires?: Date;
 
+  /**
+   * User response object
+   */
   target?: UserResponse;
 
+  /**
+   * User response object
+   */
   user?: UserResponse;
 }
 


### PR DESCRIPTION
## CLA

https://linear.app/stream/issue/REACT-1067/wrap-up-filter-pr-in-generator

Regenerate API layer to integrate this fix: https://github.com/GetStream/chat/pull/15704 and https://github.com/GetStream/chat/pull/15657

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

## Changelog

-
