### PR TITLE
fix: signal api

### DIFF
--- a/docs/fileUpload.md
+++ b/docs/fileUpload.md
@@ -95,7 +95,7 @@ const response = await channel.sendFile(
 
 ## `axiosRequestConfig` (channel and client uploads)
 
-Channel uploads use Axios under the hood. Both **`channel.sendFile`** and **`channel.sendImage`** accept an optional **fifth argument** `axiosRequestConfig` (`AxiosRequestConfig` from axios). The same optional argument exists on **`client.uploadFile`** and **`client.uploadImage`**.
+Channel uploads use Axios under the hood. Both **`channel.sendFile`** and **`channel.sendImage`** accept an optional **fifth argument** `axiosRequestConfig` (`AxiosRequestConfig` from axios). The same optional argument exists on **`client.uploadFile_`** and **`client.uploadImage_`** — the trailing-underscore names are the positional-argument uploads; the underscore-less `client.uploadFile` / `client.uploadImage` are the generated request-object methods (`{ file? }`) and take `requestOptions`, not an axios config.
 
 The client merges your config **after** its upload defaults (`timeout: 0`, large `maxContentLength` / `maxBodyLength`). Any property you set can override or extend those defaults. Multipart headers — including the boundary — are set by axios from the `FormData` body; the SDK no longer computes them itself (v9 took them from `form-data`'s `getHeaders()`).
 
@@ -105,11 +105,13 @@ Typical uses:
 - **`signal`** — pass `AbortSignal` from an `AbortController` to cancel an in-flight upload
 - Other Axios per-request options your runtime supports
 
+> **Uploads are the exception.** They are the only methods that still take a full axios config; every other request-issuing method on `StreamChat` and `Channel` takes a narrow `requestOptions` (`StreamRequestOptions`, currently `{ signal?: AbortSignal }`) as its **last** argument instead — e.g. `client.search(request, { signal })`. Either way you cancel by passing a `signal`: v9's `client.createAbortControllerForNextRequest()` is removed, because it armed one controller that whichever request went out next would consume. See `v9-to-v10-migration-guide-methods.md` for the before/after.
+
 ### Upload progress (`onUploadProgress`)
 
 ```js
-// client.uploadFile with progress
-const response = await client.uploadFile(file, file.name, file.type, undefined, {
+// client.uploadFile_ with progress
+const response = await client.uploadFile_(file, file.name, file.type, undefined, {
   onUploadProgress: (progressEvent) => {
     const percent = progressEvent.total
       ? Math.round((progressEvent.loaded * 100) / progressEvent.total)

--- a/scripts/generate-client.sh
+++ b/scripts/generate-client.sh
@@ -6,7 +6,7 @@ CHAT_DIR="../chat"
 
 rm -rf $OUTPUT_DIR
 
-( cd $CHAT_DIR ; make openapi ; make -C projects/chat-manager build; build/chat-manager openapi generate-client --language ts --spec releases/v2/chat-clientside-api.yaml --output $OUTPUT_DIR --opt typed_filters=true)
+( cd $CHAT_DIR ; make openapi ; make -C projects/chat-manager build; build/chat-manager openapi generate-client --language ts --spec releases/v2/chat-clientside-api.yaml --output $OUTPUT_DIR --opt typed_filters=true --opt with_request_options=true)
 
 # apply-custom-data-types matches `export interface` / `}` anchored to column 0,
 # but the generator emits them indented — format first so it can track which

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -6,6 +6,7 @@ import type {
   RateLimit,
   RequestMetadata,
   SendFileAPIResponse,
+  StreamRequestOptions,
   UserResponse,
 } from './types';
 import { StreamAPIError } from './types';
@@ -19,8 +20,6 @@ const logger = chatLoggerSystem.getLogger('api-client');
 export class ApiClient {
   client!: StreamChat;
 
-  private nextRequestAbortController: AbortController | null = null;
-
   constructor(client?: StreamChat) {
     if (client) this.client = client;
   }
@@ -31,10 +30,6 @@ export class ApiClient {
     return this.client.tokenManager.getToken();
   }
 
-  createAbortControllerForNextRequest() {
-    return (this.nextRequestAbortController = new AbortController());
-  }
-
   sendRequest<T>(
     method: Method,
     url: string,
@@ -42,12 +37,14 @@ export class ApiClient {
     queryParams?: Record<string, unknown>,
     body?: unknown,
     requestContentType?: string,
+    options?: StreamRequestOptions,
   ): Promise<{ body: T; metadata: RequestMetadata }> {
     const resolvedUrl = this.resolveUrl(url, pathParams);
 
     return this._doRequest<T>(method, resolvedUrl, body, {
       params: queryParams,
       headers: { 'Content-Type': requestContentType },
+      ...toAxiosRequestConfig(options),
     });
   }
 
@@ -114,19 +111,10 @@ export class ApiClient {
     return resolved;
   }
 
-  private getNextAbortSignal(): AbortSignal | undefined {
-    if (!this.nextRequestAbortController) return;
-
-    const signal = this.nextRequestAbortController.signal;
-    this.nextRequestAbortController = null;
-    return signal;
-  }
-
   populateRequestConfigWithDefaults(
     additonalConfig: AxiosRequestConfig,
   ): AxiosRequestConfig {
     const token = this._getToken();
-    const signal = this.getNextAbortSignal();
 
     return {
       ...additonalConfig,
@@ -151,7 +139,6 @@ export class ApiClient {
         connection_id:
           additonalConfig.params?.connection_id || this.client._getConnectionID(),
       },
-      signal,
     } satisfies AxiosRequestConfig;
   }
 
@@ -261,6 +248,14 @@ export class ApiClient {
     }
   }
 }
+
+/**
+ * Maps the SDK-level per-request options onto the axios request config they
+ * translate to. Extend this when a new option is added to `StreamRequestOptions`.
+ */
+const toAxiosRequestConfig = ({
+  signal,
+}: StreamRequestOptions = {}): AxiosRequestConfig => ({ signal });
 
 const errorIsApiError = (error: unknown): error is AxiosError<APIError> => {
   if (!(error instanceof AxiosError)) return false;

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -250,12 +250,24 @@ export class ApiClient {
 }
 
 /**
+ * An `AbortSignal` that went through JSON persistence - as it does when an offline-db task
+ * payload is stored and replayed after a restart - revives as a plain `{}`: `aborted` is
+ * `undefined` and `addEventListener` is gone. Axios reaches straight for
+ * `signal.addEventListener`, so handing it such an object throws a `TypeError` and takes the
+ * replay down with it. Only forward a signal that can still be listened to.
+ */
+const isUsableAbortSignal = (signal: unknown): signal is AbortSignal =>
+  typeof (signal as AbortSignal | undefined)?.addEventListener === 'function';
+
+/**
  * Maps the SDK-level per-request options onto the axios request config they
  * translate to. Extend this when a new option is added to `StreamRequestOptions`.
  */
 const toAxiosRequestConfig = ({
   signal,
-}: StreamRequestOptions = {}): AxiosRequestConfig => ({ signal });
+}: StreamRequestOptions = {}): AxiosRequestConfig => ({
+  signal: isUsableAbortSignal(signal) ? signal : undefined,
+});
 
 const errorIsApiError = (error: unknown): error is AxiosError<APIError> => {
   if (!(error instanceof AxiosError)) return false;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -34,11 +34,9 @@ import type {
   EventPayload,
   EventType,
   GetRepliesAPIResponse,
-  GetRepliesRequest,
   LocalMessage,
   MarkReadRequest,
   MarkReadResponse,
-  MarkUnreadRequest,
   MessagePaginationOptions,
   MessageRequest,
   MessageResponse,
@@ -48,10 +46,10 @@ import type {
   QueryMembersPayload,
   ReactionAPIResponse,
   ReactionRequest,
-  SearchPayload,
   SendMessageOptions,
   SendReactionRequest,
   SharedLocation,
+  StreamRequestOptions,
   StreamResponse,
   UnBanUserOptions,
   UpdateChannelPartialRequest,
@@ -64,14 +62,8 @@ import { StateStore } from './store';
 import type {
   ChannelMemberRequest as Gen_ChannelMemberRequest,
   ChannelPushPreferencesResponse as Gen_ChannelPushPreferencesResponse,
-  ChannelStopWatchingRequest as Gen_ChannelStopWatchingRequest,
-  CreateDraftRequest as Gen_CreateDraftRequest,
-  HideChannelRequest as Gen_HideChannelRequest,
   MuteChannelRequest as Gen_MuteChannelRequest,
-  SendMessageRequest as Gen_SendMessageRequest,
-  ShowChannelRequest as Gen_ShowChannelRequest,
   UnmuteChannelRequest as Gen_UnmuteChannelRequest,
-  UpdateChannelRequest as Gen_UpdateChannelRequest,
   WSEvent,
 } from './gen/models';
 import type { ChatApi } from './gen/chat/ChatApi';
@@ -332,18 +324,20 @@ export class Channel extends ChannelApi {
     return client.configs[this.cid];
   }
 
-  _sendMessage(request: Gen_SendMessageRequest) {
-    return super.sendMessage(request);
+  _sendMessage(...args: Parameters<ChannelApi['sendMessage']>) {
+    return super.sendMessage(...args);
   }
 
   /**
    * Sends a message to this channel.
    *
-   * @param request - The send message request payload, including the message body and optional flags
-   *   such as `skip_enrich_url`, `skip_push`, and `keep_channel_hidden`.
+   * @param ...args - `[request, requestOptions]`. `request` holds the message body and optional
+   *   flags such as `skip_enrich_url`, `skip_push`, and `keep_channel_hidden`; `requestOptions`
+   *   carries per-request options such as an abort `signal` and is never serialized into the request.
    * @returns The server response.
    */
-  override async sendMessage(request: Gen_SendMessageRequest) {
+  override async sendMessage(...args: Parameters<ChannelApi['sendMessage']>) {
+    const [request] = args;
     try {
       const offlineDb = this.getClient().offlineDb;
       const messageId = request.message?.id;
@@ -353,7 +347,7 @@ export class Channel extends ChannelApi {
             channelId: this.id as string,
             channelType: this.type,
             messageId,
-            payload: [request],
+            payload: args,
             type: 'send-message',
           },
         });
@@ -363,7 +357,7 @@ export class Channel extends ChannelApi {
         .withExtraTags('sendMessage', this.cid)
         .error('Sending the message failed.', { error });
     }
-    return await this._sendMessage(request);
+    return await this._sendMessage(...args);
   }
 
   /**
@@ -548,34 +542,40 @@ export class Channel extends ChannelApi {
     );
   }
 
-  deleteFile(url: string) {
-    return this.deleteChannelFile({ url });
+  deleteFile(url: string, requestOptions?: StreamRequestOptions) {
+    return this.deleteChannelFile({ url }, requestOptions);
   }
 
-  deleteImage(url: string) {
-    return this.deleteChannelImage({ url });
+  deleteImage(url: string, requestOptions?: StreamRequestOptions) {
+    return this.deleteChannelImage({ url }, requestOptions);
   }
 
   /**
    * Sends an event on this channel.
    *
-   * @param event - For example `{ type: 'message.read' }`.
+   * @param request - For example `{ event: { type: 'message.read' } }`.
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  override async sendEvent(request: { event: Event }) {
+  override async sendEvent(
+    request: { event: Event },
+    requestOptions?: StreamRequestOptions,
+  ) {
     this._checkInitialized();
-    return await super.sendEvent(request);
+    return await super.sendEvent(request, requestOptions);
   }
 
   /**
    * Queries messages.
    *
-   * @param request - The search request payload (optional). The inner `payload` accepts
-   *   MongoDB-style filters and additional options such as `user_id`.
+   * @param ...args - `[request, requestOptions]`. The optional `request.payload` accepts
+   *   MongoDB-style filters and additional options such as `user_id`. `requestOptions` carries
+   *   per-request options such as an abort `signal` and is never serialized into the request.
    * @returns The search messages response.
    */
-  async search(request?: { payload?: SearchPayload }) {
-    return await this.getClient().search(request);
+  async search(...args: Parameters<ChatApi['search']>) {
+    return await this.getClient().search(...args);
   }
 
   /**
@@ -584,9 +584,14 @@ export class Channel extends ChannelApi {
    * @param request - The query members request payload (optional). The inner `payload` accepts
    *   MongoDB-style filters, sort directions (e.g. `[{ field: 'created_at', direction: -1 }]`),
    *   and pagination options (`limit`, `offset`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The query members response.
    */
-  async queryMembers(request?: { payload?: Partial<QueryMembersPayload> }) {
+  async queryMembers(
+    request?: { payload?: Partial<QueryMembersPayload> },
+    requestOptions?: StreamRequestOptions,
+  ) {
     const payload = {
       type: this.type,
       // TODO: these should be probably optional in the OAPI spec
@@ -603,12 +608,15 @@ export class Channel extends ChannelApi {
       }));
     }
     // Return a list of members
-    return await this.getClient().queryMembers({
-      payload: {
-        ...payload,
-        ...request?.payload,
+    return await this.getClient().queryMembers(
+      {
+        payload: {
+          ...payload,
+          ...request?.payload,
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   /**
@@ -616,13 +624,15 @@ export class Channel extends ChannelApi {
    * that sending the reaction is queued up if it fails due to bad internet conditions and executed
    * later.
    *
-   * @param request - The send-reaction request payload, including the target message ID, the
+   * @param ...args - `[request, requestOptions]`. `request` holds the target message ID, the
    *   reaction object (e.g. `{ type: 'love' }`), and optional flags such as `enforce_unique` and
-   *   `skip_push`.
+   *   `skip_push`; `requestOptions` carries per-request options such as an abort `signal`.
+   *   When the call is queued for offline replay, `requestOptions` is queued with it - see the
+   *   note on signal persistence in `AbstractOfflineDB.queueTask`.
    * @returns The server response.
    */
-  async sendReaction(request: Parameters<ChatApi['sendReaction']>[0]) {
-    const { id: messageId } = request;
+  async sendReaction(...args: Parameters<ChatApi['sendReaction']>) {
+    const [{ id: messageId }] = args;
 
     try {
       const offlineDb = this.getClient().offlineDb;
@@ -634,7 +644,7 @@ export class Channel extends ChannelApi {
             channelId: this.id as string,
             channelType: this.type,
             messageId,
-            payload: [request],
+            payload: args,
             type: 'send-reaction',
           },
         });
@@ -645,15 +655,16 @@ export class Channel extends ChannelApi {
         .error('Sending the reaction failed.', { error });
     }
 
-    return this._sendReaction(request);
+    return this._sendReaction(...args);
   }
 
-  _sendReaction(request: Parameters<ChatApi['sendReaction']>[0]) {
-    return this.getClient().sendReaction(request);
+  _sendReaction(...args: Parameters<ChatApi['sendReaction']>) {
+    return this.getClient().sendReaction(...args);
   }
 
-  async deleteReaction(request: Parameters<ChatApi['deleteReaction']>[0]) {
+  async deleteReaction(...args: Parameters<ChatApi['deleteReaction']>) {
     this._checkInitialized();
+    const [request] = args;
 
     try {
       const offlineDb = this.getClient().offlineDb;
@@ -665,7 +676,7 @@ export class Channel extends ChannelApi {
             channelId: this.id as string,
             channelType: this.type,
             messageId: request.id,
-            payload: [request],
+            payload: args,
             type: 'delete-reaction',
           },
         });
@@ -676,29 +687,33 @@ export class Channel extends ChannelApi {
         .error('Deleting the reaction failed.', { error });
     }
 
-    return await this._deleteReaction(request);
+    return await this._deleteReaction(...args);
   }
 
   /**
    * Deletes a reaction by user and type.
    *
-   * @param request - The delete reaction request payload identifying the target message and reaction type.
+   * @param ...args - `[request, requestOptions]`. `request` identifies the target message and
+   *   reaction type; `requestOptions` carries per-request options such as an abort `signal` and is
+   *   never serialized into the request.
    * @returns The server response.
    */
-  async _deleteReaction(request: Parameters<ChatApi['deleteReaction']>[0]) {
-    return await this.getClient().deleteReaction(request);
+  async _deleteReaction(...args: Parameters<ChatApi['deleteReaction']>) {
+    return await this.getClient().deleteReaction(...args);
   }
 
   /**
    * Edit the channel using the inherited `update()` from `ChannelApi`. Caches the
    * server-returned channel onto `this.data`.
    *
-   * @param request - Channel update payload, e.g. `{ data: { name: 'foo' }, message }` (optional).
+   * @param ...args - `[request, requestOptions]`. `request` is the channel update payload, e.g.
+   *   `{ data: { name: 'foo' }, message }`; `requestOptions` carries per-request options such as an
+   *   abort `signal` and is never serialized into the request.
    * @returns The server response.
    */
-  override async update(request?: Gen_UpdateChannelRequest) {
+  override async update(...args: Parameters<ChannelApi['update']>) {
     const previousData = this.data;
-    const data = await super.update(request);
+    const data = await super.update(...args);
     this.data = data.channel;
     this._syncStateFromChannelData(this.data, previousData);
     return data;
@@ -708,10 +723,15 @@ export class Channel extends ChannelApi {
    * Partial update of channel properties.
    *
    * @param update - The partial update request.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async updatePartial(update: UpdateChannelPartialRequest) {
-    const data = await this.updateChannelPartial(update);
+  async updatePartial(
+    update: UpdateChannelPartialRequest,
+    requestOptions?: StreamRequestOptions,
+  ) {
+    const data = await this.updateChannelPartial(update, requestOptions);
 
     if (!this.getClient()._cacheEnabled) return data;
 
@@ -742,19 +762,23 @@ export class Channel extends ChannelApi {
    * Enables slow mode.
    *
    * @param coolDownInterval - The cooldown interval in seconds.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async enableSlowMode(coolDownInterval: number) {
-    return await this.update({ cooldown: coolDownInterval });
+  async enableSlowMode(coolDownInterval: number, requestOptions?: StreamRequestOptions) {
+    return await this.update({ cooldown: coolDownInterval }, requestOptions);
   }
 
   /**
    * Disables slow mode.
    *
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async disableSlowMode() {
-    return await this.update({ cooldown: 0 });
+  async disableSlowMode(requestOptions?: StreamRequestOptions) {
+    return await this.update({ cooldown: 0 }, requestOptions);
   }
 
   public async sendSharedLocation(location: SharedLocation & { message_id?: string }) {
@@ -775,11 +799,17 @@ export class Channel extends ChannelApi {
     return result;
   }
 
-  public async stopLiveLocationSharing(payload: UpdateLiveLocationRequest) {
-    const location = await this.getClient().updateLiveLocation({
-      ...payload,
-      end_at: new Date(),
-    });
+  public async stopLiveLocationSharing(
+    payload: UpdateLiveLocationRequest,
+    requestOptions?: StreamRequestOptions,
+  ) {
+    const location = await this.getClient().updateLiveLocation(
+      {
+        ...payload,
+        end_at: new Date(),
+      },
+      requestOptions,
+    );
     this.getClient().dispatchEvent({
       live_location: location,
       type: 'live_location_sharing.stopped',
@@ -790,20 +820,30 @@ export class Channel extends ChannelApi {
    * Accepts an invitation to the channel.
    *
    * @param options - The object to update the custom properties of this channel with (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async acceptInvite(options: ChannelUpdateOptions = {}) {
-    return await this.update({ accept_invite: true, ...options });
+  async acceptInvite(
+    options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return await this.update({ accept_invite: true, ...options }, requestOptions);
   }
 
   /**
    * Rejects an invitation to the channel.
    *
    * @param options - The object to update the custom properties of this channel with (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async rejectInvite(options: ChannelUpdateOptions = {}) {
-    return await this.update({ reject_invite: true, ...options });
+  async rejectInvite(
+    options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return await this.update({ reject_invite: true, ...options }, requestOptions);
   }
 
   /**
@@ -812,20 +852,26 @@ export class Channel extends ChannelApi {
    * @param members - An array of members to add to the channel.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async addMembers(
     members: string[] | Array<Gen_ChannelMemberRequest>,
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({
-      add_members: members.map((member) =>
-        typeof member === 'string' ? { user_id: member } : member,
-      ),
-      message,
-      ...options,
-    });
+    return await this.update(
+      {
+        add_members: members.map((member) =>
+          typeof member === 'string' ? { user_id: member } : member,
+        ),
+        message,
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -834,14 +880,20 @@ export class Channel extends ChannelApi {
    * @param tags - An array of tags to add to the channel.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async addFilterTags(
     tags: string[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ add_filter_tags: tags, message, ...options });
+    return await this.update(
+      { add_filter_tags: tags, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -850,14 +902,20 @@ export class Channel extends ChannelApi {
    * @param tags - An array of tags to remove from the channel.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async removeFilterTags(
     tags: string[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ remove_filter_tags: tags, message, ...options });
+    return await this.update(
+      { remove_filter_tags: tags, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -866,14 +924,20 @@ export class Channel extends ChannelApi {
    * @param members - An array of member identifiers.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async addModerators(
     members: string[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ add_moderators: members, message, ...options });
+    return await this.update(
+      { add_moderators: members, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -882,14 +946,20 @@ export class Channel extends ChannelApi {
    * @param roles - List of role assignments.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async assignRoles(
     roles: { channel_role: RoleName; user_id: string }[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ assign_roles: roles, message, ...options });
+    return await this.update(
+      { assign_roles: roles, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -898,20 +968,26 @@ export class Channel extends ChannelApi {
    * @param members - An array of members to invite to the channel.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async inviteMembers(
     members: string[] | Required<Omit<Gen_ChannelMemberRequest, 'channel_role'>>[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({
-      invites: members.map((member) =>
-        typeof member === 'string' ? { user_id: member } : member,
-      ),
-      message,
-      ...options,
-    });
+    return await this.update(
+      {
+        invites: members.map((member) =>
+          typeof member === 'string' ? { user_id: member } : member,
+        ),
+        message,
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -920,14 +996,20 @@ export class Channel extends ChannelApi {
    * @param members - An array of member identifiers.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async removeMembers(
     members: string[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ remove_members: members, message, ...options });
+    return await this.update(
+      { remove_members: members, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -936,14 +1018,20 @@ export class Channel extends ChannelApi {
    * @param members - An array of member identifiers.
    * @param message - Message object for channel members notification (optional).
    * @param options - Configuration to control the behavior while updating (optional, defaults to `{}`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
   async demoteModerators(
     members: string[],
     message?: MessageRequest,
     options: ChannelUpdateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    return await this.update({ demote_moderators: members, message, ...options });
+    return await this.update(
+      { demote_moderators: members, message, ...options },
+      requestOptions,
+    );
   }
 
   /**
@@ -959,13 +1047,18 @@ export class Channel extends ChannelApi {
    *
    * @param options - Mute options (optional, defaults to `{}`).
    * @param options.expiration - Expiration in minutes (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async mute(options?: Gen_MuteChannelRequest) {
-    return await this.getClient().muteChannel({
-      channel_cids: [this.cid],
-      ...options,
-    });
+  async mute(options?: Gen_MuteChannelRequest, requestOptions?: StreamRequestOptions) {
+    return await this.getClient().muteChannel(
+      {
+        channel_cids: [this.cid],
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -977,13 +1070,21 @@ export class Channel extends ChannelApi {
    *
    * @param options - Unmute options (optional, defaults to `{}`).
    * @param options.user_id - User ID (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async unmute(options?: Gen_UnmuteChannelRequest) {
-    return await this.getClient().unmuteChannel({
-      channel_cids: [this.cid],
-      ...options,
-    });
+  async unmute(
+    options?: Gen_UnmuteChannelRequest,
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return await this.getClient().unmuteChannel(
+      {
+        channel_cids: [this.cid],
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -992,10 +1093,12 @@ export class Channel extends ChannelApi {
    * @example
    * await channel.archive();
    *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async archive() {
-    return await this.updateMemberPartial({ set: { archived: true } });
+  async archive(requestOptions?: StreamRequestOptions) {
+    return await this.updateMemberPartial({ set: { archived: true } }, requestOptions);
   }
 
   /**
@@ -1004,10 +1107,12 @@ export class Channel extends ChannelApi {
    * @example
    * await channel.unarchive();
    *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async unarchive() {
-    return await this.updateMemberPartial({ set: { archived: false } });
+  async unarchive(requestOptions?: StreamRequestOptions) {
+    return await this.updateMemberPartial({ set: { archived: false } }, requestOptions);
   }
 
   /**
@@ -1016,10 +1121,12 @@ export class Channel extends ChannelApi {
    * @example
    * await channel.pin();
    *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async pin() {
-    return await this.updateMemberPartial({ set: { pinned: true } });
+  async pin(requestOptions?: StreamRequestOptions) {
+    return await this.updateMemberPartial({ set: { pinned: true } }, requestOptions);
   }
 
   /**
@@ -1028,10 +1135,12 @@ export class Channel extends ChannelApi {
    * @example
    * await channel.unpin();
    *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The server response.
    */
-  async unpin() {
-    return await this.updateMemberPartial({ set: { pinned: false } });
+  async unpin(requestOptions?: StreamRequestOptions) {
+    return await this.updateMemberPartial({ set: { pinned: false } }, requestOptions);
   }
 
   /**
@@ -1044,15 +1153,22 @@ export class Channel extends ChannelApi {
     return this.getClient()._muteStatus(this.cid);
   }
 
-  sendAction(messageId: string, formData: Record<string, string>) {
+  sendAction(
+    messageId: string,
+    formData: Record<string, string>,
+    requestOptions?: StreamRequestOptions,
+  ) {
     this._checkInitialized();
     if (!messageId) {
       throw Error(`Message ID is missing`);
     }
-    return this.getClient().runMessageAction({
-      id: messageId,
-      form_data: formData,
-    });
+    return this.getClient().runMessageAction(
+      {
+        id: messageId,
+        form_data: formData,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -1063,8 +1179,14 @@ export class Channel extends ChannelApi {
    *
    * @param parentId - Set this field to `message.id` to indicate that the typing event is happening in a thread (optional).
    * @param options - Optional override carrying a `user_id` (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    */
-  async keystroke(parentId?: string, options?: { user_id: string }) {
+  async keystroke(
+    parentId?: string,
+    options?: { user_id: string },
+    requestOptions?: StreamRequestOptions,
+  ) {
     if (!this._isTypingIndicatorsEnabled()) {
       return;
     }
@@ -1075,15 +1197,18 @@ export class Channel extends ChannelApi {
     // send a typing.start every 2 seconds
     if (diff === null || diff > 2000) {
       this.lastTypingEvent = new Date();
-      await this.sendEvent({
-        event: {
-          type: 'typing.start',
-          parent_id: parentId,
-          ...(options || {}),
-          created_at: new Date(),
-          custom: {},
+      await this.sendEvent(
+        {
+          event: {
+            type: 'typing.start',
+            parent_id: parentId,
+            ...(options || {}),
+            created_at: new Date(),
+            custom: {},
+          },
         },
-      });
+        requestOptions,
+      );
     }
   }
 
@@ -1095,50 +1220,68 @@ export class Channel extends ChannelApi {
    * @param state - The new state of the AI process, e.g. thinking, generating.
    * @param options - Parameters such as `ai_message` to include additional details in the event (optional, defaults to `{}`).
    * @param options.ai_message - Additional message detail to include in the event (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    */
   async updateAIState(
     messageId: string,
     state: AIState,
     options: { ai_message?: string } = {},
+    requestOptions?: StreamRequestOptions,
   ) {
-    await this.sendEvent({
-      event: {
-        ...options,
-        type: 'ai_indicator.update',
-        message_id: messageId,
-        ai_state: state,
-        created_at: new Date(),
-        custom: {},
+    await this.sendEvent(
+      {
+        event: {
+          ...options,
+          type: 'ai_indicator.update',
+          message_id: messageId,
+          ai_state: state,
+          created_at: new Date(),
+          custom: {},
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   /**
    * Sends an event to notify watchers to clear the typing/thinking UI when the AI response starts streaming.
    * Typically used by the server connected to the AI service to inform clients that the AI response has started.
+   *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    */
-  async clearAIIndicator() {
-    await this.sendEvent({
-      event: {
-        type: 'ai_indicator.clear',
-        created_at: new Date(),
-        custom: {},
+  async clearAIIndicator(requestOptions?: StreamRequestOptions) {
+    await this.sendEvent(
+      {
+        event: {
+          type: 'ai_indicator.clear',
+          created_at: new Date(),
+          custom: {},
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   /**
    * Sends an event to stop AI response generation, leaving the message in its current state.
    * Triggered by the user to halt the AI response process.
+   *
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    */
-  async stopAIResponse() {
-    await this.sendEvent({
-      event: {
-        type: 'ai_indicator.stop',
-        created_at: new Date(),
-        custom: {},
+  async stopAIResponse(requestOptions?: StreamRequestOptions) {
+    await this.sendEvent(
+      {
+        event: {
+          type: 'ai_indicator.stop',
+          created_at: new Date(),
+          custom: {},
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   /**
@@ -1148,22 +1291,31 @@ export class Channel extends ChannelApi {
    *
    * @param parentId - Set this field to `message.id` to indicate that the typing event is happening in a thread (optional).
    * @param options - Optional override carrying a `user_id` (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    */
-  async stopTyping(parentId?: string, options?: { user_id: string }) {
+  async stopTyping(
+    parentId?: string,
+    options?: { user_id: string },
+    requestOptions?: StreamRequestOptions,
+  ) {
     if (!this._isTypingIndicatorsEnabled()) {
       return;
     }
     this.lastTypingEvent = null;
     this.isTyping = false;
-    await this.sendEvent({
-      event: {
-        type: 'typing.stop',
-        parent_id: parentId,
-        ...(options || {}),
-        created_at: new Date(),
-        custom: {},
+    await this.sendEvent(
+      {
+        event: {
+          type: 'typing.stop',
+          parent_id: parentId,
+          ...(options || {}),
+          created_at: new Date(),
+          custom: {},
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   _isTypingIndicatorsEnabled(): boolean {
@@ -1190,33 +1342,37 @@ export class Channel extends ChannelApi {
    * Override of the inherited `markRead()` from `ChannelApi` that requires the
    * channel to be initialized and respects the `read_events` channel config.
    *
-   * @param data - Mark read options (optional, defaults to `{}`).
+   * @param ...args - `[data, requestOptions]`. `data` holds the mark-read options;
+   *   `requestOptions` carries per-request options such as an abort `signal` and is never
+   *   serialized into the request.
    * @returns The server response, or `null` if the request was skipped.
    */
-  override async markRead(data?: MarkReadRequest) {
+  override async markRead(...args: Parameters<ChannelApi['markRead']>) {
     this._checkInitialized();
 
     if (!this.getConfig()?.read_events) {
       throw new Error('Read events are disabled for this application');
     }
 
-    return await super.markRead(data);
+    return await super.markRead(...args);
   }
 
   /**
    * Marks the channel as unread from `messageId`. Only works when the `read_events` setting is enabled.
    *
-   * @param data - Mark unread options.
+   * @param ...args - `[data, requestOptions]`. `data` holds the mark-unread options;
+   *   `requestOptions` carries per-request options such as an abort `signal` and is never
+   *   serialized into the request.
    * @returns An API response, or `null` if the request was skipped.
    */
-  override async markUnread(data?: MarkUnreadRequest) {
+  override async markUnread(...args: Parameters<ChannelApi['markUnread']>) {
     this._checkInitialized();
 
     if (!this.getConfig()?.read_events) {
       throw new Error('Read events are disabled for this application');
     }
 
-    return await super.markUnread(data);
+    return await super.markUnread(...args);
   }
 
   /**
@@ -1344,11 +1500,13 @@ export class Channel extends ChannelApi {
   /**
    * Stops watching the channel.
    *
-   * @param request - The stop-watching request payload (optional).
+   * @param ...args - `[request, requestOptions]`. `request` is the stop-watching payload;
+   *   `requestOptions` carries per-request options such as an abort `signal` and is never
+   *   serialized into the request.
    * @returns The server response.
    */
-  override async stopWatching(request?: Gen_ChannelStopWatchingRequest) {
-    const response = await super.stopWatching(request);
+  override async stopWatching(...args: Parameters<ChannelApi['stopWatching']>) {
+    const response = await super.stopWatching(...args);
 
     logger.withExtraTags('stopWatching', this.cid).info('Stopped watching the channel.');
 
@@ -1360,12 +1518,13 @@ export class Channel extends ChannelApi {
    *
    * The recommended way of working with threads is to use the `Thread` class.
    *
-   * @param request - The get-replies request payload, including the parent message ID, pagination
-   *   params, and optional sort directions for `created_at`.
+   * @param ...args - `[request, requestOptions]`. `request` holds the parent message ID, pagination
+   *   params, and optional sort directions for `created_at`; `requestOptions` carries per-request
+   *   options such as an abort `signal` and is never serialized into the request.
    * @returns A response with a list of messages.
    */
-  async getReplies(request: GetRepliesRequest) {
-    const data = await this.getClient().getReplies(request);
+  async getReplies(...args: Parameters<ChatApi['getReplies']>) {
+    const data = await this.getClient().getReplies(...args);
 
     // Thread reply state is owned by the Thread object (Thread.messagePaginator); the returned
     // replies are consumed there. The channel message list is owned by channel.messagePaginator.
@@ -1398,22 +1557,25 @@ export class Channel extends ChannelApi {
   /**
    * List the reactions; supports pagination.
    *
-   * @param request - The request payload, including the target message ID and
-   *   pagination options (`limit`, `offset`).
+   * @param ...args - `[request, requestOptions]`. `request` holds the target message ID and
+   *   pagination options (`limit`, `offset`); `requestOptions` carries per-request options such as
+   *   an abort `signal` and is never serialized into the request.
    * @returns The server response.
    */
-  getReactions(request: Parameters<ChatApi['getReactions']>[0]) {
-    return this.getClient().getReactions(request);
+  getReactions(...args: Parameters<ChatApi['getReactions']>) {
+    return this.getClient().getReactions(...args);
   }
 
   /**
    * Retrieves a list of messages by ID.
    *
    * @param messageIds - The IDs of the messages to retrieve from this channel.
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns Server response.
    */
-  getMessagesById(messageIds: string[]) {
-    return this.getManyMessages({ ids: messageIds });
+  getMessagesById(messageIds: string[], requestOptions?: StreamRequestOptions) {
+    return this.getManyMessages({ ids: messageIds }, requestOptions);
   }
 
   /**
@@ -1520,11 +1682,14 @@ export class Channel extends ChannelApi {
    *   messages into state. Use `current` to load the initial channel state or to extend the
    *   currently displayed messages; use `latest` to load/extend the latest messages; `new` is
    *   used for loading a specific message and its surroundings (optional, defaults to `'current'`).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns A query response.
    */
   async query(
     options: ChannelGetOrCreateRequest = {},
     messageSetToAddToIfDoesNotExist: MessageSetType = 'current',
+    requestOptions?: StreamRequestOptions,
   ) {
     // Snapshot the loaded message ids BEFORE the network await, for a latest-window (re)seed only.
     // When this query re-seeds an already-loaded window (reconnect / re-hydrate), seedFirstPageSync
@@ -1567,11 +1732,14 @@ export class Channel extends ChannelApi {
     };
 
     const state = this.id
-      ? await this.getOrCreate(queryPayload)
-      : await this.getClient().getOrCreateDistinctChannel({
-          type: this.type,
-          ...queryPayload,
-        });
+      ? await this.getOrCreate(queryPayload, requestOptions)
+      : await this.getClient().getOrCreateDistinctChannel(
+          {
+            type: this.type,
+            ...queryPayload,
+          },
+          requestOptions,
+        );
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const channel = state.channel!;
@@ -1705,24 +1873,27 @@ export class Channel extends ChannelApi {
    * Hides the channel from `queryChannels` for the user until a message is added.
    * If `clear_history` is set to `true`, all messages will be removed for the user.
    *
-   * @param request - The hide channel request payload (optional). Pass `{ clear_history: true }`
-   *   to clear message history for the user.
+   * @param ...args - `[request, requestOptions]`. Pass `request: { clear_history: true }` to clear
+   *   message history for the user; `requestOptions` carries per-request options such as an abort
+   *   `signal` and is never serialized into the request.
    * @returns The server response.
    */
-  override async hide(request?: Gen_HideChannelRequest) {
+  override async hide(...args: Parameters<ChannelApi['hide']>) {
     this._checkInitialized();
-    return await super.hide(request);
+    return await super.hide(...args);
   }
 
   /**
    * Removes the hidden status for a channel. Ensures the channel is initialized first.
    *
-   * @param request - The show channel request payload (optional).
+   * @param ...args - `[request, requestOptions]`. `request` is the show-channel payload;
+   *   `requestOptions` carries per-request options such as an abort `signal` and is never
+   *   serialized into the request.
    * @returns The server response.
    */
-  override async show(request?: Gen_ShowChannelRequest) {
+  override async show(...args: Parameters<ChannelApi['show']>) {
     this._checkInitialized();
-    return await super.show(request);
+    return await super.show(...args);
   }
 
   /**
@@ -1774,27 +1945,29 @@ export class Channel extends ChannelApi {
   /**
    * Casts or cancels one or more votes on a poll.
    *
-   * @param request - The cast-poll-vote request payload, including the target message ID, poll ID,
-   *   and the vote to cast (or an empty payload to cancel).
+   * @param ...args - `[request, requestOptions]`. `request` holds the target message ID, poll ID,
+   *   and the vote to cast (or an empty payload to cancel); `requestOptions` carries per-request
+   *   options such as an abort `signal` and is never serialized into the request.
    * @returns The poll vote response.
    */
-  async vote(request: Parameters<ChatApi['castPollVote']>[0]) {
-    return await this.getClient().castPollVote(request);
+  async vote(...args: Parameters<ChatApi['castPollVote']>) {
+    return await this.getClient().castPollVote(...args);
   }
 
-  async removeVote(request: Parameters<ChatApi['deletePollVote']>[0]) {
-    return await this.getClient().deletePollVote(request);
+  async removeVote(...args: Parameters<ChatApi['deletePollVote']>) {
+    return await this.getClient().deletePollVote(...args);
   }
 
-  async _createDraft(request: Gen_CreateDraftRequest) {
-    return await super.createDraft(request);
+  async _createDraft(...args: Parameters<ChannelApi['createDraft']>) {
+    return await super.createDraft(...args);
   }
 
   /**
    * Creates or updates a draft message in a channel. If offline support is enabled, the
    * call is queued so it is replayed on reconnect.
    */
-  override async createDraft(request: Gen_CreateDraftRequest) {
+  override async createDraft(...args: Parameters<ChannelApi['createDraft']>) {
+    const [request] = args;
     try {
       const offlineDb = this.getClient().offlineDb;
       if (offlineDb) {
@@ -1803,7 +1976,7 @@ export class Channel extends ChannelApi {
             channelId: this.id as string,
             channelType: this.type,
             threadId: request.message?.parent_id,
-            payload: [request],
+            payload: args,
             type: 'create-draft',
           },
         })) as Awaited<ReturnType<ChannelApi['createDraft']>>;
@@ -1814,18 +1987,19 @@ export class Channel extends ChannelApi {
         .error('Creating the draft in the offline database failed.', { error });
     }
 
-    return this._createDraft(request);
+    return this._createDraft(...args);
   }
 
-  async _deleteDraft(request?: Parameters<ChannelApi['deleteDraft']>[0]) {
-    return await super.deleteDraft(request);
+  async _deleteDraft(...args: Parameters<ChannelApi['deleteDraft']>) {
+    return await super.deleteDraft(...args);
   }
 
   /**
    * Deletes a draft message from a channel or a thread. If offline support is enabled, the
    * call is queued so it is replayed on reconnect.
    */
-  override async deleteDraft(request?: Parameters<ChannelApi['deleteDraft']>[0]) {
+  override async deleteDraft(...args: Parameters<ChannelApi['deleteDraft']>) {
+    const [request] = args;
     try {
       const offlineDb = this.getClient().offlineDb;
       if (offlineDb) {
@@ -1834,7 +2008,7 @@ export class Channel extends ChannelApi {
             channelId: this.id as string,
             channelType: this.type,
             threadId: request?.parent_id,
-            payload: [request],
+            payload: args,
             type: 'delete-draft',
           },
         })) as Awaited<ReturnType<ChannelApi['deleteDraft']>>;
@@ -1845,7 +2019,7 @@ export class Channel extends ChannelApi {
         .error('Deleting the draft from the offline database failed.', { error });
     }
 
-    return this._deleteDraft(request);
+    return this._deleteDraft(...args);
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -225,7 +225,6 @@ export class StreamChat extends ChatApi {
   appIdentifier?: AppIdentifier;
   private cachedUserAgent?: string;
   readonly messageComposerCache: FixedSizeQueueCache<string, MessageComposer>;
-  private nextRequestAbortController: AbortController | null = null;
   instanceConfigurationService = new InstanceConfigurationService();
 
   /**
@@ -1216,11 +1215,13 @@ export class StreamChat extends ChatApi {
    *   and options such as `presence`.
    * @returns The user query response.
    */
-  override async queryUsers(request?: { payload?: Gen_QueryUsersPayload }) {
+  override async queryUsers(...args: Parameters<ChatApi['queryUsers']>) {
+    const request = args[0] ?? {};
+    const options = args[1];
     // Make sure we wait for the connect promise if there is a pending one
     await this.wsPromise;
 
-    const data = await super.queryUsers(request);
+    const data = await super.queryUsers(request, options);
     this.state.updateUsers(data.users);
 
     return data;

--- a/src/client.ts
+++ b/src/client.ts
@@ -48,15 +48,14 @@ import type {
   OwnUserResponse,
   PartializeAllBut,
   PartialThreadUpdate,
-  QueryBannedUsersPayload,
   QueryChannelsRequest,
   QueryChannelsResponse,
   QueryReactionsRequestWithId,
   QueryThreadsRequest,
   ReactionResponse,
   SdkIdentifier,
-  SearchPayload,
   StreamChatOptions,
+  StreamRequestOptions,
   TokenOrProvider,
   UnBanUserOptions,
   UpdateUserPartialRequest,
@@ -88,7 +87,6 @@ import { StateStore } from './store';
 import type {
   GetApplicationResponse as Gen_GetApplicationResponse,
   MarkDeliveredRequest as Gen_MarkDeliveredRequest,
-  QueryUsersPayload as Gen_QueryUsersPayload,
   WSEvent,
 } from './gen/models';
 import { ChatApi } from './gen-imports';
@@ -581,9 +579,11 @@ export class StreamChat extends ChatApi {
    * Revokes tokens for a connected user issued before the given time.
    *
    * @param before - Cutoff date; tokens issued before this are revoked (optional, defaults to the current time).
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The updated users response.
    */
-  async revokeTokens(before?: Date | null) {
+  async revokeTokens(before?: Date | null, requestOptions?: StreamRequestOptions) {
     if (!before) {
       before = new Date();
     }
@@ -598,16 +598,18 @@ export class StreamChat extends ChatApi {
       },
     ];
 
-    return await this.updateUsersPartial({ users });
+    return await this.updateUsersPartial({ users }, requestOptions);
   }
 
   /**
    * Retrieves application settings.
    *
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The application settings response.
    */
-  async getAppSettings() {
-    return await (this.appSettingsPromise = this.getApp());
+  async getAppSettings(requestOptions?: StreamRequestOptions) {
+    return await (this.appSettingsPromise = this.getApp(requestOptions));
   }
 
   /**
@@ -697,10 +699,12 @@ export class StreamChat extends ChatApi {
    * Sets up a temporary guest user.
    *
    * @param user - Data about this user, e.g. `{ name: 'john' }`.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns A promise that resolves when the connection is set up.
    */
-  async setGuestUser(user: UserResponse) {
-    const response = await this.createGuest({ user });
+  async setGuestUser(user: UserResponse, requestOptions?: StreamRequestOptions) {
+    const response = await this.createGuest({ user }, requestOptions);
 
     const {
       created_at: _created_at,
@@ -1210,18 +1214,18 @@ export class StreamChat extends ChatApi {
   /**
    * Queries users and watches user presence.
    *
-   * @param request - The query users request payload (optional). The inner `payload` accepts
+   * @param ...args - `[request, requestOptions]`. The optional `request.payload` accepts
    *   MongoDB-style filter conditions, sort directions (e.g. `[{ field: 'last_active', direction: -1 }]`),
-   *   and options such as `presence`.
+   *   and options such as `presence`. `requestOptions` carries per-request options such as an
+   *   abort `signal` and is never serialized into the request.
    * @returns The user query response.
    */
   override async queryUsers(...args: Parameters<ChatApi['queryUsers']>) {
-    const request = args[0] ?? {};
-    const options = args[1];
+    const [request, requestOptions] = args;
     // Make sure we wait for the connect promise if there is a pending one
     await this.wsPromise;
 
-    const data = await super.queryUsers(request, options);
+    const data = await super.queryUsers(request ?? {}, requestOptions);
     this.state.updateUsers(data.users);
 
     return data;
@@ -1230,15 +1234,16 @@ export class StreamChat extends ChatApi {
   /**
    * Queries user bans.
    *
-   * @param request - The query banned users request payload (optional). The inner `payload`
-   *   accepts MongoDB-style filter conditions, sort directions
+   * @param ...args - `[request, requestOptions]`. The optional `request.payload` accepts
+   *   MongoDB-style filter conditions, sort directions
    *   (e.g. `[{ field: 'created_at', direction: 1 }]`), and options such as `limit`, `offset`,
-   *   and `exclude_expired_bans`.
+   *   and `exclude_expired_bans`. `requestOptions` carries per-request options such as an abort
+   *   `signal` and is never serialized into the request.
    * @returns The ban query response.
    */
-  async queryBannedUsers(request?: { payload?: QueryBannedUsersPayload }) {
+  async queryBannedUsers(...args: Parameters<ChatApi['queryBannedUsers']>) {
     // Return a list of user bans
-    return await super.queryBannedUsers(request);
+    return await super.queryBannedUsers(...args);
   }
 
   /**
@@ -1250,12 +1255,14 @@ export class StreamChat extends ChatApi {
    * only the channel list. In the next major release, the request/response APIs should
    * be consolidated so callers can access the full response through the primary API.
    *
-   * @param request - The query channels request payload (optional). Accepts MongoDB-style filter
-   *   conditions, sort directions (e.g. `[{ field: 'created_at', direction: -1 }]`), and options
-   *   such as `predefined_filter`, `filter_values`, and `sort_values`.
+   * @param ...args - `[request, requestOptions]`. The optional `request` accepts MongoDB-style
+   *   filter conditions, sort directions (e.g. `[{ field: 'created_at', direction: -1 }]`), and
+   *   options such as `predefined_filter`, `filter_values`, and `sort_values`. `requestOptions`
+   *   carries per-request options such as an abort `signal` and is never serialized into the request.
    * @returns The full query channels response.
    */
-  override async queryChannels(request?: QueryChannelsRequest) {
+  override async queryChannels(...args: Parameters<ChatApi['queryChannels']>) {
+    const [request, requestOptions] = args;
     const defaultOptions: ChannelOptions = {
       state: true,
       watch: true,
@@ -1293,7 +1300,7 @@ export class StreamChat extends ChatApi {
           ...restOptions,
         };
 
-    return await super.queryChannels(payload);
+    return await super.queryChannels(payload, requestOptions);
   }
 
   /**
@@ -1315,19 +1322,24 @@ export class StreamChat extends ChatApi {
    * @param stateOptions.withResponse - Returns the full query response with hydrated channels.
    *   This is a compatibility bridge for internal callers that need response-level metadata while
    *   the default return value remains `Channel[]` (optional).
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The hydrated channel list, or the full response when `withResponse` is `true`.
    */
   async queryChannelsAndHydrate(
     options?: QueryChannelsRequest,
     stateOptions?: ChannelStateOptions & { withResponse: true },
+    requestOptions?: StreamRequestOptions,
   ): Promise<QueryChannelsResponseWithChannels>;
   async queryChannelsAndHydrate(
     options?: QueryChannelsRequest,
     stateOptions?: ChannelStateOptions,
+    requestOptions?: StreamRequestOptions,
   ): Promise<Channel[]>;
   async queryChannelsAndHydrate(
     options?: QueryChannelsRequest,
     stateOptions: ChannelStateOptions = {},
+    requestOptions?: StreamRequestOptions,
   ): Promise<Channel[] | QueryChannelsResponseWithChannels> {
     // TODO(perf/cleanup): prefer a `memberIds` snapshot over `headItems.map` here too — see the
     // matching TODO in channel.query() for the full rationale.
@@ -1337,7 +1349,7 @@ export class StreamChat extends ChatApi {
       if (head?.length)
         candidateIdsByCid.set(cid, new Set(head.map((message) => message.id)));
     }
-    const queryChannelsResponse = await this.queryChannels(options);
+    const queryChannelsResponse = await this.queryChannels(options, requestOptions);
     const channels = queryChannelsResponse.channels;
 
     this.dispatchEvent({
@@ -1378,9 +1390,14 @@ export class StreamChat extends ChatApi {
    * @param request - The query reactions request payload, including the target message ID,
    *   MongoDB-style filters, sort directions (e.g. `[{ field: 'created_at', direction: -1 }]`),
    *   and pagination options.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The query reactions response.
    */
-  async queryReactionsAndHydrate(request: QueryReactionsRequestWithId) {
+  async queryReactionsAndHydrate(
+    request: QueryReactionsRequestWithId,
+    requestOptions?: StreamRequestOptions,
+  ) {
     const { filter, next, id: messageId, sort, limit } = request;
 
     if (this.offlineDb?.getReactions && !next) {
@@ -1408,7 +1425,7 @@ export class StreamChat extends ChatApi {
     // Make sure we wait for the connect promise if there is a pending one
     await this.wsPromise;
 
-    return await this.queryReactions(request);
+    return await this.queryReactions(request, requestOptions);
   }
 
   hydrateActiveChannels(
@@ -1483,11 +1500,14 @@ export class StreamChat extends ChatApi {
   /**
    * Queries messages.
    *
-   * @param request - The search request payload (optional). The inner `payload` accepts
+   * @param ...args - `[request, requestOptions]`. The optional `request.payload` accepts
    *   MongoDB-style filter conditions, a search query, and options such as `user_id`.
+   *   `requestOptions` carries per-request options such as an abort `signal` and is never
+   *   serialized into the request.
    * @returns The search messages response.
    */
-  override async search(request?: { payload?: SearchPayload }) {
+  override async search(...args: Parameters<ChatApi['search']>) {
+    const [request, requestOptions] = args;
     if (request?.payload?.offset && request?.payload?.next) {
       throw Error(`Cannot specify "offset" with "next"`);
     }
@@ -1495,7 +1515,7 @@ export class StreamChat extends ChatApi {
     // Make sure we wait for the connect promise if there is a pending one
     await this.wsPromise;
 
-    return await super.search(request);
+    return await super.search(request, requestOptions);
   }
 
   /**
@@ -1747,10 +1767,13 @@ export class StreamChat extends ChatApi {
       ...options,
     });
   }
-  async blockUser(blockedUserId: string) {
-    const result = await this.blockUsers({
-      blocked_user_id: blockedUserId,
-    });
+  async blockUser(blockedUserId: string, requestOptions?: StreamRequestOptions) {
+    const result = await this.blockUsers(
+      {
+        blocked_user_id: blockedUserId,
+      },
+      requestOptions,
+    );
     if (this._cacheEnabled()) {
       this.blockedUsers.next(({ userIds }) => ({
         userIds: userIds.concat(blockedUserId),
@@ -1759,8 +1782,8 @@ export class StreamChat extends ChatApi {
     return result;
   }
 
-  override async getBlockedUsers() {
-    const result = await super.getBlockedUsers();
+  override async getBlockedUsers(...args: Parameters<ChatApi['getBlockedUsers']>) {
+    const result = await super.getBlockedUsers(...args);
     if (this._cacheEnabled()) {
       this.blockedUsers.partialNext({
         userIds: result.blocks.map(({ blocked_user_id }) => blocked_user_id),
@@ -1769,10 +1792,13 @@ export class StreamChat extends ChatApi {
     return result;
   }
 
-  async unblockUser(blockedUserId: string) {
-    const result = await this.unblockUsers({
-      blocked_user_id: blockedUserId,
-    });
+  async unblockUser(blockedUserId: string, requestOptions?: StreamRequestOptions) {
+    const result = await this.unblockUsers(
+      {
+        blocked_user_id: blockedUserId,
+      },
+      requestOptions,
+    );
     if (this._cacheEnabled()) {
       this.blockedUsers.next(({ userIds }) => ({
         userIds: userIds.filter((id) => id !== blockedUserId),
@@ -1946,42 +1972,56 @@ export class StreamChat extends ChatApi {
    * @param pinnedAt - Date when the message should be pinned. It affects the order of pinned
    *   messages. Use a negative number to set relative time in the past, `string` or `Date` to
    *   set the exact date of pin (optional).
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The updated message response.
    */
   pinMessage(
     messageOrMessageId: string | { id: string },
     timeoutOrExpirationDate?: null | number | string | Date,
     pinnedAt?: number | string | Date,
+    requestOptions?: StreamRequestOptions,
   ) {
     const id = this._validateAndGetMessageId(
       messageOrMessageId,
       'Please specify the message id when calling pinMessage',
     );
-    return this.updateMessagePartial({
-      id,
-      set: {
-        pinned: true,
-        pin_expires: this._normalizeExpiration(timeoutOrExpirationDate),
-        pinned_at: this._normalizeExpiration(pinnedAt),
+    return this.updateMessagePartial(
+      {
+        id,
+        set: {
+          pinned: true,
+          pin_expires: this._normalizeExpiration(timeoutOrExpirationDate),
+          pinned_at: this._normalizeExpiration(pinnedAt),
+        },
       },
-    });
+      requestOptions,
+    );
   }
 
   /**
    * Unpins the message that was previously pinned.
    *
    * @param messageOrMessageId - MessageRequest object or message ID.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The updated message response.
    */
-  unpinMessage(messageOrMessageId: string | { id: string }) {
+  unpinMessage(
+    messageOrMessageId: string | { id: string },
+    requestOptions?: StreamRequestOptions,
+  ) {
     const id = this._validateAndGetMessageId(
       messageOrMessageId,
       'Please specify the message id when calling unpinMessage',
     );
-    return this.updateMessagePartial({
-      id,
-      set: { pinned: false },
-    });
+    return this.updateMessagePartial(
+      {
+        id,
+        set: { pinned: false },
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -1989,8 +2029,12 @@ export class StreamChat extends ChatApi {
    * so it is replayed on reconnect.
    */
   override async updateMessage(
-    request: Parameters<ChatApi['updateMessage']>[0] & { message: { cid?: string } },
+    ...args: [
+      request: Parameters<ChatApi['updateMessage']>[0] & { message: { cid?: string } },
+      requestOptions?: StreamRequestOptions,
+    ]
   ) {
+    const [request] = args;
     try {
       if (this.offlineDb) {
         return await this.offlineDb.queueTask<
@@ -1999,7 +2043,7 @@ export class StreamChat extends ChatApi {
           task: {
             ...getPendingTaskChannelData(request.message?.cid),
             messageId: request.id,
-            payload: [request],
+            payload: args,
             type: 'update-message',
           },
         });
@@ -2010,18 +2054,19 @@ export class StreamChat extends ChatApi {
         .error('Updating the message failed.', { error });
     }
 
-    return await this._updateMessage(request);
+    return await this._updateMessage(...args);
   }
 
-  async _updateMessage(request: Parameters<ChatApi['updateMessage']>[0]) {
-    return await super.updateMessage(request);
+  async _updateMessage(...args: Parameters<ChatApi['updateMessage']>) {
+    return await super.updateMessage(...args);
   }
 
   /**
    * Deletes a message. When an `offlineDb` is registered the call is queued so it
    * is replayed on reconnect.
    */
-  override async deleteMessage(request: Parameters<ChatApi['deleteMessage']>[0]) {
+  override async deleteMessage(...args: Parameters<ChatApi['deleteMessage']>) {
+    const [request] = args;
     try {
       if (this.offlineDb) {
         if (request.hard) {
@@ -2037,7 +2082,7 @@ export class StreamChat extends ChatApi {
         >({
           task: {
             messageId: request.id,
-            payload: [request],
+            payload: args,
             type: 'delete-message',
           },
         });
@@ -2048,11 +2093,12 @@ export class StreamChat extends ChatApi {
         .error('Deleting the message failed.', { error });
     }
 
-    return this._deleteMessage(request);
+    return this._deleteMessage(...args);
   }
 
-  async _deleteMessage(request: Parameters<ChatApi['deleteMessage']>[0]) {
-    const result = await super.deleteMessage(request);
+  async _deleteMessage(...args: Parameters<ChatApi['deleteMessage']>) {
+    const [request] = args;
+    const result = await super.deleteMessage(...args);
 
     // necessary to populate the below values as the server does not return the message in the response as deleted
     if (request.delete_for_me) {
@@ -2074,9 +2120,14 @@ export class StreamChat extends ChatApi {
    * @param options.reply_limit - Limits the number of replies returned per thread (optional).
    * @param options.filter - MongoDB style filters for threads (optional).
    * @param options.sort - MongoDB style sort for threads (optional).
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The list of threads and the next cursor.
    */
-  async queryThreadsAndHydrate(options: QueryThreadsRequest = {}) {
+  async queryThreadsAndHydrate(
+    options: QueryThreadsRequest = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
     const optionsWithDefaults = {
       limit: 10,
       participant_limit: 10,
@@ -2100,7 +2151,7 @@ export class StreamChat extends ChatApi {
       requestBody.sort = optionsWithDefaults.sort;
     }
 
-    const response = await this.queryThreads(requestBody);
+    const response = await this.queryThreads(requestBody, requestOptions);
 
     // Hydrate the polls for the parent messages of the threads
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -2124,9 +2175,15 @@ export class StreamChat extends ChatApi {
    * @param options.watch - Subscribes the user to the channel of the thread (optional).
    * @param options.participant_limit - Limits the number of participants returned per thread (optional).
    * @param options.reply_limit - Limits the number of replies returned per thread (optional).
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The thread.
    */
-  async getThreadAndHydrate(messageId: string, options: GetThreadOptions = {}) {
+  async getThreadAndHydrate(
+    messageId: string,
+    options: GetThreadOptions = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
     if (!messageId) {
       throw new Error('Please specify the messageId when calling getThreadAndHydrate');
     }
@@ -2138,10 +2195,13 @@ export class StreamChat extends ChatApi {
       ...options,
     };
 
-    const response = await this.getThread({
-      message_id: messageId,
-      ...optionsWithDefaults,
-    });
+    const response = await this.getThread(
+      {
+        message_id: messageId,
+        ...optionsWithDefaults,
+      },
+      requestOptions,
+    );
 
     return new Thread({ client: this, threadData: response.thread });
   }
@@ -2151,9 +2211,15 @@ export class StreamChat extends ChatApi {
    *
    * @param messageId - The ID of the thread message which needs to be updated.
    * @param partialThreadObject - Should contain `set` or `unset` params for any of the thread's non-reserved fields.
+   * @param   requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The updated thread.
    */
-  async partialUpdateThread(messageId: string, partialThreadObject: PartialThreadUpdate) {
+  async partialUpdateThread(
+    messageId: string,
+    partialThreadObject: PartialThreadUpdate,
+    requestOptions?: StreamRequestOptions,
+  ) {
     if (!messageId) {
       throw Error('Please specify the message id when calling partialUpdateThread');
     }
@@ -2181,10 +2247,13 @@ export class StreamChat extends ChatApi {
       }
     }
 
-    return await this.updateThreadPartial({
-      message_id: messageId,
-      ...partialThreadObject,
-    });
+    return await this.updateThreadPartial(
+      {
+        message_id: messageId,
+        ...partialThreadObject,
+      },
+      requestOptions,
+    );
   }
 
   getUserAgent = (): string => {
@@ -2276,19 +2345,21 @@ export class StreamChat extends ChatApi {
    * @param request.filter - Vote filter conditions.
    * @returns The poll answers.
    */
-  async queryPollAnswers({
-    poll_id,
-    filter,
-    ...options
-  }: Parameters<ChatApi['queryPollVotes']>[0]) {
-    return await this.queryPollVotes({
-      poll_id,
-      filter: {
-        ...filter,
-        is_answer: true,
+  async queryPollAnswers(
+    { poll_id, filter, ...options }: Parameters<ChatApi['queryPollVotes']>[0],
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return await this.queryPollVotes(
+      {
+        poll_id,
+        filter: {
+          ...filter,
+          is_answer: true,
+        },
+        ...options,
       },
-      ...options,
-    });
+      requestOptions,
+    );
   }
 
   /**
@@ -2350,9 +2421,12 @@ export class StreamChat extends ChatApi {
    * @param request - Mark delivered options.
    * @returns The server response, or `undefined` if there are no messages to mark.
    */
-  async markChannelsDelivered(request?: Gen_MarkDeliveredRequest) {
+  async markChannelsDelivered(
+    request?: Gen_MarkDeliveredRequest,
+    requestOptions?: StreamRequestOptions,
+  ) {
     if (!request?.latest_delivered_messages?.length) return;
-    return await this.markDelivered(request);
+    return await this.markDelivered(request, requestOptions);
   }
 
   syncDeliveredCandidates(collections: Channel[]) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,5 @@
 import type { AxiosResponse } from 'axios';
+import { isCancel } from 'axios';
 import type { APIError as Gen_APIError } from './types';
 
 export const APIErrorCodes: Record<string, { name: string; retryable: boolean }> = {
@@ -52,10 +53,17 @@ export function isErrorRetryable(error: APIError) {
  * Whether an error is EPHEMERAL — a transient failure worth queueing/retrying rather than a
  * definitive rejection. True when the server never responded (connection/network/offline error - no
  * `response`, i.e an axios network error or an `OfflineError`) and when the server responded with a
- * retryable code (see {@link APIErrorCodes}); false only when the server responded with a
- * non-retryable code (InputError 4, DoesNotExist 16, NotAllowed 17, …).
+ * retryable code (see {@link APIErrorCodes}); false when the server responded with a
+ * non-retryable code (InputError 4, DoesNotExist 16, NotAllowed 17, …) and when the caller
+ * cancelled the request.
+ *
+ * Cancellation is deliberately NOT ephemeral even though an aborted request carries no `response`.
+ * A caller who aborts via `StreamRequestOptions.signal` wants the operation dropped, so treating it
+ * as transient would do the opposite of what was asked: the task would be queued and replayed on
+ * reconnect, and any optimistic local update would be kept rather than rolled back.
  */
 export function isEphemeral(error: Error): boolean {
+  if (isCancel(error)) return false;
   if (!(error as { response?: unknown }).response) return true;
   return isErrorRetryable(error as APIError);
 }

--- a/src/gen-imports.ts
+++ b/src/gen-imports.ts
@@ -1,3 +1,4 @@
 export { ChatApi } from './gen/chat/ChatApi';
 export type { StreamResponse } from './types';
 export { ApiClient } from './api-client';
+export type { StreamRequestOptions } from './types';

--- a/src/gen/chat/ChannelApi.ts
+++ b/src/gen/chat/ChannelApi.ts
@@ -1,4 +1,4 @@
-import type { ChatApi, StreamResponse } from '../../gen-imports';
+import type { ChatApi, StreamRequestOptions, StreamResponse } from '../../gen-imports';
 import type {
   ChannelGetOrCreateRequest,
   ChannelStateResponse,
@@ -41,195 +41,35 @@ export class ChannelApi {
     public id: string | undefined,
   ) {}
 
-  delete(request?: {
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteChannelResponse>> {
+  delete(
+    request?: { hard_delete?: boolean },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteChannelResponse>> {
     if (!this.id) {
       throw new Error(
         `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
       );
     }
 
