### PR TITLE
[CHA-4716] Retention maxAgeHours upper bound is 61320, not 43800

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -5394,7 +5394,7 @@ export class StreamChat {
    * Server-side only.
    *
    * @param {string} policy The policy type ('old-messages' or 'inactive-channels')
-   * @param {number} maxAgeHours Max age in hours (24-43800)
+   * @param {number} maxAgeHours Max age in hours (24-61320)
    * @returns {Promise<SetRetentionPolicyResponse>}
    */
   async setRetentionPolicy(policy: string, maxAgeHours: number) {


### PR DESCRIPTION
## Ticket
- https://linear.app/stream/issue/CHA-4716/retention-max-age-hours-capped-at-5y-by-one-validator-constant-no-per

## Summary

`setRetentionPolicy`'s docstring advertises `Max age in hours (24-43800)`. GetStream/chat#16047 raises the server-side cap to 61,320h (7 years), so the documented upper bound is stale.

Docstring only — the SDK does not enforce the bound, it forwards `max_age_hours` and the API validates it.

## Draft on purpose

Held until the chat release carrying the new bound is deployed, so the SDK does not document a value the API still rejects. Same hold applies to the docs-content page (GetStream/docs-content#1530) and the dashboard form bound (GetStream/volt-dashboard#853).