### PR TITLE
ci(release): analyze commits with the conventionalcommits preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -19,7 +19,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "angular",
+        "preset": "conventionalcommits",
         "releaseRules": [
           {
             "type": "chore",


### PR DESCRIPTION
## Why

[Run 32373483292](https://github.com/GetStream/stream-chat-js/actions/runs/32373483292) succeeded and released nothing:

```
ℹ  Found git tag v10.0.0-rc.4 associated with version 10.0.0-rc.4 on branch release-v10
ℹ  Found 1 commits since last release
ℹ  Analyzing commit: feat(i18n)!: share the translation runtime as stream-chat/i18n (#1830)
ℹ  Analysis of 1 commits complete: no release
ℹ  There are no relevant changes, so no new version is released.
```

`@semantic-release/commit-analyzer` was configured with the **angular** preset, whose header pattern is:

```js
/^(\w*)(?:\((.*)\))?: (.*)$/
```

There is no slot for `!` between the scope and the colon, so a `feat(i18n)!:` header fails to match **entirely** — not just in its breaking marker. Parsing 40cf0629 with each preset:

| preset | `type` | `scope` | BREAKING notes |
| --- | --- | --- | --- |
| `angular` | `undefined` | `undefined` | 0 |
| `conventionalcommits` | `feat` | `i18n` | 1 |

With `type` and `notes` both empty nothing can match — not the custom `releaseRules`, and not the built-in defaults (`{breaking: true → major}`, `{type: 'feat' → minor}`). Those defaults were reachable: custom rules are tried first and the built-ins are the fallback. There is no `BREAKING CHANGE:` footer in the body either, which is the only other thing angular's parser reads.

## Three things this reconciles

- `release-notes-generator` in this same config **already** uses `conventionalcommits`, so the two plugins disagreed. The notes would have rendered a breaking feature the analyzer never saw.
- commitlint accepts the `!` form — the "Validate PR Title" check passed on that exact title — so we lint for a convention the release pipeline cannot act on.
- The analyzer now understands both `!` and a `BREAKING CHANGE:` footer, rather than only the footer.

## Verification

Replayed both presets through the real `analyzeCommits` over the last 400 commits on `master` and `release-v10`:

```
analyzed 400 commits
verdict changes: 1
  40cf0629 none -> major          feat(i18n)!: share the translation runtime as stream-chat/i18n (#1830)
angular  tally: {"none":165,"minor":103,"patch":127,"major":5}
convcomm tally: {"none":164,"minor":103,"patch":127,"major":6}
```

Exactly one verdict changes; the other 399 are identical. Also confirmed the analyzer returns `major` when driven from `.releaserc.json` as written, so the preset resolves — `conventional-changelog-conventionalcommits` is already a devDependency.

## After this merges

Re-running Release from `release-v10` still finds only 40cf0629 since `v10.0.0-rc.4`, and will now cut **`10.0.0-rc.5`**. That is what unblocks [stream-chat-react#3271](https://github.com/GetStream/stream-chat-react/pull/3271) and [stream-chat-react-native#3777](https://github.com/GetStream/stream-chat-react-native/pull/3777), whose CI currently compiles against published rc.3 and so cannot see the `./i18n` subpath.

`master` carries the identical angular config and the same latent bug, but no `!` commit has hit it yet. Worth the same one-line change there before one does.