-    return this.chatApi.deleteChannel({ id: this.id, type: this.type, ...request });
+    return this.chatApi.deleteChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
-  get(request?: {
-    state?: boolean;
-    messages_limit?: number;
-    members_limit?: number;
-    watchers_limit?: number;
-    messages_id_lt?: string;
-    messages_id_lte?: string;
-    messages_id_gt?: string;
-    messages_id_gte?: string;
-    messages_id_around?: string;
-  }): Promise<StreamResponse<ChannelStateResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.getChannel({ id: this.id, type: this.type, ...request });
-  }
-
-  updateChannelPartial(
-    request?: UpdateChannelPartialRequest,
-  ): Promise<StreamResponse<UpdateChannelPartialResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.updateChannelPartial({
-      id: this.id,
-      type: this.type,
-      ...request,
-    });
-  }
-
-  update(request?: UpdateChannelRequest): Promise<StreamResponse<UpdateChannelResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.updateChannel({ id: this.id, type: this.type, ...request });
-  }
-
-  deleteDraft(request?: { parent_id?: string }): Promise<StreamResponse<Response>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.deleteDraft({ id: this.id, type: this.type, ...request });
-  }
-
-  getDraft(request?: { parent_id?: string }): Promise<StreamResponse<GetDraftResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.getDraft({ id: this.id, type: this.type, ...request });
-  }
-
-  createDraft(request: CreateDraftRequest): Promise<StreamResponse<CreateDraftResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.createDraft({ id: this.id, type: this.type, ...request });
-  }
-
-  sendEvent(request: SendEventRequest): Promise<StreamResponse<EventResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.sendEvent({ id: this.id, type: this.type, ...request });
-  }
-
-  deleteChannelFile(request?: { url?: string }): Promise<StreamResponse<Response>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.deleteChannelFile({ id: this.id, type: this.type, ...request });
-  }
-
-  uploadChannelFile(
-    request?: UploadChannelFileRequest,
-  ): Promise<StreamResponse<UploadChannelFileResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.uploadChannelFile({ id: this.id, type: this.type, ...request });
-  }
-
-  hide(request?: HideChannelRequest): Promise<StreamResponse<HideChannelResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.hideChannel({ id: this.id, type: this.type, ...request });
-  }
-
-  deleteChannelImage(request?: { url?: string }): Promise<StreamResponse<Response>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.deleteChannelImage({ id: this.id, type: this.type, ...request });
-  }
-
-  uploadChannelImage(
-    request?: UploadChannelRequest,
-  ): Promise<StreamResponse<UploadChannelResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.uploadChannelImage({ id: this.id, type: this.type, ...request });
-  }
-
-  updateMemberPartial(
-    request?: UpdateMemberPartialRequest,
-  ): Promise<StreamResponse<UpdateMemberPartialResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.updateMemberPartial({ id: this.id, type: this.type, ...request });
-  }
-
-  sendMessage(request: SendMessageRequest): Promise<StreamResponse<SendMessageResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.sendMessage({ id: this.id, type: this.type, ...request });
-  }
-
-  getManyMessages(request: {
-    ids: Array<string>;
-    member_custom_include?: Array<string>;
-  }): Promise<StreamResponse<GetManyMessagesResponse>> {
-    if (!this.id) {
-      throw new Error(
-        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
-      );
-    }
-
-    return this.chatApi.getManyMessages({ id: this.id, type: this.type, ...request });
-  }
-
-  getOrCreate(
-    request?: ChannelGetOrCreateRequest & { connection_id?: string },
+  get(
+    request?: {
+      state?: boolean;
+      messages_limit?: number;
+      members_limit?: number;
+      watchers_limit?: number;
+      messages_id_lt?: string;
+      messages_id_lte?: string;
+      messages_id_gt?: string;
+      messages_id_gte?: string;
+      messages_id_around?: string;
+    },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ChannelStateResponse>> {
     if (!this.id) {
       throw new Error(
@@ -237,31 +77,49 @@ export class ChannelApi {
       );
     }
 
-    return this.chatApi.getOrCreateChannel({ id: this.id, type: this.type, ...request });
+    return this.chatApi.getChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
-  markRead(request?: MarkReadRequest): Promise<StreamResponse<MarkReadResponse>> {
+  updateChannelPartial(
+    request?: UpdateChannelPartialRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UpdateChannelPartialResponse>> {
     if (!this.id) {
       throw new Error(
         `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
       );
     }
 
-    return this.chatApi.markRead({ id: this.id, type: this.type, ...request });
+    return this.chatApi.updateChannelPartial(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
-  show(request?: ShowChannelRequest): Promise<StreamResponse<ShowChannelResponse>> {
+  update(
+    request?: UpdateChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UpdateChannelResponse>> {
     if (!this.id) {
       throw new Error(
         `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
       );
     }
 
-    return this.chatApi.showChannel({ id: this.id, type: this.type, ...request });
+    return this.chatApi.updateChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
-  stopWatching(
-    request?: ChannelStopWatchingRequest & { connection_id?: string },
+  deleteDraft(
+    request?: { parent_id?: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<Response>> {
     if (!this.id) {
       throw new Error(
@@ -269,11 +127,265 @@ export class ChannelApi {
       );
     }
 
-    return this.chatApi.stopWatchingChannel({ id: this.id, type: this.type, ...request });
+    return this.chatApi.deleteDraft(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  getDraft(
+    request?: { parent_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetDraftResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.getDraft(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  createDraft(
+    request: CreateDraftRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<CreateDraftResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.createDraft(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  sendEvent(
+    request: SendEventRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<EventResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.sendEvent(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  deleteChannelFile(
+    request?: { url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.deleteChannelFile(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  uploadChannelFile(
+    request?: UploadChannelFileRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UploadChannelFileResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.uploadChannelFile(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  hide(
+    request?: HideChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<HideChannelResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.hideChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  deleteChannelImage(
+    request?: { url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.deleteChannelImage(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  uploadChannelImage(
+    request?: UploadChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UploadChannelResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.uploadChannelImage(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  updateMemberPartial(
+    request?: UpdateMemberPartialRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UpdateMemberPartialResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.updateMemberPartial(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  sendMessage(
+    request: SendMessageRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<SendMessageResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.sendMessage(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  getManyMessages(
+    request: { ids: Array<string>; member_custom_include?: Array<string> },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetManyMessagesResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.getManyMessages(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  getOrCreate(
+    request?: ChannelGetOrCreateRequest & { connection_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ChannelStateResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.getOrCreateChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  markRead(
+    request?: MarkReadRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<MarkReadResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.markRead(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  show(
+    request?: ShowChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ShowChannelResponse>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.showChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
+  }
+
+  stopWatching(
+    request?: ChannelStopWatchingRequest & { connection_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
+    if (!this.id) {
+      throw new Error(
+        `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
+      );
+    }
+
+    return this.chatApi.stopWatchingChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
   truncate(
     request?: TruncateChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<TruncateChannelResponse>> {
     if (!this.id) {
       throw new Error(
@@ -281,16 +393,26 @@ export class ChannelApi {
       );
     }
 
-    return this.chatApi.truncateChannel({ id: this.id, type: this.type, ...request });
+    return this.chatApi.truncateChannel(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 
-  markUnread(request?: MarkUnreadRequest): Promise<StreamResponse<Response>> {
+  markUnread(
+    request?: MarkUnreadRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     if (!this.id) {
       throw new Error(
         `Channel isn't yet created, call getOrCreateDistinctChannel() before this operation`,
       );
     }
 
-    return this.chatApi.markUnread({ id: this.id, type: this.type, ...request });
+    return this.chatApi.markUnread(
+      { id: this.id, type: this.type, ...request },
+      requestOptions,
+    );
   }
 }

--- a/src/gen/chat/ChatApi.ts
+++ b/src/gen/chat/ChatApi.ts
@@ -1,4 +1,4 @@
-import type { ApiClient, StreamResponse } from '../../gen-imports';
+import type { ApiClient, StreamRequestOptions, StreamResponse } from '../../gen-imports';
 import type {
   AddUserGroupMembersRequest,
   AddUserGroupMembersResponse,
@@ -153,21 +153,22 @@ import { decoders } from '../model-decoders/decoders';
 export class ChatApi {
   constructor(public readonly apiClient: ApiClient) {}
 
-  async getApp(): Promise<StreamResponse<GetApplicationResponse>> {
+  async getApp(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetApplicationResponse>> {
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetApplicationResponse>
-    >('GET', '/api/v2/app', undefined, undefined);
+    >('GET', '/api/v2/app', undefined, undefined, undefined, undefined, requestOptions);
 
     decoders['GetApplicationResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async listBlockLists(request?: {
-    team?: string;
-    cursor?: string;
-    limit?: number;
-  }): Promise<StreamResponse<ListBlockListResponse>> {
+  async listBlockLists(
+    request?: { team?: string; cursor?: string; limit?: number },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ListBlockListResponse>> {
     const queryParams = {
       team: request?.team,
       cursor: request?.cursor,
@@ -176,7 +177,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<ListBlockListResponse>
-    >('GET', '/api/v2/blocklists', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/blocklists',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['ListBlockListResponse']?.(response.body);
 
@@ -185,6 +194,8 @@ export class ChatApi {
 
   async createBlockList(
     request: CreateBlockListRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<CreateBlockListResponse>> {
     const body = {
       name: request?.name,
@@ -199,7 +210,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<CreateBlockListResponse>
-    >('POST', '/api/v2/blocklists', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/blocklists',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['CreateBlockListResponse']?.(response.body);
 
@@ -208,6 +227,7 @@ export class ChatApi {
 
   async importBlockList(
     request: ImportBlockListRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ImportBlockListResponse>> {
     const pathParams = {
       id: request?.id,
@@ -226,6 +246,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['ImportBlockListResponse']?.(response.body);
@@ -233,10 +254,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteBlockList(request: {
-    name: string;
-    team?: string;
-  }): Promise<StreamResponse<Response>> {
+  async deleteBlockList(
+    request: { name: string; team?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       team: request?.team,
     };
@@ -249,6 +270,9 @@ export class ChatApi {
       '/api/v2/blocklists/{name}',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -258,6 +282,7 @@ export class ChatApi {
 
   async updateBlockList(
     request: UpdateBlockListRequest & { name: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateBlockListResponse>> {
     const pathParams = {
       name: request?.name,
@@ -280,6 +305,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateBlockListResponse']?.(response.body);
@@ -289,6 +315,7 @@ export class ChatApi {
 
   async queryChannels(
     request?: QueryChannelsRequest & { connection_id?: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryChannelsResponse>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -311,7 +338,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<QueryChannelsResponse>
-    >('POST', '/api/v2/chat/channels', undefined, queryParams, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/chat/channels',
+      undefined,
+      queryParams,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['QueryChannelsResponse']?.(response.body);
 
@@ -320,6 +355,8 @@ export class ChatApi {
 
   async deleteChannels(
     request: DeleteChannelsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<DeleteChannelsResponse>> {
     const body = {
       cids: request?.cids,
@@ -335,6 +372,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['DeleteChannelsResponse']?.(response.body);
@@ -344,6 +382,8 @@ export class ChatApi {
 
   async markDelivered(
     request?: MarkDeliveredRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MarkDeliveredResponse>> {
     const body = {
       latest_delivered_messages: request?.latest_delivered_messages,
@@ -358,6 +398,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MarkDeliveredResponse']?.(response.body);
@@ -367,6 +408,7 @@ export class ChatApi {
 
   async groupedQueryChannels(
     request?: GroupedQueryChannelsRequest & { connection_id?: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<GroupedQueryChannelsResponse>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -387,6 +429,7 @@ export class ChatApi {
       queryParams,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['GroupedQueryChannelsResponse']?.(response.body);
@@ -396,6 +439,8 @@ export class ChatApi {
 
   async markChannelsRead(
     request?: MarkChannelsReadRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MarkReadResponse>> {
     const body = {
       read_by_channel: request?.read_by_channel,
@@ -408,6 +453,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MarkReadResponse']?.(response.body);
@@ -417,6 +463,7 @@ export class ChatApi {
 
   async getOrCreateDistinctChannel(
     request: ChannelGetOrCreateRequest & { type: string; connection_id?: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ChannelStateResponse>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -446,6 +493,7 @@ export class ChatApi {
       queryParams,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['ChannelStateResponse']?.(response.body);
@@ -453,11 +501,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteChannel(request: {
-    type: string;
-    id: string;
-    hard_delete?: boolean;
-  }): Promise<StreamResponse<DeleteChannelResponse>> {
+  async deleteChannel(
+    request: { type: string; id: string; hard_delete?: boolean },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteChannelResponse>> {
     const queryParams = {
       hard_delete: request?.hard_delete,
     };
@@ -468,26 +515,37 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteChannelResponse>
-    >('DELETE', '/api/v2/chat/channels/{type}/{id}', pathParams, queryParams);
+    >(
+      'DELETE',
+      '/api/v2/chat/channels/{type}/{id}',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteChannelResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getChannel(request: {
-    type: string;
-    id: string;
-    state?: boolean;
-    messages_limit?: number;
-    members_limit?: number;
-    watchers_limit?: number;
-    messages_id_lt?: string;
-    messages_id_lte?: string;
-    messages_id_gt?: string;
-    messages_id_gte?: string;
-    messages_id_around?: string;
-  }): Promise<StreamResponse<ChannelStateResponse>> {
+  async getChannel(
+    request: {
+      type: string;
+      id: string;
+      state?: boolean;
+      messages_limit?: number;
+      members_limit?: number;
+      watchers_limit?: number;
+      messages_id_lt?: string;
+      messages_id_lte?: string;
+      messages_id_gt?: string;
+      messages_id_gte?: string;
+      messages_id_around?: string;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ChannelStateResponse>> {
     const queryParams = {
       state: request?.state,
       messages_limit: request?.messages_limit,
@@ -506,7 +564,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<ChannelStateResponse>
-    >('GET', '/api/v2/chat/channels/{type}/{id}', pathParams, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/channels/{type}/{id}',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['ChannelStateResponse']?.(response.body);
 
@@ -515,6 +581,7 @@ export class ChatApi {
 
   async updateChannelPartial(
     request: UpdateChannelPartialRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateChannelPartialResponse>> {
     const pathParams = {
       type: request?.type,
@@ -534,6 +601,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateChannelPartialResponse']?.(response.body);
@@ -543,6 +611,7 @@ export class ChatApi {
 
   async updateChannel(
     request: UpdateChannelRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateChannelResponse>> {
     const pathParams = {
       type: request?.type,
@@ -576,6 +645,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateChannelResponse']?.(response.body);
@@ -583,11 +653,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteDraft(request: {
-    type: string;
-    id: string;
-    parent_id?: string;
-  }): Promise<StreamResponse<Response>> {
+  async deleteDraft(
+    request: { type: string; id: string; parent_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       parent_id: request?.parent_id,
     };
@@ -601,6 +670,9 @@ export class ChatApi {
       '/api/v2/chat/channels/{type}/{id}/draft',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -608,11 +680,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getDraft(request: {
-    type: string;
-    id: string;
-    parent_id?: string;
-  }): Promise<StreamResponse<GetDraftResponse>> {
+  async getDraft(
+    request: { type: string; id: string; parent_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetDraftResponse>> {
     const queryParams = {
       parent_id: request?.parent_id,
     };
@@ -626,6 +697,9 @@ export class ChatApi {
       '/api/v2/chat/channels/{type}/{id}/draft',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetDraftResponse']?.(response.body);
@@ -635,6 +709,7 @@ export class ChatApi {
 
   async createDraft(
     request: CreateDraftRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<CreateDraftResponse>> {
     const pathParams = {
       type: request?.type,
@@ -653,6 +728,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['CreateDraftResponse']?.(response.body);
@@ -662,6 +738,7 @@ export class ChatApi {
 
   async sendEvent(
     request: SendEventRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<EventResponse>> {
     const pathParams = {
       type: request?.type,
@@ -678,6 +755,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['EventResponse']?.(response.body);
@@ -685,11 +763,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteChannelFile(request: {
-    type: string;
-    id: string;
-    url?: string;
-  }): Promise<StreamResponse<Response>> {
+  async deleteChannelFile(
+    request: { type: string; id: string; url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       url: request?.url,
     };
@@ -703,6 +780,9 @@ export class ChatApi {
       '/api/v2/chat/channels/{type}/{id}/file',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -712,6 +792,7 @@ export class ChatApi {
 
   async uploadChannelFile(
     request: UploadChannelFileRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UploadChannelFileResponse>> {
     const pathParams = {
       type: request?.type,
@@ -731,6 +812,7 @@ export class ChatApi {
       undefined,
       body,
       'multipart/form-data',
+      requestOptions,
     );
 
     decoders['UploadChannelFileResponse']?.(response.body);
@@ -740,6 +822,7 @@ export class ChatApi {
 
   async hideChannel(
     request: HideChannelRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<HideChannelResponse>> {
     const pathParams = {
       type: request?.type,
@@ -758,6 +841,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['HideChannelResponse']?.(response.body);
@@ -765,11 +849,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteChannelImage(request: {
-    type: string;
-    id: string;
-    url?: string;
-  }): Promise<StreamResponse<Response>> {
+  async deleteChannelImage(
+    request: { type: string; id: string; url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       url: request?.url,
     };
@@ -783,6 +866,9 @@ export class ChatApi {
       '/api/v2/chat/channels/{type}/{id}/image',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -792,6 +878,7 @@ export class ChatApi {
 
   async uploadChannelImage(
     request: UploadChannelRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UploadChannelResponse>> {
     const pathParams = {
       type: request?.type,
@@ -812,6 +899,7 @@ export class ChatApi {
       undefined,
       body,
       'multipart/form-data',
+      requestOptions,
     );
 
     decoders['UploadChannelResponse']?.(response.body);
@@ -821,6 +909,7 @@ export class ChatApi {
 
   async updateMemberPartial(
     request: UpdateMemberPartialRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateMemberPartialResponse>> {
     const pathParams = {
       type: request?.type,
@@ -840,6 +929,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateMemberPartialResponse']?.(response.body);
@@ -849,6 +939,7 @@ export class ChatApi {
 
   async sendMessage(
     request: SendMessageRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<SendMessageResponse>> {
     const pathParams = {
       type: request?.type,
@@ -872,6 +963,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['SendMessageResponse']?.(response.body);
@@ -879,12 +971,15 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getManyMessages(request: {
-    type: string;
-    id: string;
-    ids: Array<string>;
-    member_custom_include?: Array<string>;
-  }): Promise<StreamResponse<GetManyMessagesResponse>> {
+  async getManyMessages(
+    request: {
+      type: string;
+      id: string;
+      ids: Array<string>;
+      member_custom_include?: Array<string>;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetManyMessagesResponse>> {
     const queryParams = {
       ids: request?.ids,
       member_custom_include: request?.member_custom_include,
@@ -896,7 +991,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetManyMessagesResponse>
-    >('GET', '/api/v2/chat/channels/{type}/{id}/messages', pathParams, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/channels/{type}/{id}/messages',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['GetManyMessagesResponse']?.(response.body);
 
@@ -909,6 +1012,7 @@ export class ChatApi {
       id: string;
       connection_id?: string;
     },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ChannelStateResponse>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -939,6 +1043,7 @@ export class ChatApi {
       queryParams,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['ChannelStateResponse']?.(response.body);
@@ -948,6 +1053,7 @@ export class ChatApi {
 
   async markRead(
     request: MarkReadRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MarkReadResponse>> {
     const pathParams = {
       type: request?.type,
@@ -965,6 +1071,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MarkReadResponse']?.(response.body);
@@ -974,6 +1081,7 @@ export class ChatApi {
 
   async showChannel(
     request: ShowChannelRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ShowChannelResponse>> {
     const pathParams = {
       type: request?.type,
@@ -990,6 +1098,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['ShowChannelResponse']?.(response.body);
@@ -1003,6 +1112,7 @@ export class ChatApi {
       id: string;
       connection_id?: string;
     },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<Response>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -1020,6 +1130,7 @@ export class ChatApi {
       queryParams,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -1029,6 +1140,7 @@ export class ChatApi {
 
   async truncateChannel(
     request: TruncateChannelRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<TruncateChannelResponse>> {
     const pathParams = {
       type: request?.type,
@@ -1051,6 +1163,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['TruncateChannelResponse']?.(response.body);
@@ -1060,6 +1173,7 @@ export class ChatApi {
 
   async markUnread(
     request: MarkUnreadRequest & { type: string; id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<Response>> {
     const pathParams = {
       type: request?.type,
@@ -1078,6 +1192,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -1087,6 +1202,8 @@ export class ChatApi {
 
   async queryDrafts(
     request?: QueryDraftsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryDraftsResponse>> {
     const body = {
       limit: request?.limit,
@@ -1105,6 +1222,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryDraftsResponse']?.(response.body);
@@ -1112,9 +1230,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async queryMembers(request?: {
-    payload?: QueryMembersPayload;
-  }): Promise<StreamResponse<MembersResponse>> {
+  async queryMembers(
+    request?: { payload?: QueryMembersPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<MembersResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
@@ -1124,6 +1243,9 @@ export class ChatApi {
       '/api/v2/chat/members',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['MembersResponse']?.(response.body);
@@ -1131,11 +1253,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteMessage(request: {
-    id: string;
-    hard?: boolean;
-    delete_for_me?: boolean;
-  }): Promise<StreamResponse<DeleteMessageResponse>> {
+  async deleteMessage(
+    request: { id: string; hard?: boolean; delete_for_me?: boolean },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteMessageResponse>> {
     const queryParams = {
       hard: request?.hard,
       delete_for_me: request?.delete_for_me,
@@ -1146,14 +1267,25 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteMessageResponse>
-    >('DELETE', '/api/v2/chat/messages/{id}', pathParams, queryParams);
+    >(
+      'DELETE',
+      '/api/v2/chat/messages/{id}',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteMessageResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getMessage(request: { id: string }): Promise<StreamResponse<GetMessageResponse>> {
+  async getMessage(
+    request: { id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetMessageResponse>> {
     const pathParams = {
       id: request?.id,
     };
@@ -1163,6 +1295,9 @@ export class ChatApi {
       '/api/v2/chat/messages/{id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetMessageResponse']?.(response.body);
@@ -1172,6 +1307,7 @@ export class ChatApi {
 
   async updateMessage(
     request: UpdateMessageRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateMessageResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1191,6 +1327,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateMessageResponse']?.(response.body);
@@ -1200,6 +1337,7 @@ export class ChatApi {
 
   async updateMessagePartial(
     request: UpdateMessagePartialRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateMessagePartialResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1220,6 +1358,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateMessagePartialResponse']?.(response.body);
@@ -1229,6 +1368,7 @@ export class ChatApi {
 
   async runMessageAction(
     request: MessageActionRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MessageActionResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1246,6 +1386,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MessageActionResponse']?.(response.body);
@@ -1255,6 +1396,7 @@ export class ChatApi {
 
   async sendReaction(
     request: SendReactionRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<SendReactionResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1274,6 +1416,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['SendReactionResponse']?.(response.body);
@@ -1281,10 +1424,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteReaction(request: {
-    id: string;
-    type: string;
-  }): Promise<StreamResponse<DeleteReactionResponse>> {
+  async deleteReaction(
+    request: { id: string; type: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteReactionResponse>> {
     const pathParams = {
       id: request?.id,
       type: request?.type,
@@ -1292,18 +1435,25 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteReactionResponse>
-    >('DELETE', '/api/v2/chat/messages/{id}/reaction/{type}', pathParams, undefined);
+    >(
+      'DELETE',
+      '/api/v2/chat/messages/{id}/reaction/{type}',
+      pathParams,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteReactionResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getReactions(request: {
-    id: string;
-    limit?: number;
-    offset?: number;
-  }): Promise<StreamResponse<GetReactionsResponse>> {
+  async getReactions(
+    request: { id: string; limit?: number; offset?: number },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetReactionsResponse>> {
     const queryParams = {
       limit: request?.limit,
       offset: request?.offset,
@@ -1314,7 +1464,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetReactionsResponse>
-    >('GET', '/api/v2/chat/messages/{id}/reactions', pathParams, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/messages/{id}/reactions',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['GetReactionsResponse']?.(response.body);
 
@@ -1323,6 +1481,7 @@ export class ChatApi {
 
   async queryReactions(
     request: QueryReactionsRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryReactionsResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1344,6 +1503,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryReactionsResponse']?.(response.body);
@@ -1353,6 +1513,7 @@ export class ChatApi {
 
   async translateMessage(
     request: TranslateMessageRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MessageActionResponse>> {
     const pathParams = {
       id: request?.id,
@@ -1370,6 +1531,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MessageActionResponse']?.(response.body);
@@ -1379,6 +1541,7 @@ export class ChatApi {
 
   async castPollVote(
     request: CastPollVoteRequest & { message_id: string; poll_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<PollVoteResponse>> {
     const pathParams = {
       message_id: request?.message_id,
@@ -1395,6 +1558,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollVoteResponse']?.(response.body);
@@ -1402,11 +1566,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deletePollVote(request: {
-    message_id: string;
-    poll_id: string;
-    vote_id: string;
-  }): Promise<StreamResponse<PollVoteResponse>> {
+  async deletePollVote(
+    request: { message_id: string; poll_id: string; vote_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<PollVoteResponse>> {
     const pathParams = {
       message_id: request?.message_id,
       poll_id: request?.poll_id,
@@ -1418,6 +1581,9 @@ export class ChatApi {
       '/api/v2/chat/messages/{message_id}/polls/{poll_id}/vote/{vote_id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['PollVoteResponse']?.(response.body);
@@ -1425,16 +1591,25 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteReminder(request: {
-    message_id: string;
-  }): Promise<StreamResponse<DeleteReminderResponse>> {
+  async deleteReminder(
+    request: { message_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteReminderResponse>> {
     const pathParams = {
       message_id: request?.message_id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteReminderResponse>
-    >('DELETE', '/api/v2/chat/messages/{message_id}/reminders', pathParams, undefined);
+    >(
+      'DELETE',
+      '/api/v2/chat/messages/{message_id}/reminders',
+      pathParams,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteReminderResponse']?.(response.body);
 
@@ -1443,6 +1618,7 @@ export class ChatApi {
 
   async updateReminder(
     request: UpdateReminderRequest & { message_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateReminderResponse>> {
     const pathParams = {
       message_id: request?.message_id,
@@ -1460,6 +1636,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateReminderResponse']?.(response.body);
@@ -1469,6 +1646,7 @@ export class ChatApi {
 
   async createReminder(
     request: CreateReminderRequest & { message_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ReminderResponseData>> {
     const pathParams = {
       message_id: request?.message_id,
@@ -1486,6 +1664,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['ReminderResponseData']?.(response.body);
@@ -1493,17 +1672,20 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getReplies(request: {
-    parent_id: string;
-    limit?: number;
-    id_gte?: string;
-    id_gt?: string;
-    id_lte?: string;
-    id_lt?: string;
-    id_around?: string;
-    sort?: Array<SortParamRequest>;
-    member_custom_include?: Array<string>;
-  }): Promise<StreamResponse<GetRepliesResponse>> {
+  async getReplies(
+    request: {
+      parent_id: string;
+      limit?: number;
+      id_gte?: string;
+      id_gt?: string;
+      id_lte?: string;
+      id_lt?: string;
+      id_around?: string;
+      sort?: Array<SortParamRequest>;
+      member_custom_include?: Array<string>;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetRepliesResponse>> {
     const queryParams = {
       limit: request?.limit,
       id_gte: request?.id_gte,
@@ -1523,6 +1705,9 @@ export class ChatApi {
       '/api/v2/chat/messages/{parent_id}/replies',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetRepliesResponse']?.(response.body);
@@ -1530,16 +1715,25 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async queryMessageFlags(request?: {
-    payload?: QueryMessageFlagsPayload;
-  }): Promise<StreamResponse<QueryMessageFlagsResponse>> {
+  async queryMessageFlags(
+    request?: { payload?: QueryMessageFlagsPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueryMessageFlagsResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<QueryMessageFlagsResponse>
-    >('GET', '/api/v2/chat/moderation/flags/message', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/moderation/flags/message',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['QueryMessageFlagsResponse']?.(response.body);
 
@@ -1548,6 +1742,8 @@ export class ChatApi {
 
   async muteChannel(
     request?: MuteChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<MuteChannelResponse>> {
     const body = {
       expiration: request?.expiration,
@@ -1563,6 +1759,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MuteChannelResponse']?.(response.body);
@@ -1572,6 +1769,8 @@ export class ChatApi {
 
   async unmuteChannel(
     request?: UnmuteChannelRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UnmuteResponse>> {
     const body = {
       expiration: request?.expiration,
@@ -1585,6 +1784,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UnmuteResponse']?.(response.body);
@@ -1592,32 +1792,50 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async queryBannedUsers(request?: {
-    payload?: QueryBannedUsersPayload;
-  }): Promise<StreamResponse<QueryBannedUsersResponse>> {
+  async queryBannedUsers(
+    request?: { payload?: QueryBannedUsersPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueryBannedUsersResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<QueryBannedUsersResponse>
-    >('GET', '/api/v2/chat/query_banned_users', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/query_banned_users',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['QueryBannedUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async queryFutureChannelBans(request?: {
-    payload?: QueryFutureChannelBansPayload;
-  }): Promise<StreamResponse<QueryFutureChannelBansResponse>> {
+  async queryFutureChannelBans(
+    request?: { payload?: QueryFutureChannelBansPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueryFutureChannelBansResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<QueryFutureChannelBansResponse>
-    >('GET', '/api/v2/chat/query_future_channel_bans', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/chat/query_future_channel_bans',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['QueryFutureChannelBansResponse']?.(response.body);
 
@@ -1626,6 +1844,8 @@ export class ChatApi {
 
   async queryReminders(
     request?: QueryRemindersRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryRemindersResponse>> {
     const body = {
       limit: request?.limit,
@@ -1644,6 +1864,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryRemindersResponse']?.(response.body);
@@ -1651,9 +1872,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async search(request?: {
-    payload?: SearchPayload;
-  }): Promise<StreamResponse<SearchResponse>> {
+  async search(
+    request?: { payload?: SearchPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<SearchResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
@@ -1663,6 +1885,9 @@ export class ChatApi {
       '/api/v2/chat/search',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['SearchResponse']?.(response.body);
@@ -1676,6 +1901,7 @@ export class ChatApi {
       watch?: boolean;
       connection_id?: string;
     },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<SyncResponse>> {
     const queryParams = {
       with_inaccessible_cids: request?.with_inaccessible_cids,
@@ -1694,6 +1920,7 @@ export class ChatApi {
       queryParams,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['SyncResponse']?.(response.body);
@@ -1703,6 +1930,7 @@ export class ChatApi {
 
   async queryThreads(
     request?: QueryThreadsRequest & { connection_id?: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryThreadsResponse>> {
     const queryParams = {
       connection_id: request?.connection_id,
@@ -1721,21 +1949,32 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<QueryThreadsResponse>
-    >('POST', '/api/v2/chat/threads', undefined, queryParams, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/chat/threads',
+      undefined,
+      queryParams,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['QueryThreadsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getThread(request: {
-    message_id: string;
-    watch?: boolean;
-    connection_id?: string;
-    reply_limit?: number;
-    participant_limit?: number;
-    member_limit?: number;
-  }): Promise<StreamResponse<GetThreadResponse>> {
+  async getThread(
+    request: {
+      message_id: string;
+      watch?: boolean;
+      connection_id?: string;
+      reply_limit?: number;
+      participant_limit?: number;
+      member_limit?: number;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetThreadResponse>> {
     const queryParams = {
       watch: request?.watch,
       connection_id: request?.connection_id,
@@ -1752,6 +1991,9 @@ export class ChatApi {
       '/api/v2/chat/threads/{message_id}',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetThreadResponse']?.(response.body);
@@ -1761,6 +2003,7 @@ export class ChatApi {
 
   async updateThreadPartial(
     request: UpdateThreadPartialRequest & { message_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateThreadPartialResponse>> {
     const pathParams = {
       message_id: request?.message_id,
@@ -1779,6 +2022,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpdateThreadPartialResponse']?.(response.body);
@@ -1786,17 +2030,30 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async unreadCounts(): Promise<StreamResponse<WrappedUnreadCountsResponse>> {
+  async unreadCounts(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<WrappedUnreadCountsResponse>> {
     const response = await this.apiClient.sendRequest<
       StreamResponse<WrappedUnreadCountsResponse>
-    >('GET', '/api/v2/chat/unread', undefined, undefined);
+    >(
+      'GET',
+      '/api/v2/chat/unread',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['WrappedUnreadCountsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteDevice(request: { id: string }): Promise<StreamResponse<Response>> {
+  async deleteDevice(
+    request: { id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       id: request?.id,
     };
@@ -1806,6 +2063,9 @@ export class ChatApi {
       '/api/v2/devices',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -1813,17 +2073,31 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async listDevices(): Promise<StreamResponse<ListDevicesResponse>> {
+  async listDevices(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ListDevicesResponse>> {
     const response = await this.apiClient.sendRequest<
       StreamResponse<ListDevicesResponse>
-    >('GET', '/api/v2/devices', undefined, undefined);
+    >(
+      'GET',
+      '/api/v2/devices',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['ListDevicesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async createDevice(request: CreateDeviceRequest): Promise<StreamResponse<Response>> {
+  async createDevice(
+    request: CreateDeviceRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const body = {
       id: request?.id,
       push_provider: request?.push_provider,
@@ -1839,6 +2113,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -1848,6 +2123,8 @@ export class ChatApi {
 
   async createGuest(
     request: CreateGuestRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<CreateGuestResponse>> {
     const body = {
       user: request?.user,
@@ -1855,17 +2132,25 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<CreateGuestResponse>
-    >('POST', '/api/v2/guest', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/guest',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['CreateGuestResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async longPoll(request?: {
-    connection_id?: string;
-    json?: WSAuthMessage;
-  }): Promise<StreamResponse<{}>> {
+  async longPoll(
+    request?: { connection_id?: string; json?: WSAuthMessage },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<{}>> {
     const queryParams = {
       connection_id: request?.connection_id,
       json: request?.json,
@@ -1876,6 +2161,9 @@ export class ChatApi {
       '/api/v2/longpoll',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['{}']?.(response.body);
@@ -1883,7 +2171,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getOG(request: { url: string }): Promise<StreamResponse<GetOGResponse>> {
+  async getOG(
+    request: { url: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetOGResponse>> {
     const queryParams = {
       url: request?.url,
     };
@@ -1893,6 +2184,9 @@ export class ChatApi {
       '/api/v2/og',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetOGResponse']?.(response.body);
@@ -1900,7 +2194,11 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async createPoll(request: CreatePollRequest): Promise<StreamResponse<PollResponse>> {
+  async createPoll(
+    request: CreatePollRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<PollResponse>> {
     const body = {
       name: request?.name,
       allow_answers: request?.allow_answers,
@@ -1922,6 +2220,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollResponse']?.(response.body);
@@ -1929,7 +2228,11 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async updatePoll(request: UpdatePollRequest): Promise<StreamResponse<PollResponse>> {
+  async updatePoll(
+    request: UpdatePollRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<PollResponse>> {
     const body = {
       id: request?.id,
       name: request?.name,
@@ -1951,6 +2254,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollResponse']?.(response.body);
@@ -1960,6 +2264,8 @@ export class ChatApi {
 
   async queryPolls(
     request?: QueryPollsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryPollsResponse>> {
     const body = {
       limit: request?.limit,
@@ -1976,6 +2282,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryPollsResponse']?.(response.body);
@@ -1983,7 +2290,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deletePoll(request: { poll_id: string }): Promise<StreamResponse<Response>> {
+  async deletePoll(
+    request: { poll_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const pathParams = {
       poll_id: request?.poll_id,
     };
@@ -1993,6 +2303,9 @@ export class ChatApi {
       '/api/v2/polls/{poll_id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -2000,7 +2313,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getPoll(request: { poll_id: string }): Promise<StreamResponse<PollResponse>> {
+  async getPoll(
+    request: { poll_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<PollResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
     };
@@ -2010,6 +2326,9 @@ export class ChatApi {
       '/api/v2/polls/{poll_id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['PollResponse']?.(response.body);
@@ -2019,6 +2338,7 @@ export class ChatApi {
 
   async updatePollPartial(
     request: UpdatePollPartialRequest & { poll_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<PollResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
@@ -2035,6 +2355,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollResponse']?.(response.body);
@@ -2044,6 +2365,7 @@ export class ChatApi {
 
   async createPollOption(
     request: CreatePollOptionRequest & { poll_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<PollOptionResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
@@ -2060,6 +2382,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollOptionResponse']?.(response.body);
@@ -2069,6 +2392,7 @@ export class ChatApi {
 
   async updatePollOption(
     request: UpdatePollOptionRequest & { poll_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<PollOptionResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
@@ -2086,6 +2410,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollOptionResponse']?.(response.body);
@@ -2093,10 +2418,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deletePollOption(request: {
-    poll_id: string;
-    option_id: string;
-  }): Promise<StreamResponse<Response>> {
+  async deletePollOption(
+    request: { poll_id: string; option_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const pathParams = {
       poll_id: request?.poll_id,
       option_id: request?.option_id,
@@ -2107,6 +2432,9 @@ export class ChatApi {
       '/api/v2/polls/{poll_id}/options/{option_id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -2114,10 +2442,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getPollOption(request: {
-    poll_id: string;
-    option_id: string;
-  }): Promise<StreamResponse<PollOptionResponse>> {
+  async getPollOption(
+    request: { poll_id: string; option_id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<PollOptionResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
       option_id: request?.option_id,
@@ -2128,6 +2456,9 @@ export class ChatApi {
       '/api/v2/polls/{poll_id}/options/{option_id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['PollOptionResponse']?.(response.body);
@@ -2137,6 +2468,7 @@ export class ChatApi {
 
   async queryPollVotes(
     request: QueryPollVotesRequest & { poll_id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<PollVotesResponse>> {
     const pathParams = {
       poll_id: request?.poll_id,
@@ -2156,6 +2488,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['PollVotesResponse']?.(response.body);
@@ -2165,6 +2498,8 @@ export class ChatApi {
 
   async updatePushNotificationPreferences(
     request: UpsertPushPreferencesRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpsertPushPreferencesResponse>> {
     const body = {
       preferences: request?.preferences,
@@ -2172,20 +2507,31 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<UpsertPushPreferencesResponse>
-    >('POST', '/api/v2/push_preferences', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/push_preferences',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['UpsertPushPreferencesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async searchRoles(request: {
-    query: string;
-    limit?: number;
-    name_gt?: string;
-    role_type?: string;
-    include_global_roles?: boolean;
-  }): Promise<StreamResponse<SearchRolesResponse>> {
+  async searchRoles(
+    request: {
+      query: string;
+      limit?: number;
+      name_gt?: string;
+      role_type?: string;
+      include_global_roles?: boolean;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<SearchRolesResponse>> {
     const queryParams = {
       query: request?.query,
       limit: request?.limit,
@@ -2196,14 +2542,25 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<SearchRolesResponse>
-    >('GET', '/api/v2/roles/search', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/roles/search',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['SearchRolesResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteFile(request?: { url?: string }): Promise<StreamResponse<Response>> {
+  async deleteFile(
+    request?: { url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       url: request?.url,
     };
@@ -2213,6 +2570,9 @@ export class ChatApi {
       '/api/v2/uploads/file',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -2222,6 +2582,8 @@ export class ChatApi {
 
   async uploadFile(
     request?: FileUploadRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<FileUploadResponse>> {
     const body = {
       file: request?.file,
@@ -2235,6 +2597,7 @@ export class ChatApi {
       undefined,
       body,
       'multipart/form-data',
+      requestOptions,
     );
 
     decoders['FileUploadResponse']?.(response.body);
@@ -2242,7 +2605,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteImage(request?: { url?: string }): Promise<StreamResponse<Response>> {
+  async deleteImage(
+    request?: { url?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       url: request?.url,
     };
@@ -2252,6 +2618,9 @@ export class ChatApi {
       '/api/v2/uploads/image',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -2261,6 +2630,8 @@ export class ChatApi {
 
   async uploadImage(
     request?: ImageUploadRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<ImageUploadResponse>> {
     const body = {
       file: request?.file,
@@ -2270,19 +2641,30 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<ImageUploadResponse>
-    >('POST', '/api/v2/uploads/image', undefined, undefined, body, 'multipart/form-data');
+    >(
+      'POST',
+      '/api/v2/uploads/image',
+      undefined,
+      undefined,
+      body,
+      'multipart/form-data',
+      requestOptions,
+    );
 
     decoders['ImageUploadResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async listUserGroups(request?: {
-    limit?: number;
-    id_gt?: string;
-    created_at_gt?: string;
-    team_id?: string;
-  }): Promise<StreamResponse<ListUserGroupsResponse>> {
+  async listUserGroups(
+    request?: {
+      limit?: number;
+      id_gt?: string;
+      created_at_gt?: string;
+      team_id?: string;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ListUserGroupsResponse>> {
     const queryParams = {
       limit: request?.limit,
       id_gt: request?.id_gt,
@@ -2292,7 +2674,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<ListUserGroupsResponse>
-    >('GET', '/api/v2/usergroups', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/usergroups',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['ListUserGroupsResponse']?.(response.body);
 
@@ -2301,6 +2691,8 @@ export class ChatApi {
 
   async createUserGroup(
     request: CreateUserGroupRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<CreateUserGroupResponse>> {
     const body = {
       name: request?.name,
@@ -2312,20 +2704,31 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<CreateUserGroupResponse>
-    >('POST', '/api/v2/usergroups', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/usergroups',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['CreateUserGroupResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async searchUserGroups(request: {
-    query: string;
-    limit?: number;
-    name_gt?: string;
-    id_gt?: string;
-    team_id?: string;
-  }): Promise<StreamResponse<SearchUserGroupsResponse>> {
+  async searchUserGroups(
+    request: {
+      query: string;
+      limit?: number;
+      name_gt?: string;
+      id_gt?: string;
+      team_id?: string;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<SearchUserGroupsResponse>> {
     const queryParams = {
       query: request?.query,
       limit: request?.limit,
@@ -2336,17 +2739,25 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<SearchUserGroupsResponse>
-    >('GET', '/api/v2/usergroups/search', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/usergroups/search',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['SearchUserGroupsResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteUserGroup(request: {
-    id: string;
-    team_id?: string;
-  }): Promise<StreamResponse<Response>> {
+  async deleteUserGroup(
+    request: { id: string; team_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<Response>> {
     const queryParams = {
       team_id: request?.team_id,
     };
@@ -2359,6 +2770,9 @@ export class ChatApi {
       '/api/v2/usergroups/{id}',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['Response']?.(response.body);
@@ -2366,10 +2780,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getUserGroup(request: {
-    id: string;
-    team_id?: string;
-  }): Promise<StreamResponse<GetUserGroupResponse>> {
+  async getUserGroup(
+    request: { id: string; team_id?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetUserGroupResponse>> {
     const queryParams = {
       team_id: request?.team_id,
     };
@@ -2379,7 +2793,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetUserGroupResponse>
-    >('GET', '/api/v2/usergroups/{id}', pathParams, queryParams);
+    >(
+      'GET',
+      '/api/v2/usergroups/{id}',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['GetUserGroupResponse']?.(response.body);
 
@@ -2388,6 +2810,7 @@ export class ChatApi {
 
   async updateUserGroup(
     request: UpdateUserGroupRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateUserGroupResponse>> {
     const pathParams = {
       id: request?.id,
@@ -2400,7 +2823,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<UpdateUserGroupResponse>
-    >('PUT', '/api/v2/usergroups/{id}', pathParams, undefined, body, 'application/json');
+    >(
+      'PUT',
+      '/api/v2/usergroups/{id}',
+      pathParams,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['UpdateUserGroupResponse']?.(response.body);
 
@@ -2409,6 +2840,7 @@ export class ChatApi {
 
   async addUserGroupMembers(
     request: AddUserGroupMembersRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<AddUserGroupMembersResponse>> {
     const pathParams = {
       id: request?.id,
@@ -2428,6 +2860,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['AddUserGroupMembersResponse']?.(response.body);
@@ -2437,6 +2870,7 @@ export class ChatApi {
 
   async removeUserGroupMembers(
     request: RemoveUserGroupMembersRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<RemoveUserGroupMembersResponse>> {
     const pathParams = {
       id: request?.id,
@@ -2455,6 +2889,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['RemoveUserGroupMembersResponse']?.(response.body);
@@ -2462,9 +2897,10 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async queryUsers(request?: {
-    payload?: QueryUsersPayload;
-  }): Promise<StreamResponse<QueryUsersResponse>> {
+  async queryUsers(
+    request?: { payload?: QueryUsersPayload },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueryUsersResponse>> {
     const queryParams = {
       payload: request?.payload,
     };
@@ -2474,6 +2910,9 @@ export class ChatApi {
       '/api/v2/users',
       undefined,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['QueryUsersResponse']?.(response.body);
@@ -2483,6 +2922,8 @@ export class ChatApi {
 
   async updateUsersPartial(
     request: UpdateUsersPartialRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateUsersResponse>> {
     const body = {
       users: request?.users,
@@ -2490,7 +2931,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<UpdateUsersResponse>
-    >('PATCH', '/api/v2/users', undefined, undefined, body, 'application/json');
+    >(
+      'PATCH',
+      '/api/v2/users',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['UpdateUsersResponse']?.(response.body);
 
@@ -2499,6 +2948,8 @@ export class ChatApi {
 
   async updateUsers(
     request: UpdateUsersRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpdateUsersResponse>> {
     const body = {
       users: request?.users,
@@ -2506,17 +2957,35 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<UpdateUsersResponse>
-    >('POST', '/api/v2/users', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/users',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['UpdateUsersResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getBlockedUsers(): Promise<StreamResponse<GetBlockedUsersResponse>> {
+  async getBlockedUsers(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetBlockedUsersResponse>> {
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetBlockedUsersResponse>
-    >('GET', '/api/v2/users/block', undefined, undefined);
+    >(
+      'GET',
+      '/api/v2/users/block',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['GetBlockedUsersResponse']?.(response.body);
 
@@ -2525,6 +2994,8 @@ export class ChatApi {
 
   async blockUsers(
     request: BlockUsersRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<BlockUsersResponse>> {
     const body = {
       blocked_user_id: request?.blocked_user_id,
@@ -2537,6 +3008,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['BlockUsersResponse']?.(response.body);
@@ -2544,10 +3016,20 @@ export class ChatApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getUserLiveLocations(): Promise<StreamResponse<SharedLocationsResponse>> {
+  async getUserLiveLocations(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<SharedLocationsResponse>> {
     const response = await this.apiClient.sendRequest<
       StreamResponse<SharedLocationsResponse>
-    >('GET', '/api/v2/users/live_locations', undefined, undefined);
+    >(
+      'GET',
+      '/api/v2/users/live_locations',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['SharedLocationsResponse']?.(response.body);
 
@@ -2556,6 +3038,8 @@ export class ChatApi {
 
   async updateLiveLocation(
     request: UpdateLiveLocationRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<SharedLocationResponse>> {
     const body = {
       message_id: request?.message_id,
@@ -2573,6 +3057,7 @@ export class ChatApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['SharedLocationResponse']?.(response.body);
@@ -2582,6 +3067,8 @@ export class ChatApi {
 
   async unblockUsers(
     request: UnblockUsersRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UnblockUsersResponse>> {
     const body = {
       blocked_user_id: request?.blocked_user_id,
@@ -2589,7 +3076,15 @@ export class ChatApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<UnblockUsersResponse>
-    >('POST', '/api/v2/users/unblock', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/users/unblock',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['UnblockUsersResponse']?.(response.body);
 

--- a/src/gen/moderation/ModerationApi.ts
+++ b/src/gen/moderation/ModerationApi.ts
@@ -1,4 +1,4 @@
-import type { ApiClient, StreamResponse } from '../../gen-imports';
+import type { ApiClient, StreamRequestOptions, StreamResponse } from '../../gen-imports';
 import type {
   AppealRequest,
   AppealResponse,
@@ -44,12 +44,15 @@ import { decoders } from '../model-decoders/decoders';
 export class ModerationApi {
   constructor(public readonly apiClient: ApiClient) {}
 
-  async getActionConfig(request?: {
-    queue_type?: string;
-    entity_type?: string;
-    exclude_defaults?: boolean;
-    only_defaults?: boolean;
-  }): Promise<StreamResponse<GetActionConfigResponse>> {
+  async getActionConfig(
+    request?: {
+      queue_type?: string;
+      entity_type?: string;
+      exclude_defaults?: boolean;
+      only_defaults?: boolean;
+    },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetActionConfigResponse>> {
     const queryParams = {
       queue_type: request?.queue_type,
       entity_type: request?.entity_type,
@@ -59,7 +62,15 @@ export class ModerationApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<GetActionConfigResponse>
-    >('GET', '/api/v2/moderation/action_config', undefined, queryParams);
+    >(
+      'GET',
+      '/api/v2/moderation/action_config',
+      undefined,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['GetActionConfigResponse']?.(response.body);
 
@@ -68,6 +79,8 @@ export class ModerationApi {
 
   async upsertActionConfig(
     request: UpsertActionConfigRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpsertActionConfigResponse>> {
     const body = {
       action: request?.action,
@@ -89,6 +102,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpsertActionConfigResponse']?.(response.body);
@@ -98,6 +112,8 @@ export class ModerationApi {
 
   async bulkUpsertActionConfig(
     request: BulkUpsertActionConfigRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<BulkUpsertActionConfigResponse>> {
     const body = {
       action_configs: request?.action_configs,
@@ -112,6 +128,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['BulkUpsertActionConfigResponse']?.(response.body);
@@ -121,6 +138,8 @@ export class ModerationApi {
 
   async bulkDeleteActionConfig(
     request: BulkDeleteActionConfigRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<BulkDeleteActionConfigResponse>> {
     const body = {
       ids: request?.ids,
@@ -135,6 +154,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['BulkDeleteActionConfigResponse']?.(response.body);
@@ -142,23 +162,36 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteActionConfig(request: {
-    id: string;
-  }): Promise<StreamResponse<DeleteActionConfigResponse>> {
+  async deleteActionConfig(
+    request: { id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteActionConfigResponse>> {
     const pathParams = {
       id: request?.id,
     };
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteActionConfigResponse>
-    >('DELETE', '/api/v2/moderation/action_config/{id}', pathParams, undefined);
+    >(
+      'DELETE',
+      '/api/v2/moderation/action_config/{id}',
+      pathParams,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteActionConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async appeal(request: AppealRequest): Promise<StreamResponse<AppealResponse>> {
+  async appeal(
+    request: AppealRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<AppealResponse>> {
     const body = {
       appeal_reason: request?.appeal_reason,
       entity_id: request?.entity_id,
@@ -174,6 +207,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['AppealResponse']?.(response.body);
@@ -181,7 +215,10 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getAppeal(request: { id: string }): Promise<StreamResponse<GetAppealResponse>> {
+  async getAppeal(
+    request: { id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetAppealResponse>> {
     const pathParams = {
       id: request?.id,
     };
@@ -191,6 +228,9 @@ export class ModerationApi {
       '/api/v2/moderation/appeal/{id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetAppealResponse']?.(response.body);
@@ -200,6 +240,8 @@ export class ModerationApi {
 
   async queryAppeals(
     request?: QueryAppealsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryAppealsResponse>> {
     const body = {
       limit: request?.limit,
@@ -218,6 +260,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryAppealsResponse']?.(response.body);
@@ -227,6 +270,8 @@ export class ModerationApi {
 
   async bulkActionAppeals(
     request: BulkActionAppealsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<BulkActionAppealsResponse>> {
     const body = {
       action_type: request?.action_type,
@@ -247,6 +292,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['BulkActionAppealsResponse']?.(response.body);
@@ -254,7 +300,11 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async ban(request: BanRequest): Promise<StreamResponse<ModerationBanResponse>> {
+  async ban(
+    request: BanRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ModerationBanResponse>> {
     const body = {
       target_user_id: request?.target_user_id,
       banned_by_id: request?.banned_by_id,
@@ -269,7 +319,15 @@ export class ModerationApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<ModerationBanResponse>
-    >('POST', '/api/v2/moderation/ban', undefined, undefined, body, 'application/json');
+    >(
+      'POST',
+      '/api/v2/moderation/ban',
+      undefined,
+      undefined,
+      body,
+      'application/json',
+      requestOptions,
+    );
 
     decoders['ModerationBanResponse']?.(response.body);
 
@@ -278,6 +336,8 @@ export class ModerationApi {
 
   async upsertConfig(
     request: UpsertConfigRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<UpsertConfigResponse>> {
     const body = {
       key: request?.key,
@@ -311,6 +371,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UpsertConfigResponse']?.(response.body);
@@ -318,10 +379,10 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async deleteConfig(request: {
-    key: string;
-    team?: string;
-  }): Promise<StreamResponse<DeleteModerationConfigResponse>> {
+  async deleteConfig(
+    request: { key: string; team?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<DeleteModerationConfigResponse>> {
     const queryParams = {
       team: request?.team,
     };
@@ -331,17 +392,25 @@ export class ModerationApi {
 
     const response = await this.apiClient.sendRequest<
       StreamResponse<DeleteModerationConfigResponse>
-    >('DELETE', '/api/v2/moderation/config/{key}', pathParams, queryParams);
+    >(
+      'DELETE',
+      '/api/v2/moderation/config/{key}',
+      pathParams,
+      queryParams,
+      undefined,
+      undefined,
+      requestOptions,
+    );
 
     decoders['DeleteModerationConfigResponse']?.(response.body);
 
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getConfig(request: {
-    key: string;
-    team?: string;
-  }): Promise<StreamResponse<GetConfigResponse>> {
+  async getConfig(
+    request: { key: string; team?: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<GetConfigResponse>> {
     const queryParams = {
       team: request?.team,
     };
@@ -354,6 +423,9 @@ export class ModerationApi {
       '/api/v2/moderation/config/{key}',
       pathParams,
       queryParams,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['GetConfigResponse']?.(response.body);
@@ -363,6 +435,8 @@ export class ModerationApi {
 
   async queryModerationConfigs(
     request?: QueryModerationConfigsRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryModerationConfigsResponse>> {
     const body = {
       limit: request?.limit,
@@ -381,6 +455,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryModerationConfigsResponse']?.(response.body);
@@ -388,7 +463,11 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async flag(request: FlagRequest): Promise<StreamResponse<FlagItemResponse>> {
+  async flag(
+    request: FlagRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<FlagItemResponse>> {
     const body = {
       entity_id: request?.entity_id,
       entity_type: request?.entity_type,
@@ -405,6 +484,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['FlagItemResponse']?.(response.body);
@@ -412,7 +492,11 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async mute(request: MuteRequest): Promise<StreamResponse<MuteResponse>> {
+  async mute(
+    request: MuteRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<MuteResponse>> {
     const body = {
       target_ids: request?.target_ids,
       timeout: request?.timeout,
@@ -425,6 +509,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['MuteResponse']?.(response.body);
@@ -432,12 +517,17 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async listQueues(): Promise<StreamResponse<ListQueuesResponse>> {
+  async listQueues(
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<ListQueuesResponse>> {
     const response = await this.apiClient.sendRequest<StreamResponse<ListQueuesResponse>>(
       'GET',
       '/api/v2/moderation/queues',
       undefined,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['ListQueuesResponse']?.(response.body);
@@ -445,7 +535,11 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async createQueue(request: CreateQueueRequest): Promise<StreamResponse<QueueResponse>> {
+  async createQueue(
+    request: CreateQueueRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueueResponse>> {
     const body = {
       name: request?.name,
       type: request?.type,
@@ -461,6 +555,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueueResponse']?.(response.body);
@@ -468,7 +563,10 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async getQueue(request: { id: string }): Promise<StreamResponse<QueueResponse>> {
+  async getQueue(
+    request: { id: string },
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<QueueResponse>> {
     const pathParams = {
       id: request?.id,
     };
@@ -478,6 +576,9 @@ export class ModerationApi {
       '/api/v2/moderation/queues/{id}',
       pathParams,
       undefined,
+      undefined,
+      undefined,
+      requestOptions,
     );
 
     decoders['QueueResponse']?.(response.body);
@@ -487,6 +588,7 @@ export class ModerationApi {
 
   async updateQueue(
     request: UpdateQueueRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueueResponse>> {
     const pathParams = {
       id: request?.id,
@@ -505,6 +607,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueueResponse']?.(response.body);
@@ -514,6 +617,7 @@ export class ModerationApi {
 
   async deleteQueue(
     request: DeleteQueueRequest & { id: string },
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueueResponse>> {
     const pathParams = {
       id: request?.id,
@@ -527,6 +631,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueueResponse']?.(response.body);
@@ -536,6 +641,8 @@ export class ModerationApi {
 
   async queryReviewQueue(
     request?: QueryReviewQueueRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<QueryReviewQueueResponse>> {
     const body = {
       exclude_default_action_config: request?.exclude_default_action_config,
@@ -559,6 +666,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['QueryReviewQueueResponse']?.(response.body);
@@ -568,6 +676,8 @@ export class ModerationApi {
 
   async submitAction(
     request: SubmitActionRequest,
+
+    requestOptions?: StreamRequestOptions,
   ): Promise<StreamResponse<SubmitActionResponse>> {
     const body = {
       action_type: request?.action_type,
@@ -602,6 +712,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['SubmitActionResponse']?.(response.body);
@@ -609,7 +720,11 @@ export class ModerationApi {
     return { ...response.body, metadata: response.metadata };
   }
 
-  async unmute(request: UnmuteRequest): Promise<StreamResponse<UnmuteResponse>> {
+  async unmute(
+    request: UnmuteRequest,
+
+    requestOptions?: StreamRequestOptions,
+  ): Promise<StreamResponse<UnmuteResponse>> {
     const body = {
       target_ids: request?.target_ids,
     };
@@ -621,6 +736,7 @@ export class ModerationApi {
       undefined,
       body,
       'application/json',
+      requestOptions,
     );
 
     decoders['UnmuteResponse']?.(response.body);

--- a/src/moderation.ts
+++ b/src/moderation.ts
@@ -1,4 +1,8 @@
-import type { ModerationFlagOptions, UnmuteUserResponse } from './types';
+import type {
+  ModerationFlagOptions,
+  StreamRequestOptions,
+  UnmuteUserResponse,
+} from './types';
 import type { StreamChat } from './client';
 import { ModerationApi } from './gen/moderation/ModerationApi';
 
@@ -23,16 +27,26 @@ export class Moderation extends ModerationApi {
    * @param reason - Reason for flagging the user.
    * @param options - Additional options for flagging the user (optional, defaults to `{}`).
    * @param options.custom - Additional data to be stored with the flag (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The flag response.
    */
-  flagUser(flaggedUserId: string, reason: string, options: ModerationFlagOptions = {}) {
-    return this.flag({
-      entity_type: MODERATION_ENTITY_TYPES.user,
-      entity_id: flaggedUserId,
-      entity_creator_id: '',
-      reason,
-      ...options,
-    });
+  flagUser(
+    flaggedUserId: string,
+    reason: string,
+    options: ModerationFlagOptions = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return this.flag(
+      {
+        entity_type: MODERATION_ENTITY_TYPES.user,
+        entity_id: flaggedUserId,
+        entity_creator_id: '',
+        reason,
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**
@@ -42,16 +56,26 @@ export class Moderation extends ModerationApi {
    * @param reason - Reason for flagging the message.
    * @param options - Additional options for flagging the message (optional, defaults to `{}`).
    * @param options.custom - Additional data to be stored with the flag (optional).
+   * @param requestOptions - Per-request options such as an abort `signal`. Never serialized
+   *   into the request (optional).
    * @returns The flag response.
    */
-  flagMessage(messageId: string, reason: string, options: ModerationFlagOptions = {}) {
-    return this.flag({
-      entity_type: MODERATION_ENTITY_TYPES.message,
-      entity_id: messageId,
-      entity_creator_id: '',
-      reason,
-      ...options,
-    });
+  flagMessage(
+    messageId: string,
+    reason: string,
+    options: ModerationFlagOptions = {},
+    requestOptions?: StreamRequestOptions,
+  ) {
+    return this.flag(
+      {
+        entity_type: MODERATION_ENTITY_TYPES.message,
+        entity_id: messageId,
+        entity_creator_id: '',
+        reason,
+        ...options,
+      },
+      requestOptions,
+    );
   }
 
   /**

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1206,6 +1206,26 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
    *
    * It will return the response from the execution if it succeeded.
    *
+   * A task payload is the argument list of the method being replayed, so it carries that
+   * method's trailing `requestOptions` too. How far an `AbortSignal` in there survives depends on
+   * the path:
+   *
+   * - Step 1 above never leaves memory, so the signal is live and the call is cancellable exactly
+   *   as it would be outside the queue. This is the common case.
+   * - A task that reaches the pending-tasks table survives only as far as the concrete
+   *   implementation's storage allows. {@link OfflineDBApi.addPendingTask} and
+   *   {@link OfflineDBApi.getPendingTasks} make no serialization promise either way: a store that
+   *   hands back the object it was given keeps the signal live, while one that encodes the payload
+   *   (as a SQLite-backed store does) revives it as an inert `{}`. Across a process restart it is
+   *   always the latter.
+   *
+   * `ApiClient` drops a signal it cannot listen to rather than handing it to axios (which would
+   * throw), so a replay that lost its signal simply runs uncancellable.
+   *
+   * Note that cancelling is not a way to drop a queued task after the fact — an aborted request is
+   * a definitive rejection ({@link isEphemeral} is `false` for it), so it is never queued in the
+   * first place.
+   *
    * @param task - the pending task we want to execute
    */
   public queueTask = async <T>({ task }: { task: PendingTask }): Promise<T> => {
@@ -1233,7 +1253,8 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
    * i.e. the failure is a definitive rejection rather than an ephemeral/retryable one. A task is
    * kept in the queue only when its error is {@link isEphemeral} (connection/network error or a
    * retryable server code). A non retryable server response (i.e bad request, not allowed etc) is
-   * skipped since retrying it would never succeed.
+   * skipped since retrying it would never succeed, and so is a request the caller cancelled via
+   * `StreamRequestOptions.signal` - replaying it would defeat the point of aborting.
    *
    * @param error - The error thrown while executing the failed task.
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -981,4 +981,8 @@ export type UpdateMessageAPIResponse = StreamResponse<UpdateMessageResponse>;
 export type GiphyVersions = keyof Images;
 export type TranslationLanguage = TranslateMessageRequest['language'];
 
+export type StreamRequestOptions = {
+  signal?: AbortSignal;
+};
+
 export * from './gen/models';

--- a/test/unit/api-client.test.ts
+++ b/test/unit/api-client.test.ts
@@ -66,6 +66,21 @@ describe('ApiClient request options', () => {
     expect(firstConfig().signal?.aborted).to.be.true;
   });
 
+  // An offline-db task payload carries the method's `requestOptions`, so a task that was
+  // persisted and replayed after a restart arrives with a JSON-revived signal: an inert `{}`.
+  // Axios reaches for `signal.addEventListener` unconditionally, so it must not get through.
+  it('drops a signal that did not survive JSON persistence', async () => {
+    const revived = JSON.parse(
+      JSON.stringify({ signal: new AbortController().signal }),
+    ) as { signal: AbortSignal };
+
+    expect(revived.signal.addEventListener).to.be.undefined;
+
+    await sendRequest(revived);
+
+    expect(firstConfig().signal).to.be.undefined;
+  });
+
   it('applies the options to a single request only', async () => {
     const controller = new AbortController();
 

--- a/test/unit/api-client.test.ts
+++ b/test/unit/api-client.test.ts
@@ -1,0 +1,89 @@
+import { AxiosError } from 'axios';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getClientWithUser } from './test-utils/getClient';
+
+import type { StreamChat } from '../../src/client';
+
+describe('ApiClient request options', () => {
+  let client: StreamChat;
+  let requestSpy: ReturnType<typeof vi.spyOn>;
+
+  const configOfCall = (index: number) =>
+    requestSpy.mock.calls[index][0] as { signal?: AbortSignal };
+  const firstConfig = () => configOfCall(0);
+
+  beforeEach(() => {
+    client = getClientWithUser();
+    requestSpy = vi
+      .spyOn(client.axiosInstance, 'request')
+      .mockResolvedValue({ data: {}, status: 200, headers: {} });
+  });
+
+  const sendRequest = (options?: { signal?: AbortSignal }) =>
+    client.api.sendRequest(
+      'GET',
+      '/api/v2/chat/channels',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      options,
+    );
+
+  it('sends no signal when no options are given', async () => {
+    await sendRequest();
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(firstConfig().signal).to.be.undefined;
+  });
+
+  it('forwards the signal from the request options to axios', async () => {
+    const controller = new AbortController();
+
+    await sendRequest({ signal: controller.signal });
+
+    expect(firstConfig().signal).to.equal(controller.signal);
+  });
+
+  it('aborts the request when the caller aborts the signal', async () => {
+    const controller = new AbortController();
+
+    await sendRequest({ signal: controller.signal });
+    const { signal } = firstConfig();
+
+    expect(signal?.aborted).to.be.false;
+    controller.abort();
+    expect(signal?.aborted).to.be.true;
+  });
+
+  it('forwards an already aborted signal', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await sendRequest({ signal: controller.signal });
+
+    expect(firstConfig().signal?.aborted).to.be.true;
+  });
+
+  it('applies the options to a single request only', async () => {
+    const controller = new AbortController();
+
+    await sendRequest({ signal: controller.signal });
+    await sendRequest();
+
+    expect(configOfCall(1).signal).to.be.undefined;
+  });
+
+  it('keeps the same signal across retries', async () => {
+    const controller = new AbortController();
+    requestSpy.mockRejectedValueOnce(
+      Object.assign(new AxiosError('rate limited'), { status: 429 }),
+    );
+
+    await sendRequest({ signal: controller.signal });
+
+    expect(requestSpy).toHaveBeenCalledTimes(2);
+    expect(configOfCall(1).signal).to.equal(controller.signal);
+  });
+});

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -3039,6 +3039,17 @@ describe('send reaction flow', () => {
 			expect(channel._sendReaction).not.toHaveBeenCalled();
 		});
 
+		it('queues requestOptions alongside the request so replay forwards them', async () => {
+			const controller = new AbortController();
+
+			await channel.sendReaction(request, { signal: controller.signal });
+
+			expect(queueTaskSpy.mock.calls[0][0].task.payload).to.deep.equal([
+				request,
+				{ signal: controller.signal },
+			]);
+		});
+
 		it('falls back to _sendReaction if offlineDb throws', async () => {
 			client.offlineDb.queueTask.mockRejectedValue(new Error('Offline failure'));
 
@@ -3475,6 +3486,7 @@ describe('Channel.query — initial page size', () => {
 		// The initial open asks the server for exactly pageSize messages (not its larger default).
 		expect(getOrCreate).toHaveBeenCalledWith(
 			expect.objectContaining({ messages: { limit: 25 } }),
+			undefined,
 		);
 	});
 
@@ -3491,6 +3503,7 @@ describe('Channel.query — initial page size', () => {
 
 		expect(getOrCreate).toHaveBeenCalledWith(
 			expect.objectContaining({ messages: { limit: 80 } }),
+			undefined,
 		);
 	});
 });

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2621,9 +2621,15 @@ describe('Channel search', async () => {
 			.mockResolvedValue({ body: {}, metadata: {} });
 		const payload = { query: 'query', sort: [{ field: 'updated_at', direction: -1 }] };
 		await channel.search({ payload });
-		expect(sendRequest).toHaveBeenCalledWith('GET', '/api/v2/chat/search', undefined, {
-			payload,
-		});
+		expect(sendRequest).toHaveBeenCalledWith(
+			'GET',
+			'/api/v2/chat/search',
+			undefined,
+			{ payload },
+			undefined,
+			undefined,
+			undefined,
+		);
 	});
 	it('search with sorting by custom field', async () => {
 		const sendRequest = vi
@@ -2631,9 +2637,15 @@ describe('Channel search', async () => {
 			.mockResolvedValue({ body: {}, metadata: {} });
 		const payload = { query: 'query', sort: [{ field: 'custom_field', direction: -1 }] };
 		await channel.search({ payload });
-		expect(sendRequest).toHaveBeenCalledWith('GET', '/api/v2/chat/search', undefined, {
-			payload,
-		});
+		expect(sendRequest).toHaveBeenCalledWith(
+			'GET',
+			'/api/v2/chat/search',
+			undefined,
+			{ payload },
+			undefined,
+			undefined,
+			undefined,
+		);
 	});
 	it('sorting and offset works', async () => {
 		vi.spyOn(client.api, 'sendRequest').mockResolvedValue({ body: {}, metadata: {} });
@@ -3062,6 +3074,7 @@ describe('send reaction flow', () => {
 				undefined,
 				{ reaction, enforce_unique: true, skip_push: true },
 				'application/json',
+				undefined,
 			);
 		});
 
@@ -3300,11 +3313,14 @@ describe('message sending flow', () => {
 				undefined,
 				{
 					message,
+					include_channel_context: undefined,
+					include_mentioned_members: undefined,
 					keep_channel_hidden: undefined,
 					skip_enrich_url: undefined,
 					skip_push: true,
 				},
 				'application/json',
+				undefined,
 			);
 		});
 
@@ -3322,11 +3338,14 @@ describe('message sending flow', () => {
 				undefined,
 				{
 					message,
+					include_channel_context: undefined,
+					include_mentioned_members: undefined,
 					keep_channel_hidden: undefined,
 					skip_enrich_url: undefined,
 					skip_push: undefined,
 				},
 				'application/json',
+				undefined,
 			);
 		});
 	});

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1110,7 +1110,7 @@ describe('StreamChat.queryReactions', () => {
 		]);
 
 		expect(postStub).toHaveBeenCalledTimes(1);
-		expect(postStub).toHaveBeenCalledWith(request);
+		expect(postStub).toHaveBeenCalledWith(request, undefined);
 
 		expect(result).to.eql(postResponse);
 	});
@@ -1126,7 +1126,7 @@ describe('StreamChat.queryReactions', () => {
 		await client.queryReactionsAndHydrate(request);
 
 		expect(client.offlineDb.getReactions).not.toHaveBeenCalled();
-		expect(postStub).toHaveBeenCalledWith(request);
+		expect(postStub).toHaveBeenCalledWith(request, undefined);
 	});
 
 	it('should not dispatch event if offlineDb returns null', async () => {
@@ -1142,7 +1142,7 @@ describe('StreamChat.queryReactions', () => {
 
 		expect(client.offlineDb.getReactions).toHaveBeenCalledTimes(1);
 		expect(dispatchSpy).not.toHaveBeenCalled();
-		expect(postStub).toHaveBeenCalledWith(request);
+		expect(postStub).toHaveBeenCalledWith(request, undefined);
 	});
 
 	it('should log a warning if offlineDb.getReactions throws', async () => {
@@ -1167,12 +1167,15 @@ describe('StreamChat.queryReactions', () => {
 			}),
 		);
 		expect(dispatchSpy).not.toHaveBeenCalled();
-		expect(postStub).toHaveBeenCalledWith({
-			id: messageId,
-			filter,
-			sort,
-			limit: 50,
-		});
+		expect(postStub).toHaveBeenCalledWith(
+			{
+				id: messageId,
+				filter,
+				sort,
+				limit: 50,
+			},
+			undefined,
+		);
 
 		chatLoggerSystem.restoreDefaults();
 	});

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,5 +1,6 @@
-import { isErrorResponse } from '../../src/errors';
+import { isEphemeral, isErrorResponse } from '../../src/errors';
 
+import { CanceledError } from 'axios';
 import { describe, it, expect } from 'vitest';
 
 describe('error response', () => {
@@ -15,5 +16,25 @@ describe('error response', () => {
 	it('is not response with status code 2xx', () => {
 		expect(isErrorResponse({ status: 200 })).to.be.false;
 		expect(isErrorResponse({ status: 299 })).to.be.false;
+	});
+});
+
+describe('isEphemeral', () => {
+	it('is true when the server never responded', () => {
+		expect(isEphemeral(new Error('network down'))).to.be.true;
+	});
+	it('is true for a retryable server code', () => {
+		expect(isEphemeral({ code: 9, response: {} })).to.be.true; // RateLimitError
+	});
+	it('is false for a non-retryable server code', () => {
+		expect(isEphemeral({ code: 4, response: {} })).to.be.false; // InputError
+	});
+	// A cancelled request carries no `response`, so the no-response branch alone would call it
+	// ephemeral. It must not be: aborting is a caller decision, and treating it as transient would
+	// queue the request for replay and keep any optimistic local update.
+	it('is false for a cancelled request, despite it having no response', () => {
+		const canceled = new CanceledError('canceled');
+		expect(canceled.response).to.be.undefined;
+		expect(isEphemeral(canceled)).to.be.false;
 	});
 });

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -23,7 +23,7 @@ import { generateReadResponse } from '../test-utils/generateReadResponse';
 import { generatePendingTask } from '../test-utils/generatePendingTask';
 import { getClientWithUser } from '../test-utils/getClient';
 import * as utils from '../../../src/utils';
-import { AxiosError } from 'axios';
+import { AxiosError, CanceledError } from 'axios';
 import { MockOfflineDB } from './MockOfflineDB';
 
 describe('OfflineSupportApi', () => {
@@ -2005,6 +2005,13 @@ describe('OfflineSupportApi', () => {
 
         // Network/connection failure — server never responded → ephemeral → keep queued.
         expect(shouldSkipQueueingTask({} as AxiosError)).toBe(false);
+
+        // Caller cancelled via `StreamRequestOptions.signal`. Also has no `response`, but it is a
+        // deliberate rejection rather than a transient failure, so it is skipped — queueing it
+        // would replay on reconnect the very request the caller aborted.
+        expect(shouldSkipQueueingTask(new CanceledError('canceled') as AxiosError)).toBe(
+          true,
+        );
       });
 
       describe('queueTask', () => {
@@ -2314,6 +2321,74 @@ describe('OfflineSupportApi', () => {
 
           expect(clientChannelSpy).toHaveBeenCalledWith(task.channelType, task.channelId);
           expect(mockChannel._sendReaction).toHaveBeenCalledWith(...task.payload);
+        });
+
+        // A task payload is the replayed method's argument list, so it carries that method's
+        // trailing `requestOptions` too.
+        it('forwards requestOptions queued in the payload on replay', async () => {
+          const controller = new AbortController();
+          const task = generatePendingTask('send-reaction') as PendingTask;
+          const taskWithOptions = {
+            ...task,
+            payload: [task.payload[0], { signal: controller.signal }],
+          } as PendingTask;
+
+          await offlineDb['executeTask']({ task: taskWithOptions });
+
+          expect(mockChannel._sendReaction).toHaveBeenCalledWith(task.payload[0], {
+            signal: controller.signal,
+          });
+        });
+
+        // A task that reached the pending-tasks table was serialized, so its signal revives as
+        // an inert `{}`. Replay must still go through - ApiClient is what drops the dead signal.
+        it('replays a task whose persisted signal did not survive serialization', async () => {
+          const task = generatePendingTask('send-reaction') as PendingTask;
+          const persisted = JSON.parse(
+            JSON.stringify({
+              ...task,
+              payload: [task.payload[0], { signal: new AbortController().signal }],
+            }),
+          ) as PendingTask;
+
+          await offlineDb['executeTask']({ task: persisted });
+
+          expect(mockChannel._sendReaction).toHaveBeenCalledWith(persisted.payload[0], {
+            signal: {},
+          });
+        });
+
+        // Cancelling is not a way to shed a task: an aborted request is a definitive rejection, so
+        // `queueTask` must not stash it for replay on reconnect.
+        it('does not queue a task whose request the caller cancelled', async () => {
+          const handleAddPendingTaskSpy = vi
+            .spyOn(offlineDb as any, 'handleAddPendingTask')
+            .mockResolvedValue(undefined);
+          (client as any).wsConnection = { isHealthy: true };
+          (mockChannel._sendReaction as unknown as MockInstance).mockRejectedValue(
+            new CanceledError('canceled'),
+          );
+          const task = generatePendingTask('send-reaction') as PendingTask;
+
+          await expect(offlineDb.queueTask({ task })).rejects.toThrow(CanceledError);
+
+          expect(handleAddPendingTaskSpy).not.toHaveBeenCalled();
+        });
+
+        // Contrast: a genuine network failure is transient, so it IS queued.
+        it('queues a task that failed on a network error', async () => {
+          const handleAddPendingTaskSpy = vi
+            .spyOn(offlineDb as any, 'handleAddPendingTask')
+            .mockResolvedValue(undefined);
+          (client as any).wsConnection = { isHealthy: true };
+          (mockChannel._sendReaction as unknown as MockInstance).mockRejectedValue(
+            new Error('network down'),
+          );
+          const task = generatePendingTask('send-reaction') as PendingTask;
+
+          await expect(offlineDb.queueTask({ task })).rejects.toThrow('network down');
+
+          expect(handleAddPendingTaskSpy).toHaveBeenCalledTimes(1);
         });
 
         it('should call _deleteReaction for delete-reaction task', async () => {

--- a/test/unit/pagination/paginators/ChannelPaginator.test.ts
+++ b/test/unit/pagination/paginators/ChannelPaginator.test.ts
@@ -1283,18 +1283,21 @@ describe('ChannelPaginator', () => {
       });
 
       await paginator.query();
-      expect(queryChannelsSpy).toHaveBeenCalledWith({
-        filter_conditions: {
-          muted: {
-            $eq: true,
+      expect(queryChannelsSpy).toHaveBeenCalledWith(
+        {
+          filter_conditions: {
+            muted: {
+              $eq: true,
+            },
+            name: 'A',
           },
-          name: 'A',
+          sort: [{ field: 'has_unread', direction: -1 }],
+          limit: 22,
+          message_limit: 3,
+          offset: 0,
         },
-        sort: [{ field: 'has_unread', direction: -1 }],
-        limit: 22,
-        message_limit: 3,
-        offset: 0,
-      });
+        undefined,
+      );
     });
   });
 

--- a/test/unit/reactions.optimistic.test.ts
+++ b/test/unit/reactions.optimistic.test.ts
@@ -1,3 +1,4 @@
+import { CanceledError } from 'axios';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { formatMessage, StreamChat, Thread } from '../../src';
 import type {
@@ -253,6 +254,24 @@ describe('optimistic reactions', () => {
       const message = buildMessage();
       seed(channel, message);
       vi.spyOn(channel, 'sendReaction').mockRejectedValue(apiError(4));
+
+      await expect(
+        channel.addReactionWithLocalUpdate({
+          messageId: message.id,
+          reaction: { type: 'love' },
+        }),
+      ).rejects.toThrow();
+
+      expect(ownReactionTypes(channel.messagePaginator, message.id)).toEqual([]);
+    });
+
+    // A cancelled request has no `response`, like a network error, but it is a caller decision
+    // rather than something a reconnect will fix — so the optimistic reaction has to go, otherwise
+    // the UI would show a reaction that is never sent.
+    it('reverts when the caller cancelled the request', async () => {
+      const message = buildMessage();
+      seed(channel, message);
+      vi.spyOn(channel, 'sendReaction').mockRejectedValue(new CanceledError('canceled'));
 
       await expect(
         channel.addReactionWithLocalUpdate({

--- a/v9-to-v10-migration-guide-methods.md
+++ b/v9-to-v10-migration-guide-methods.md
@@ -22,6 +22,17 @@ Before applying any per-method entry below, apply these repo-wide renames — th
 
 The `secret` parameter, `client.secret`, `client._isUsingServerAuth()`, and all server-only methods are gone. Where a v9 method took a `user_id?` / `userID?` / `currentUserID?` override, that argument has been dropped in v10 (the connected user is always used).
 
+**Every request-issuing method takes an optional trailing `requestOptions`.** The per-method signatures below omit it for readability, but every method generated from the OpenAPI spec ends with `requestOptions?: StreamRequestOptions` — currently `{ signal?: AbortSignal }` — and so does every hand-written wrapper around one, on both `StreamChat` and `Channel`. It is always **last**, immediately after the method's own arguments, and is never serialized into the request:
+
+```ts
+const controller = new AbortController();
+await client.search({ payload: { query: 'hello' } }, { signal: controller.signal });
+await channel.queryMembers({ payload: { limit: 10 } }, { signal: controller.signal });
+controller.abort();
+```
+
+This replaces v9's `client.createAbortControllerForNextRequest()` — see [below](#clientcreateabortcontrollerfornextrequest). The four upload methods (`client.uploadFile_` / `uploadImage_`, `channel.sendFile` / `sendImage`) are the exception: they keep their wider v9 `axiosRequestConfig` parameter, which already carries `signal` alongside `onUploadProgress`.
+
 ---
 
 ## StreamChat
@@ -378,6 +389,32 @@ client.api.sendFile(url, uri, name?, contentType?, user?, axiosRequestConfig?);
 ```
 
 `client.api` is a new getter returning the internal `ApiClient` instance.
+
+#### `client.createAbortControllerForNextRequest`
+
+**REMOVED.** Pass an `AbortSignal` through the target method's trailing `requestOptions` instead.
+
+```ts
+// v9 — arm a controller, and whichever request happened to go out next picked it up
+const controller = client.createAbortControllerForNextRequest();
+const users = await client.queryUsers({ id: { $in: ['jane'] } });
+controller.abort();
+
+// v10 — hand the signal to the call you actually want to cancel
+const controller = new AbortController();
+const users = await client.queryUsers(
+  { payload: { filter_conditions: { id: { $in: ['jane'] } } } },
+  { signal: controller.signal },
+);
+controller.abort();
+```
+
+Why it went away: the v9 mechanism armed a single controller on the client and the **next** outgoing request consumed it, whichever one that turned out to be. With concurrent requests in flight there was no way to say which call the signal would land on. The v10 parameter is explicit per call.
+
+- **Where it is accepted:** every generated method and every hand-written wrapper around one — see the global note above.
+- **Last resort:** for a request with no wrapper at all, `client.api.sendRequest(method, url, pathParams, queryParams, body, contentType, { signal })` is the layer that reads the option and puts `signal` on the axios request config.
+- **Search sources** already do this internally: `BaseSearchSource` owns an `AbortController` per query and passes `SearchQueryOptions` (`{ signal }`, structurally the same type) into each source's `query()`, which forwards it as the request options. A custom `BaseSearchSource` subclass should forward the `options` argument it receives rather than arm anything itself.
+- **With offline support enabled:** cancelling a call that can be queued (`sendMessage`, `sendReaction`, `deleteReaction`, `updateMessage`, `deleteMessage`, `createDraft`, `deleteDraft`) does **not** queue it for replay — an aborted request is treated as a definitive rejection, and any optimistic local update is rolled back. Cancelling means the operation is dropped, not deferred.
 
 #### `client.uploadFile` / `client.uploadImage`
 

--- a/v9-to-v10-migration-guide-type-renames.md
+++ b/v9-to-v10-migration-guide-type-renames.md
@@ -12,7 +12,7 @@
 
 For every entry in the table below:
 
-1. Rewrite every occurrence of the v9 name (imports, type annotations, generic arguments, casts, JSDoc) to the v10 name. Match on **whole-word boundaries** — do not blindly replace substrings. Several v9 names appear as prefixes of unrelated identifiers (`PollVote` is a substring of `castPollVote`, `PollVoteResponseData`, `PollVoteChanged`; `ReminderResponse` is a substring of `ReminderResponseData`; `Mute` is a substring of `MuteResponse`, `MuteUserOptions`, `UserMuteResponse`, and many method/field names). Blind `s/PollVote/PollVoteResponseData/g` will corrupt method names and produce identifiers like `castPollVoteResponseData` that do not exist.
+1. Rewrite every occurrence of the v9 name (imports, type annotations, generic arguments, casts, JSDoc) to the v10 name. Match on **whole-word boundaries** — do not blindly replace substrings. Several v9 names appear as prefixes or suffixes of unrelated identifiers (`PollVote` is a substring of `castPollVote`, `PollVoteResponseData`, `PollVoteChanged`; `ReminderResponse` is a substring of `ReminderResponseData`; `Mute` is a substring of `MuteResponse`, `MuteUserOptions`, `UserMuteResponse`, and many method/field names; `RequestOptions` is a substring of `UploadRequestOptions`, which is a **different** type and is not renamed). Blind `s/PollVote/PollVoteResponseData/g` will corrupt method names and produce identifiers like `castPollVoteResponseData` that do not exist.
 2. Keep the import path unchanged — `import { X } from 'stream-chat'` still works with the v10 name.
 3. Do **not** rewrite string literals, JSDoc prose, or command-name data (e.g. `{ name: 'mute', description: 'Mute a user' }`) — only identifiers used in type positions.
 
@@ -64,6 +64,7 @@ v10 exposes two generated types whose names collide with v9 aliases that pointed
 | `QueryUserGroupsResponse`      | `StreamResponse<ListUserGroupsResponse>` | Was a hand-rolled `APIResponse & { user_groups: UserGroupResponse[] }`; v10 uses the generated `ListUserGroupsResponse` wrapped in `StreamResponse<...>`, which adds a `metadata: RequestMetadata` field alongside `duration` and `user_groups`. Callers that only destructure `user_groups` are unaffected.                                                                                                                                                   |
 | `ReadResponse`                 | `ReadStateResponse`                      | Per-user read state on a channel/thread.                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | `ReminderResponse`             | `ReminderResponseData`                   | The single-reminder entry returned by the reminders paginator. Note: this is only the type; helper names like `generateReminderResponse` in test utilities should stay as-is.                                                                                                                                                                                                                                                                                  |
+| `RequestOptions`               | `StreamRequestOptions`                   | Per-request options that are never serialized into the payload — still `{ signal?: AbortSignal }`, so the type itself is a 1:1 rename. **The positions that accept it changed**, see [below](#requestoptions--streamrequestoptions).                                                                                                                                                                                                                           |
 | `SharedLocationResponse`       | `SharedLocationResponseData`             | See collision note above — v10 also exports a different `SharedLocationResponse` from the generated shared-location endpoint. Use `SharedLocationResponseData` when replacing the v9 alias.                                                                                                                                                                                                                                                                    |
 | `StaticLocationPayload`        | `SharedLocation`                         | Payload for static (non-live) shared-location attachments.                                                                                                                                                                                                                                                                                                                                                                                                     |
 | `ThreadResponse`               | `ThreadStateResponse`                    | The v9 alias wrapped the generated `ThreadStateResponse` with a `custom` overlay. In v10 the custom-overlay pattern is dropped and `ThreadResponse` in `stream-chat` refers to the minimal generated shape — which is missing `read`, `latest_replies`, and `draft`. Anything using those fields must switch to `ThreadStateResponse`. (`thread_participants` and `parent_message` are on both shapes.) `generateThreadResponse` in test-utils keeps its name. |
@@ -109,6 +110,33 @@ v9 used this one alias for three endpoints. v10 gives each its own generated res
 | `client.markChannelsDelivered` → v10 `markDelivered` | `StreamResponse<MarkDeliveredResponse>` | none — `{ duration }` only. Read the event off the WS stream here. |
 
 Two things to watch on the `markRead` row: `event` became optional, so destructuring it needs narrowing; and `MarkReadResponseEvent` is a **narrower shape than the WS `Event` union** (`type: string` rather than the `'message.read'` literal, and none of the WS read-event extras such as `total_unread_count` / `unread_channels`). It is not assignable to `Event` — do not feed it to code that expects a WS event.
+
+## Rows where the type is unchanged but the call sites moved
+
+### `RequestOptions` → `StreamRequestOptions`
+
+The type is a 1:1 rename — both are `{ signal?: AbortSignal }`, "per-request options that are never part of the serialized request payload". `StreamRequestOptions` is exported from the package root like every other row here. What changed is **where you pass it**.
+
+In v9 it arrived two ways: as a trailing positional parameter (`requestOptions: RequestOptions = {}`) on a handful of hand-written client/channel methods, and as part of `ChannelStateOptions`, which composed `RequestOptions` so that `queryChannels` could carry the abort signal in the same bag as its state flags. In v10:
+
+- `ChannelStateOptions` **no longer composes it** — it is `{ offlineMode?; skipInitialization?; skipHydration?; withResponse? }` only. A `{ ..., signal }` passed there is no longer read.
+- Every method generated from the OpenAPI spec takes `requestOptions?: StreamRequestOptions` as its **last parameter, immediately after the single request object** — e.g. `chatApi.search(request, requestOptions)`.
+- Hand-written overrides in `client.ts` / `channel.ts` only accept it when they forward their arguments wholesale (`...args: Parameters<ChatApi['x']>`). Overrides that narrowed their signature to a single request object dropped the parameter.
+
+Mapping for the v9 methods that took a `RequestOptions`:
+
+| v9 call site                                                      | v10                                                                     |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `client.queryUsers(filters, sort, options, requestOptions)`       | `client.queryUsers(request, requestOptions)` — still accepted           |
+| `client.searchRoles(options, requestOptions)`                     | `client.searchRoles(request, requestOptions)` — still accepted          |
+| `client.searchUserGroups(options, requestOptions)`                | `client.searchUserGroups(request, requestOptions)` — still accepted     |
+| `client.search(filterConditions, query, options, requestOptions)` | `client.search(request)` — **no `requestOptions` parameter**            |
+| `client.queryChannelsRequestWithResponse(…, requestOptions)`      | `client.queryChannels(request)` — **no `requestOptions` parameter**     |
+| `channel.queryMembers(filters, sort, options, requestOptions)`    | `channel.queryMembers({ payload })` — **no `requestOptions` parameter** |
+
+For the last three there is currently no way to cancel through the wrapper — the override hides the generated method, and `ChatApi` itself is not exported from the package root. The remaining route is `client.api.sendRequest(method, url, pathParams, queryParams, body, contentType, { signal })`, which is the layer that reads the option and puts `signal` on the axios request config.
+
+v9 also had `client.createAbortControllerForNextRequest()`, which armed a controller that the next outgoing request picked up implicitly. That is **removed** — pass a `signal` through `StreamRequestOptions` instead.
 
 ## Types that are **not** renamed (kept as-is)
 

--- a/v9-to-v10-migration-guide-type-renames.md
+++ b/v9-to-v10-migration-guide-type-renames.md
@@ -117,26 +117,25 @@ Two things to watch on the `markRead` row: `event` became optional, so destructu
 
 The type is a 1:1 rename — both are `{ signal?: AbortSignal }`, "per-request options that are never part of the serialized request payload". `StreamRequestOptions` is exported from the package root like every other row here. What changed is **where you pass it**.
 
-In v9 it arrived two ways: as a trailing positional parameter (`requestOptions: RequestOptions = {}`) on a handful of hand-written client/channel methods, and as part of `ChannelStateOptions`, which composed `RequestOptions` so that `queryChannels` could carry the abort signal in the same bag as its state flags. In v10:
+In v9 it arrived two ways: as a trailing positional parameter (`requestOptions: RequestOptions = {}`) on a handful of hand-written client/channel methods, and as part of `ChannelStateOptions`, which composed `RequestOptions` so that `queryChannels` could carry the abort signal in the same bag as its state flags. In v10 there is exactly one way to pass it:
 
-- `ChannelStateOptions` **no longer composes it** — it is `{ offlineMode?; skipInitialization?; skipHydration?; withResponse? }` only. A `{ ..., signal }` passed there is no longer read.
-- Every method generated from the OpenAPI spec takes `requestOptions?: StreamRequestOptions` as its **last parameter, immediately after the single request object** — e.g. `chatApi.search(request, requestOptions)`.
-- Hand-written overrides in `client.ts` / `channel.ts` only accept it when they forward their arguments wholesale (`...args: Parameters<ChatApi['x']>`). Overrides that narrowed their signature to a single request object dropped the parameter.
+- **It is always the last parameter**, immediately after the method's own arguments — on every method generated from the OpenAPI spec (`chatApi.search(request, requestOptions)`) and on every hand-written wrapper around one, on both `StreamChat` and `Channel`.
+- `ChannelStateOptions` **no longer composes it** — it is `{ offlineMode?; skipInitialization?; skipHydration?; withResponse? }` only. A `{ ..., signal }` passed there is no longer read. `client.queryChannelsAndHydrate` takes `requestOptions` as its own third parameter, after `stateOptions`.
 
-Mapping for the v9 methods that took a `RequestOptions`:
+Mapping for the v9 methods that took a `RequestOptions` — all six still accept one, only the arguments ahead of it changed shape:
 
-| v9 call site                                                      | v10                                                                     |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| `client.queryUsers(filters, sort, options, requestOptions)`       | `client.queryUsers(request, requestOptions)` — still accepted           |
-| `client.searchRoles(options, requestOptions)`                     | `client.searchRoles(request, requestOptions)` — still accepted          |
-| `client.searchUserGroups(options, requestOptions)`                | `client.searchUserGroups(request, requestOptions)` — still accepted     |
-| `client.search(filterConditions, query, options, requestOptions)` | `client.search(request)` — **no `requestOptions` parameter**            |
-| `client.queryChannelsRequestWithResponse(…, requestOptions)`      | `client.queryChannels(request)` — **no `requestOptions` parameter**     |
-| `channel.queryMembers(filters, sort, options, requestOptions)`    | `channel.queryMembers({ payload })` — **no `requestOptions` parameter** |
+| v9 call site                                                      | v10                                                 |
+| ----------------------------------------------------------------- | --------------------------------------------------- |
+| `client.queryUsers(filters, sort, options, requestOptions)`       | `client.queryUsers(request, requestOptions)`        |
+| `client.searchRoles(options, requestOptions)`                     | `client.searchRoles(request, requestOptions)`       |
+| `client.searchUserGroups(options, requestOptions)`                | `client.searchUserGroups(request, requestOptions)`  |
+| `client.search(filterConditions, query, options, requestOptions)` | `client.search(request, requestOptions)`            |
+| `client.queryChannelsRequestWithResponse(…, requestOptions)`      | `client.queryChannels(request, requestOptions)`     |
+| `channel.queryMembers(filters, sort, options, requestOptions)`    | `channel.queryMembers({ payload }, requestOptions)` |
 
-For the last three there is currently no way to cancel through the wrapper — the override hides the generated method, and `ChatApi` itself is not exported from the package root. The remaining route is `client.api.sendRequest(method, url, pathParams, queryParams, body, contentType, { signal })`, which is the layer that reads the option and puts `signal` on the axios request config.
+For a request with no wrapper at all, `client.api.sendRequest(method, url, pathParams, queryParams, body, contentType, { signal })` is the layer that reads the option and puts `signal` on the axios request config.
 
-v9 also had `client.createAbortControllerForNextRequest()`, which armed a controller that the next outgoing request picked up implicitly. That is **removed** — pass a `signal` through `StreamRequestOptions` instead.
+v9 also had `client.createAbortControllerForNextRequest()`, which armed a controller that the **next** outgoing request picked up implicitly — with concurrent requests in flight, there was no telling which call the signal would land on. It is **removed**; pass a `signal` through `StreamRequestOptions` on the specific call instead. See `v9-to-v10-migration-guide-methods.md` for the before/after and the offline-queue interaction.
 
 ## Types that are **not** renamed (kept as-is)
 


### PR DESCRIPTION
## CLA

https://linear.app/stream/issue/REACT-1081/fix-createabortcontrollerfornextrequest-mechanism

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?
- Generated API methods all expose a `requestOptions` param - for now, we expose `signal`, same as `master`
- Every hand-written stream-chat-js method exposes `requestOptions` also
- `requestOptions` are also forwarded to offline tasks -> but since`signal` can't be serialized, they will be lost if the task needs to be persisted in db
- with this we can remove `createAbortControllerForNextRequest` 

## Changelog

-
