### PR TITLE
fix: do not reset channel unread count on thread read

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2007,15 +2007,9 @@ export class Channel {
       // delivery-report network sync below is skipped for it.
       case 'message.read_locally':
       case 'message.read':
-        // A thread read (`markRead({ thread_id })`) echoes back an event carrying
-        // `event.thread`. It concerns that thread alone — `Thread.subscribeRepliesRead`
-        // applies it — so none of the channel-scoped read state below may move, for any
-        // user: a reply being read says nothing about the channel messages around it.
-        // This also skips the delivery sync below; that only delays the next delivery
-        // report to the following `message.new` / `message.delivered` / channel query,
-        // which supersede it anyway (the report is a latest-delivered high-water mark).
-        // `markReadLocally()` never sets `thread`, so the shared placement above the
-        // `message.read_locally` label is inert for that event, not a behaviour change.
+        // Thread read events are handled indiscriminately within the reactive `thread` object, we can
+        // skip them here in order to ensure the channel does not get read incidentally when it should
+        // not.
         if (event.thread) break;
         if (event.user?.id && event.created_at) {
           const previousReadState = channelState.read[event.user.id];

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2007,6 +2007,16 @@ export class Channel {
       // delivery-report network sync below is skipped for it.
       case 'message.read_locally':
       case 'message.read':
+        // A thread read (`markRead({ thread_id })`) echoes back an event carrying
+        // `event.thread`. It concerns that thread alone — `Thread.subscribeRepliesRead`
+        // applies it — so none of the channel-scoped read state below may move, for any
+        // user: a reply being read says nothing about the channel messages around it.
+        // This also skips the delivery sync below; that only delays the next delivery
+        // report to the following `message.new` / `message.delivered` / channel query,
+        // which supersede it anyway (the report is a latest-delivered high-water mark).
+        // `markReadLocally()` never sets `thread`, so the shared placement above the
+        // `message.read_locally` label is inert for that event, not a behaviour change.
+        if (event.thread) break;
         if (event.user?.id && event.created_at) {
           const previousReadState = channelState.read[event.user.id];
           channelState.read[event.user.id] = {

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1050,6 +1050,14 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     }
 
     if (type === 'message.read' || type === 'notification.mark_read') {
+      // Mirrors the thread-read carve-out in `Channel._handleChannelEvent`, and like it
+      // covers `message.read` only — the event `markRead({ thread_id })` echoes back.
+      // `handleRead` is channel-scoped (cid-keyed), so persisting a thread read would store
+      // unread_messages: 0 for the whole channel and re-hydrate that 0 on the next restart.
+      // `notification.mark_read` is deliberately left alone: its in-memory counterpart in
+      // `StreamChat._handleClientEvent` does not check `thread`, and guarding only this layer
+      // would let the DB and the in-memory state disagree across a restart.
+      if (type === 'message.read' && event.thread) return [];
       return this.handleRead({ event, unreadMessages: 0, execute });
     }
 

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -1050,14 +1050,10 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     }
 
     if (type === 'message.read' || type === 'notification.mark_read') {
-      // Mirrors the thread-read carve-out in `Channel._handleChannelEvent`, and like it
-      // covers `message.read` only — the event `markRead({ thread_id })` echoes back.
-      // `handleRead` is channel-scoped (cid-keyed), so persisting a thread read would store
-      // unread_messages: 0 for the whole channel and re-hydrate that 0 on the next restart.
-      // `notification.mark_read` is deliberately left alone: its in-memory counterpart in
-      // `StreamChat._handleClientEvent` does not check `thread`, and guarding only this layer
-      // would let the DB and the in-memory state disagree across a restart.
-      if (type === 'message.read' && event.thread) return [];
+      // We make sure not to update channel reads (which is what's stored in
+      // the offline DB in any case) whenever we receive a read event for a
+      // a thread specifically.
+      if (event.thread) return [];
       return this.handleRead({ event, unreadMessages: 0, execute });
     }
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -1042,6 +1042,45 @@ describe('Channel _handleChannelEvent', function () {
 			expect(channel.state.read[anotherUser.id].unread_messages).toBe(initialCountUnread);
 			expect(onMessageRead).not.toHaveBeenCalled();
 		});
+
+		// Skipping the case also skips the delivery sync at its tail. Pinned because it is a
+		// deliberate behaviour change, not an oversight: the next `message.new` /
+		// `message.delivered` / channel query supersedes the report anyway.
+		it('should not sync delivery report candidates on a thread read', () => {
+			const syncDeliveredCandidates = vi.spyOn(client, 'syncDeliveredCandidates');
+			const event = {
+				...messageReadEvent,
+				thread: { parent_message_id: 'parent-message-id' },
+			};
+
+			channel._handleChannelEvent(event);
+
+			expect(syncDeliveredCandidates).not.toHaveBeenCalled();
+		});
+
+		// The stored fields above are only half of it: `countUnread()` re-derives the count from
+		// `read[user].last_read`, so an advanced cursor reproduces the reported 0 even with
+		// `unreadCount` guarded. This pins the value the integrator actually reads.
+		it('should keep lastRead() and countUnread() consistent after a thread read', () => {
+			// An unread channel message sent after the current user's last channel read but before
+			// the thread read - it must keep counting as unread once the thread is read.
+			channel.state.addMessagesSorted([
+				generateMsg({ date: new Date(1800).toISOString(), user: otherUser }),
+			]);
+			channel.state.read[user.id] = {
+				...initialReadState,
+				last_read: new Date(initialReadState.last_read),
+			};
+			const event = {
+				...messageReadEvent,
+				thread: { parent_message_id: 'parent-message-id' },
+			};
+
+			channel._handleChannelEvent(event);
+
+			expect(channel.lastRead().getTime()).toBe(1500);
+			expect(channel.countUnread(channel.lastRead())).toBe(1);
+		});
 	});
 
 	describe('message.delivered', () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -991,6 +991,57 @@ describe('Channel _handleChannelEvent', function () {
 				initialReadState.last_delivered_message_id,
 			);
 		});
+		// regression #1676: `markRead({ thread_id })` echoes a `message.read` carrying
+		// `event.thread`. It concerns the thread only — `Thread.subscribeRepliesRead` picks
+		// it up off the client event bus — so no channel read state may move.
+		it('should not touch channel read state for a thread read', () => {
+			channel.state.unreadCount = initialCountUnread;
+			channel.state.read[user.id] = initialReadState;
+			const onMessageRead = vi.spyOn(channel.messageReceiptsTracker, 'onMessageRead');
+			const event = {
+				...messageReadEvent,
+				thread: { parent_message_id: 'parent-message-id' },
+			};
+
+			channel._handleChannelEvent(event);
+
+			expect(channel.state.unreadCount).toBe(initialCountUnread);
+			expect(new Date(channel.state.read[user.id].last_read).getTime()).toBe(
+				new Date(initialReadState.last_read).getTime(),
+			);
+			expect(channel.state.read[user.id].last_read_message_id).toBe(
+				initialReadState.last_read_message_id,
+			);
+			expect(channel.state.read[user.id].unread_messages).toBe(initialCountUnread);
+			expect(onMessageRead).not.toHaveBeenCalled();
+		});
+
+		// The guard is not scoped to the connected user: another user reading a thread reply
+		// says nothing about the channel messages around it either, so their channel read
+		// marker (what "seen by" indicators render from) must not advance.
+		it('should not touch channel read state for another user’s thread read', () => {
+			const anotherUser = { id: 'another-user' };
+			channel.state.unreadCount = initialCountUnread;
+			channel.state.read[anotherUser.id] = initialReadState;
+			const onMessageRead = vi.spyOn(channel.messageReceiptsTracker, 'onMessageRead');
+			const event = {
+				...messageReadEvent,
+				user: anotherUser,
+				thread: { parent_message_id: 'parent-message-id' },
+			};
+
+			channel._handleChannelEvent(event);
+
+			expect(channel.state.unreadCount).toBe(initialCountUnread);
+			expect(new Date(channel.state.read[anotherUser.id].last_read).getTime()).toBe(
+				new Date(initialReadState.last_read).getTime(),
+			);
+			expect(channel.state.read[anotherUser.id].last_read_message_id).toBe(
+				initialReadState.last_read_message_id,
+			);
+			expect(channel.state.read[anotherUser.id].unread_messages).toBe(initialCountUnread);
+			expect(onMessageRead).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('message.delivered', () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -991,9 +991,7 @@ describe('Channel _handleChannelEvent', function () {
 				initialReadState.last_delivered_message_id,
 			);
 		});
-		// regression #1676: `markRead({ thread_id })` echoes a `message.read` carrying
-		// `event.thread`. It concerns the thread only — `Thread.subscribeRepliesRead` picks
-		// it up off the client event bus — so no channel read state may move.
+		// Tests against this issue: https://github.com/GetStream/stream-chat-js/issues/1676
 		it('should not touch channel read state for a thread read', () => {
 			channel.state.unreadCount = initialCountUnread;
 			channel.state.read[user.id] = initialReadState;
@@ -1016,9 +1014,6 @@ describe('Channel _handleChannelEvent', function () {
 			expect(onMessageRead).not.toHaveBeenCalled();
 		});
 
-		// The guard is not scoped to the connected user: another user reading a thread reply
-		// says nothing about the channel messages around it either, so their channel read
-		// marker (what "seen by" indicators render from) must not advance.
 		it('should not touch channel read state for another user’s thread read', () => {
 			const anotherUser = { id: 'another-user' };
 			channel.state.unreadCount = initialCountUnread;

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1915,6 +1915,43 @@ describe('OfflineSupportApi', () => {
             expect(result).toEqual([]);
           });
         });
+
+        // regression #1676: a thread read echoes `event.thread`. `handleRead` is cid-keyed,
+        // so persisting one would store unread_messages: 0 for the whole channel.
+        describe('thread reads', () => {
+          const threadEvent = (type: string) =>
+            ({
+              ...dummyEvent,
+              type,
+              thread: { parent_message_id: 'parent-message-id' },
+            }) as unknown as Event;
+
+          it('is a no-op for message.read carrying a thread', async () => {
+            const event = threadEvent('message.read');
+
+            const result = await offlineDb.handleEvent({ event });
+
+            expect(offlineDb.handleRead).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
+          });
+
+          // The carve-out covers `message.read` only, mirroring `Channel._handleChannelEvent`.
+          // `notification.mark_read` has no `thread` check in its in-memory counterpart
+          // (`StreamChat._handleClientEvent`), so guarding it here alone would let the DB and
+          // the in-memory state disagree across a restart.
+          it('still persists notification.mark_read carrying a thread', async () => {
+            const event = threadEvent('notification.mark_read');
+
+            const result = await offlineDb.handleEvent({ event });
+
+            expect(offlineDb.handleRead).toHaveBeenCalledWith({
+              event,
+              unreadMessages: 0,
+              execute: true,
+            });
+            expect(result).toEqual(['read']);
+          });
+        });
       });
     });
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1916,8 +1916,6 @@ describe('OfflineSupportApi', () => {
           });
         });
 
