### PR TITLE
fix(i18n)!: reject from init() and drop the Streami18n brand static

### DIFF
--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -105,9 +105,6 @@ export class Streami18n<
   C extends AnyTranslationCatalog = AnyTranslationCatalog,
   Bundled extends string = never,
 > {
-  /** Marks instances across bundle copies, where `instanceof` silently fails. */
-  static readonly brand = Symbol.for('stream-chat.Streami18n');
-
   readonly i18nInstance: I18nInstance = i18next.createInstance();
 
   readonly state: StateStore<Streami18nState<C, Bundled>>;

--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -253,51 +253,63 @@ export class Streami18n<
    * Memoized, so two independent consumers — a UI SDK's chat root and its overlay host — share one
    * initialization.
    *
-   * An i18next failure does **not** reject: neither UI SDK awaits this, so a rejection would surface
-   * as an unhandled rejection and the memo would latch it for the process lifetime. It is logged
-   * instead, leaving the instance *degraded but safe*: `state.initialized` stays false, which is what
-   * keeps the methods below off a dead i18next instance, and `t` remains the default translator, so
-   * every call site still renders its inline English. There is no retry — construct a new instance.
+   * **Rejects with the original error if initialization fails.** Nothing is caught or logged here, so
+   * the failure is reported once, by whoever handles it: an integrator awaiting this sees the real
+   * error rather than having to notice a log line, and a bug in i18next configuration is loud instead
+   * of silent.
    *
-   * One path does escape: an integrator `logger` that throws is called from the `catch` itself, so it
-   * rejects out of here. Rare enough not to guard, but it is why this is not an absolute guarantee.
+   * Rejecting does not mean the instance is unusable. It is left *degraded but safe*: `initialized`
+   * stays false, which is what keeps {@link Streami18n.registerTranslation} and
+   * {@link Streami18n.setLanguage} off a dead i18next instance, and `t` remains the default
+   * translator, so every call site still renders its inline English rather than a blank or a dotted
+   * key. The promise reports the failure; the store keeps the UI alive. Those are separate concerns.
+   *
+   * A caller that ignores the returned promise gets an unhandled rejection — which is the point. Both
+   * UI SDKs call this from an effect and catch it, reporting through {@link Streami18n.logger}.
+   *
+   * The memo is cleared on failure, so a later call retries rather than replaying one rejection for
+   * the lifetime of the instance. Concurrent callers still share the in-flight promise, which is what
+   * the memo is for.
    */
   init(): Promise<Streami18nState<C, Bundled>> {
-    this.initPromise ??= this.runInit();
-    return this.initPromise;
+    if (this.initPromise) return this.initPromise;
+
+    const pending = this.runInit();
+    this.initPromise = pending;
+
+    // Bookkeeping only. The handler attaches to a *derived* promise, so it does not mark `pending`
+    // itself as handled -- that one is returned bare and still reaches the caller's `catch`.
+    pending.catch(() => {
+      if (this.initPromise === pending) this.initPromise = undefined;
+    });
+
+    return pending;
   }
 
   private async runInit(): Promise<Streami18nState<C, Bundled>> {
-    // Everything is inside the `try` -- see `init()` for why an i18next failure must not reject.
-    try {
-      this.validateCurrentLanguage();
-      this.assertPluralRulesCoverage(this.currentLanguage);
+    this.validateCurrentLanguage();
+    this.assertPluralRulesCoverage(this.currentLanguage);
 
-      const dayjsLocale = this.dayjsLocales[this.currentLanguage];
-      if (dayjsLocale) this.addOrUpdateLocale(this.currentLanguage, dayjsLocale);
+    const dayjsLocale = this.dayjsLocales[this.currentLanguage];
+    if (dayjsLocale) this.addOrUpdateLocale(this.currentLanguage, dayjsLocale);
 
-      const t = await this.i18nInstance.init({
-        ...this.i18nextConfig,
-        lng: this.currentLanguage,
-        resources: this.i18nextResources(),
-      });
+    const t = await this.i18nInstance.init({
+      ...this.i18nextConfig,
+      lng: this.currentLanguage,
+      resources: this.i18nextResources(),
+    });
 
-      this.registerFormatters();
+    this.registerFormatters();
 
-      // After init, so post-processors attach to a live instance and buffered translators flush.
-      Object.entries(this.translationBuilderTopics).forEach(([topic, Topic]) => {
-        this.translationBuilder.registerTopic(topic, Topic);
-      });
+    // After init, so post-processors attach to a live instance and buffered translators flush.
+    Object.entries(this.translationBuilderTopics).forEach(([topic, Topic]) => {
+      this.translationBuilder.registerTopic(topic, Topic);
+    });
 
-      this.state.partialNext({
-        initialized: true,
-        ...(this.tOverridden
-          ? {}
-          : { t: t as unknown as StreamTFunctionFor<C, Bundled> }),
-      });
-    } catch (error) {
-      this.logger(`Streami18n: initialization failed: ${describeError(error)}`);
-    }
+    this.state.partialNext({
+      initialized: true,
+      ...(this.tOverridden ? {} : { t: t as unknown as StreamTFunctionFor<C, Bundled> }),
+    });
 
     return this.state.getLatestValue();
   }

--- a/src/i18n/Streami18n.ts
+++ b/src/i18n/Streami18n.ts
@@ -248,28 +248,11 @@ export class Streami18n<
   }
 
   /**
-   * Initializes i18next. Idempotent and safe to call concurrently.
+   * Initializes i18next. Memoized, so concurrent callers share one initialization.
    *
-   * Memoized, so two independent consumers — a UI SDK's chat root and its overlay host — share one
-   * initialization.
-   *
-   * **Rejects with the original error if initialization fails.** Nothing is caught or logged here, so
-   * the failure is reported once, by whoever handles it: an integrator awaiting this sees the real
-   * error rather than having to notice a log line, and a bug in i18next configuration is loud instead
-   * of silent.
-   *
-   * Rejecting does not mean the instance is unusable. It is left *degraded but safe*: `initialized`
-   * stays false, which is what keeps {@link Streami18n.registerTranslation} and
-   * {@link Streami18n.setLanguage} off a dead i18next instance, and `t` remains the default
-   * translator, so every call site still renders its inline English rather than a blank or a dotted
-   * key. The promise reports the failure; the store keeps the UI alive. Those are separate concerns.
-   *
-   * A caller that ignores the returned promise gets an unhandled rejection — which is the point. Both
-   * UI SDKs call this from an effect and catch it, reporting through {@link Streami18n.logger}.
-   *
-   * The memo is cleared on failure, so a later call retries rather than replaying one rejection for
-   * the lifetime of the instance. Concurrent callers still share the in-flight promise, which is what
-   * the memo is for.
+   * **Rejects on failure**, so handle it. The instance stays usable either way: `initialized` stays
+   * false, keeping {@link Streami18n.registerTranslation} and {@link Streami18n.setLanguage} off a
+   * dead i18next instance, and `t` keeps returning each call site's inline English.
    */
   init(): Promise<Streami18nState<C, Bundled>> {
     if (this.initPromise) return this.initPromise;
@@ -277,8 +260,8 @@ export class Streami18n<
     const pending = this.runInit();
     this.initPromise = pending;
 
-    // Bookkeeping only. The handler attaches to a *derived* promise, so it does not mark `pending`
-    // itself as handled -- that one is returned bare and still reaches the caller's `catch`.
+    // Clear the memo so a later call retries. Attached to a derived promise, so `pending` stays
+    // unhandled and still reaches the caller's `catch`.
     pending.catch(() => {
       if (this.initPromise === pending) this.initPromise = undefined;
     });

--- a/test/unit/i18n/Streami18n.test.ts
+++ b/test/unit/i18n/Streami18n.test.ts
@@ -678,12 +678,8 @@ describe('Streami18n — a failed setLanguage rolls back', () => {
 });
 
 /**
- * A failed `init()` rejects, and leaves the instance degraded but *safe*.
- *
- * Two separate guarantees, and the point is that they hold together. The promise rejects with the
- * real error, so a caller is told rather than left to notice a log line. And `initialized` stays
- * false, because it means "i18next is usable" -- `registerTranslation` and `setLanguage` both branch
- * on it, and a `true` there sends them into an instance whose own init rejected.
+ * A failed `init()` rejects, *and* leaves the instance usable. Both hold together: `initialized`
+ * means "i18next is usable", and `registerTranslation` / `setLanguage` branch on it.
  */
 describe('Streami18n — a failed init()', () => {
   beforeEach(() => {
@@ -702,7 +698,7 @@ describe('Streami18n — a failed init()', () => {
     await expect(i18n.init()).rejects.toThrow('i18next exploded');
   });
 
-  /** Reported once, by whoever handles the rejection -- so core must not also log it. */
+  /** Reported once, by whoever handles the rejection. */
   it('does not log, leaving the report to the caller', async () => {
     const logger = vi.fn();
     const i18n = failing(logger);
@@ -739,11 +735,7 @@ describe('Streami18n — a failed init()', () => {
     await expect(i18n.setLanguage('de')).resolves.toBeUndefined();
   });
 
-  /**
-   * The memo is cleared on failure, so the instance is retryable rather than latching one rejection
-   * for its lifetime. This is also the check that the internal bookkeeping `catch` does not swallow
-   * the rejection on its way to the caller.
-   */
+  /** Also the check that the internal bookkeeping `catch` does not swallow the rejection. */
   it('retries on a later call, and can succeed', async () => {
     const i18n = setup();
     const spy = vi

--- a/test/unit/i18n/Streami18n.test.ts
+++ b/test/unit/i18n/Streami18n.test.ts
@@ -678,11 +678,12 @@ describe('Streami18n — a failed setLanguage rolls back', () => {
 });
 
 /**
- * A failed `init()` leaves the instance degraded but *safe*.
+ * A failed `init()` rejects, and leaves the instance degraded but *safe*.
  *
- * Neither UI SDK awaits `init()`, so it must never reject. And `initialized` must stay false, because
- * it means "i18next is usable" -- `registerTranslation` and `setLanguage` both branch on it, and a
- * `true` there sends them into an instance whose own init rejected.
+ * Two separate guarantees, and the point is that they hold together. The promise rejects with the
+ * real error, so a caller is told rather than left to notice a log line. And `initialized` stays
+ * false, because it means "i18next is usable" -- `registerTranslation` and `setLanguage` both branch
+ * on it, and a `true` there sends them into an instance whose own init rejected.
  */
 describe('Streami18n — a failed init()', () => {
   beforeEach(() => {
@@ -695,35 +696,42 @@ describe('Streami18n — a failed init()', () => {
     return i18n;
   };
 
-  it('resolves rather than rejecting, and reports the failure', async () => {
+  it('rejects with the original error', async () => {
+    const i18n = failing();
+
+    await expect(i18n.init()).rejects.toThrow('i18next exploded');
+  });
+
+  /** Reported once, by whoever handles the rejection -- so core must not also log it. */
+  it('does not log, leaving the report to the caller', async () => {
     const logger = vi.fn();
     const i18n = failing(logger);
 
-    await expect(i18n.init()).resolves.toBeDefined();
-    expect(logger).toHaveBeenCalledWith(
-      expect.stringContaining('initialization failed: i18next exploded'),
+    await expect(i18n.init()).rejects.toThrow();
+    expect(logger).not.toHaveBeenCalledWith(
+      expect.stringContaining('initialization failed'),
     );
   });
 
   it('leaves `initialized` false', async () => {
     const i18n = failing();
-    const state = await i18n.init();
 
-    expect(state.initialized).toBe(false);
+    await expect(i18n.init()).rejects.toThrow();
     expect(i18n.initialized).toBe(false);
+    expect(i18n.state.getLatestValue().initialized).toBe(false);
   });
 
   it('keeps rendering the inline English copy', async () => {
     const i18n = failing();
-    const { t } = await i18n.init();
 
-    expect(t('fixture.prose', 'Cancel')).toBe('Cancel');
+    await expect(i18n.init()).rejects.toThrow();
+    expect(i18n.state.getLatestValue().t('fixture.prose', 'Cancel')).toBe('Cancel');
   });
 
   /** The bug this guards: `addResources` on a dead instance threw out of `registerTranslation`. */
   it('does not throw from registerTranslation or setLanguage', async () => {
     const i18n = failing();
-    await i18n.init();
+    await expect(i18n.init()).rejects.toThrow();
 
     expect(() =>
       i18n.registerTranslation('de', { 'fixture.prose': 'Abbrechen' } as never),
@@ -732,19 +740,30 @@ describe('Streami18n — a failed init()', () => {
   });
 
   /**
-   * The one path that escapes, recorded rather than guarded.
-   *
-   * The logger is called from the `catch`, so a logger that throws rejects out of `init()`. Both UI
-   * SDKs call `init()` without awaiting it, so that surfaces as an unhandled rejection — worth knowing
-   * before supplying a logger that can throw.
+   * The memo is cleared on failure, so the instance is retryable rather than latching one rejection
+   * for its lifetime. This is also the check that the internal bookkeeping `catch` does not swallow
+   * the rejection on its way to the caller.
    */
-  it('rejects when the logger itself throws', async () => {
-    const i18n = failing(() => {
-      throw new Error('logger exploded');
-    });
+  it('retries on a later call, and can succeed', async () => {
+    const i18n = setup();
+    const spy = vi
+      .spyOn(i18n.i18nInstance, 'init')
+      .mockRejectedValueOnce(new Error('i18next exploded'));
 
-    await expect(i18n.init()).rejects.toThrow('logger exploded');
+    await expect(i18n.init()).rejects.toThrow('i18next exploded');
     expect(i18n.initialized).toBe(false);
+
+    spy.mockRestore();
+    await expect(i18n.init()).resolves.toBeDefined();
+    expect(i18n.initialized).toBe(true);
+  });
+
+  it('shares the in-flight promise with concurrent callers before failing', async () => {
+    const i18n = failing();
+    const first = i18n.init();
+
+    expect(i18n.init()).toBe(first);
+    await expect(first).rejects.toThrow('i18next exploded');
   });
 });
 

--- a/v9-to-v10-migration-guide-i18n.md
+++ b/v9-to-v10-migration-guide-i18n.md
@@ -229,7 +229,10 @@ Notable if you are building custom UI directly on `stream-chat`:
   value, so there is no listener-registration ordering to get right.
 - `setLanguage()` returns `Promise<void>`. The new `t` is published to `state`; a returned translator
   would go stale on the next language change.
-- `init()` is idempotent and safe to call concurrently.
+- `init()` is idempotent, safe to call concurrently, and **rejects** if i18next fails to initialize.
+  Handle it: an unhandled rejection is what you get otherwise. The instance stays usable in a degraded
+  form either way — `initialized` stays `false` and `t` keeps returning each call site's inline English,
+  so the UI renders rather than blanking. A later `init()` retries.
 - The keys with no inline default at their call site are injected via the `runtimeDefaults` option,
   because the catalog belongs to the UI layer rather than to core.
 


### PR DESCRIPTION
Two related breaking changes to `Streami18n`, both of which move a decision out of core and into the caller. They ship together because the second is only safe once the first has landed in both UI SDKs.

## 1. `init()` rejects instead of swallowing

It caught every failure, logged a string, and resolved:

```ts
} catch (error) {
  this.logger(`Streami18n: initialization failed: ${describeError(error)}`);
}
return this.state.getLatestValue();
```

A consumer had no way to know initialization had failed short of watching the log, and an integrator who supplied a `logger` to route diagnostics somewhere quiet lost the signal entirely. The original error — stack, cause, i18next's own detail — was flattened to a string and dropped. Swallowing at a library boundary is the wrong default; the caller owns the policy.

The old justification was "neither UI SDK awaits this, so a rejection would be unhandled". That is a statement about the SDKs, not about the contract — so the SDKs are what got fixed, in the companion PRs below.

`init()` now rejects with the original error, and core no longer logs. A failure is reported **once**, by whoever handles it, in a form they can inspect.

What does **not** change is the degraded-but-safe guarantee, which is a separate concern worth keeping distinct:

| after a failed `init()` | before | after |
| --- | --- | --- |
| promise | resolves | **rejects with the original error** |
| core logs | yes | no — the handler reports |
| `initialized` | `false` | `false` |
| `t` | default translator, inline English | unchanged |
| `registerTranslation` / `setLanguage` | do not throw | unchanged |

The promise reports the failure; the store keeps the UI alive. Rejecting does not mean the instance is unusable.

Two things fall out:

- **The memo is cleared on failure**, so a later `init()` retries rather than replaying one rejection for the lifetime of the instance. Concurrent callers still share the in-flight promise, which is the only thing the memo was ever for.
- **The bookkeeping handler attaches to a derived promise**, so it does not mark the returned one as handled and the caller's `catch` still sees the rejection. There is a test for exactly that, because getting it wrong silently swallows the rejection again.

## 2. `Streami18n.brand` is removed

`static readonly brand = Symbol.for('stream-chat.Streami18n')` existed so a UI SDK could recognize an instance across two physical copies of this package, where `instanceof` fails. Both SDKs have now stopped checking, so it has no consumer left in any of the three repos — verified by grep across all of them.

It was also blind to the case that actually bites. The brand sits on *core's* class, so a bare `new Streami18n()` from `stream-chat/i18n` — carrying none of a UI SDK's bundled `runtimeDefaults`, and therefore rendering `timestamp.*` and `language.*` as raw dotted keys — passed the check cleanly. All it ever rejected was a value that is not a `Streami18n` at all, which the prop types already cover.

## Companion PRs

Both UI SDKs catch the rejection in their `useStreami18n` effect and report through `console.warn`, which keeps the `Error` object and its stack intact. Neither surfaces an error state, because the degraded instance still renders English and failing a whole chat subtree over a translation-layer fault would be the worse outcome. Both also dropped the brand check.

- [stream-chat-react#3271](https://github.com/GetStream/stream-chat-react/pull/3271)
- [stream-chat-react-native#3777](https://github.com/GetStream/stream-chat-react-native/pull/3777)

Their hook tests mock `init()` itself rather than the i18next instance underneath — what is under test there is the hook's handling of a rejection, not core's decision to reject, and it keeps those tests independent of which `stream-chat` version is installed while this rolls out.

## Verification

`yarn lint` 0, `yarn types` 0, **2,881 tests**. The rewritten `Streami18n — a failed init()` block pins the new contract: rejects with the original error, does not log, leaves `initialized` false, keeps rendering inline English, does not break `registerTranslation` / `setLanguage`, retries on a later call, and shares the in-flight promise with concurrent callers before failing.

## Sequencing

This needs an rc after merge — the SDK-side `catch` is inert against rc.5, which still resolves — and then a version bump in both consumers.

BREAKING CHANGE: `Streami18n.init()` now rejects when i18next fails to initialize, where it previously logged and resolved. Callers that ignore the returned promise will see an unhandled rejection. The instance remains usable in its degraded English form either way. `Streami18n.brand` is removed; nothing in either UI SDK read it, and a custom integration that recognized instances through it should compare against its own marker or accept the instance it was handed.