-        // regression #1676: a thread read echoes `event.thread`. `handleRead` is cid-keyed,
-        // so persisting one would store unread_messages: 0 for the whole channel.
         describe('thread reads', () => {
           const threadEvent = (type: string) =>
             ({

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -1935,21 +1935,15 @@ describe('OfflineSupportApi', () => {
             expect(result).toEqual([]);
           });
 
-          // The carve-out covers `message.read` only, mirroring `Channel._handleChannelEvent`.
-          // `notification.mark_read` has no `thread` check in its in-memory counterpart
-          // (`StreamChat._handleClientEvent`), so guarding it here alone would let the DB and
-          // the in-memory state disagree across a restart.
-          it('still persists notification.mark_read carrying a thread', async () => {
+          // `handleRead` writes `unread_messages: 0` for this event type too, so a
+          // thread-scoped `notification.mark_read` would zero the whole channel just the same.
+          it('is a no-op for notification.mark_read carrying a thread', async () => {
             const event = threadEvent('notification.mark_read');
 
             const result = await offlineDb.handleEvent({ event });
 
-            expect(offlineDb.handleRead).toHaveBeenCalledWith({
-              event,
-              unreadMessages: 0,
-              execute: true,
-            });
-            expect(result).toEqual(['read']);
+            expect(offlineDb.handleRead).not.toHaveBeenCalled();
+            expect(result).toEqual([]);
           });
         });
       });


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

Fixes #1676.

### What

`channel.markRead({ thread_id })` marks a thread read, but the `message.read` event the
server echoes back was zeroing the **channel** unread count. Reading a thread reply made
still-unread channel messages disappear from the badge.

A `message.read` / `message.read_locally` carrying `event.thread` now early-outs of the
channel-scoped read branch in `Channel._handleChannelEvent` before any of it runs. The
offline DB gets the matching carve-out.

### Why

The `case 'message.read_locally': case 'message.read':` branch is entirely channel-scoped
and ran unconditionally, including for thread-scoped read events. Nothing in it looked at
`event.thread`, so five channel-scoped writes fired for an event that only concerns a
thread:

| write | why it is wrong for a thread read |
| --- | --- |
| `read[user].last_read = event.created_at` | advances the **channel** read cursor to the thread-read time |
| `read[user].last_read_message_id` | stores a thread **reply** id as the channel's last-read message |
| `read[user].unread_messages = 0` | claims the channel has no unread messages |
| `messageReceiptsTracker.onMessageRead(...)` | moves the read receipt marker behind channel "seen by" indicators |
| `channelState.unreadCount = 0` | the reported symptom |

The issue suggests gating the last of those on `isOwnEvent && !isThreadRead`. That fixes
the visible number but leaves `read[user].last_read` advanced, and everything that
re-derives from that cursor reproduces the same wrong `0`:

- `countUnread(lastRead)` (`src/channel.ts:1491`) counts messages newer than `last_read`;
  with the cursor past the unread message it returns `0` regardless of the guard.
- `channel.truncated` recomputes `unreadCount = this.countUnread(...)`.
- State hydration sets `state.unreadCount = read[user].unread_messages`, so a re-`watch`
  or reconnect restores the wrong `0`.

So the guard belongs at the top of the case, not on one line inside it — one early-out
covers all five writes and is a smaller diff than the per-line version.

`event.thread` as the discriminator is what the SDK already uses: `Thread.subscribeRepliesRead`
(`src/thread.ts:418`) returns early unless `event.thread` is present and
`event.thread.parent_message_id === this.id`. Thread read state is applied there, off the
client event bus, so nothing is lost by the channel ignoring the event.

### How

`src/channel.ts` — one early-out at the top of the case:

```ts
case 'message.read_locally':
case 'message.read':
  if (event.thread) break;
```

`break` exits the switch, not the method, so the post-switch `watcher_count` update still
runs. `_callChannelListeners` is dispatched separately by the client (`src/client.ts:1419`
vs `1425`), so `channel.on('message.read', …)` subscribers still receive the event — only
channel *state* mutation is skipped. `markReadLocally()` never sets `thread`, so the
`message.read_locally` arm is inert.

`src/offline-support/offline_support_api.ts` — the same carve-out, `message.read` only:

```ts
if (type === 'message.read' && event.thread) return [];
```

`handleRead` is cid-keyed and channel-scoped, so without this a thread read persisted
`unread_messages: 0` for the whole channel and hydration restored that `0` on restart —
the in-memory fix alone would not have survived an app restart with offline support on.

Scoped to `message.read` deliberately: `notification.mark_read` has no `event.thread`
check in its in-memory counterpart (`StreamChat._handleClientEvent`), so guarding it only
in the DB layer would let the two disagree across a restart.

### Behaviour change worth flagging

The guard is not scoped to the connected user, so **another user's** thread read no longer
advances their channel read marker either. That is deliberate — `read[userId].last_read` is
the channel read cursor, and advancing it because someone read a thread reply would make
"seen by" claim they had seen channel messages they never opened. A wrong receipt seemed
worse than a missing one, but it does affect what downstream SDKs render, so flagging it
rather than burying it. Pinned by a test; happy to narrow it to the own-user path if you
would rather keep the previous behaviour there.

`client.syncDeliveredCandidates([this])` also no longer fires on a thread read. It still
runs on `message.new`, `message.delivered` and after a channel query, and the delivery
report is a latest-delivered high-water mark, so the following one supersedes it.

### Two assumptions, stated rather than buried

1. That a thread read should leave the channel unread count alone is the reporter's reading
   of correct behaviour — no maintainer has commented on the issue, so it is not a ruling.
   If the intended semantics are different, say so and I will close this or rework it.
2. The one premise not statically provable: that the server never sends `event.thread` on a
   *channel*-level read. `src/thread.ts:418` already relies on it and
   `test/unit/threads.test.ts:767` encodes it, but I could not verify it against the backend.

### Out of scope

`src/channel.ts:2238` (`notification.mark_unread`) looks thread-blind in the same way, but
it keys off `event.thread_id` rather than `event.thread` (`src/thread.ts:336`), so this
guard would not catch it. Unreported and a different code path — left alone to keep the
diff to what closes #1676. Happy to file a follow-up.

### Tests

4 new tests, all watched failing with the guard removed and passing with it restored:

- `message.read` carrying `thread` leaves `unreadCount`, `last_read`, `last_read_message_id`
  and `unread_messages` untouched, and does not call `messageReceiptsTracker.onMessageRead`.
- The same for another user's thread read.
- Offline: `message.read` carrying `thread` does not reach `handleRead`.
- Offline: `notification.mark_read` carrying `thread` still does, pinning the narrow scope.

The pre-existing "should update channel read state produced for current user" test covers
the other direction — a `message.read` with no `thread` still zeroes `unreadCount` — and
stays green, so the guard does not over-fire.

```
baseline   78 files, 3077 passed, 1 skipped, 0 failed
this PR    78 files, 3081 passed, 1 skipped, 0 failed
```

`yarn lint` and `yarn types` both clean. `yarn test-types` not run locally — it needs live
API credentials; leaving it to CI.

## Changelog

- Fix `channel.state.unreadCount` being reset to `0` when marking a thread as read.
