### PR TITLE
feat: connection recovery

### DIFF
--- a/src/ChannelManager.ts
+++ b/src/ChannelManager.ts
@@ -15,15 +15,13 @@ import type {
 import { getChannel } from './pagination/utility.queryChannel';
 import type { Channel } from './channel';
 import { ChannelWatchStatus } from './channel_state';
-import { chatLoggerSystem } from './logger';
+import { runDetached } from './utils';
 
 export type ChannelManagerEventHandlerContext = {
   channelManager: ChannelManager;
 };
 
 type EventHandlerContext = ChannelManagerEventHandlerContext;
-
-const logger = chatLoggerSystem.getLogger('channel');
 
 type SupportedEventType = EventType | (string & {});
 
@@ -159,10 +157,8 @@ const restoreInterruptedWatch = (channel: Channel, client: StreamChat) => {
   // Takes the client as an argument rather than calling `channel.getClient()`, which THROWS for a
   // channel pending disposal — the guard above makes that unreachable today, but a throw here would
   // reject the whole event handler, so it is not a hazard worth leaving one edit away.
-  getChannel({ channel, client }).catch((error) => {
-    logger
-      .withExtraTags('restoreInterruptedWatch', channel.cid)
-      .warn('Failed to restore an interrupted channel watch.', { error });
+  runDetached(getChannel({ channel, client }), {
+    context: `restoreInterruptedWatch(${channel.cid})`,
   });
 };
 

--- a/src/ChannelManager.ts
+++ b/src/ChannelManager.ts
@@ -14,12 +14,16 @@ import type {
 } from './EventHandlerPipeline';
 import { getChannel } from './pagination/utility.queryChannel';
 import type { Channel } from './channel';
+import { ChannelWatchStatus } from './channel_state';
+import { chatLoggerSystem } from './logger';
 
 export type ChannelManagerEventHandlerContext = {
   channelManager: ChannelManager;
 };
 
 type EventHandlerContext = ChannelManagerEventHandlerContext;
+
+const logger = chatLoggerSystem.getLogger('channel');
 
 type SupportedEventType = EventType | (string & {});
 
@@ -134,6 +138,34 @@ export const ignoreEventsForUnknownChannels: EventHandlerPipelineHandler<
   if (!channel) return { action: 'stop' };
 };
 
+/**
+ * Restore a watch this client held and lost to a dropped socket.
+ *
+ * The server keys watches by connection ID, so a reconnect ends every watch the previous connection
+ * held. Reconnect recovery re-watches the first page of each list plus the active channel; everything
+ * else stays `WasWatching` — pages 2+ of a scrolled list, channels visited and navigated away from,
+ * channels matching no mounted list. Such a channel still receives member-level events (e.g.
+ * `notification.message_new`), which relocate its row but carry no message body, so its preview would
+ * sit frozen until the channel was opened. Re-watching it the moment an event proves it relevant is
+ * what closes that gap, without ever eagerly re-watching the whole cache.
+ *
+ * The request is idempotent, so a successful watch flips the status to `Watching`, and `getChannel`
+ * dedupes concurrent watches for the same cid, so a burst of events cannot produce a burst of requests.
+ */
+const restoreInterruptedWatch = (channel: Channel, client: StreamChat) => {
+  if (channel.pendingDisposal) return;
+  if (channel.watchStatus !== ChannelWatchStatus.WasWatching) return;
+
+  // Takes the client as an argument rather than calling `channel.getClient()`, which THROWS for a
+  // channel pending disposal — the guard above makes that unreachable today, but a throw here would
+  // reject the whole event handler, so it is not a hazard worth leaving one edit away.
+  getChannel({ channel, client }).catch((error) => {
+    logger
+      .withExtraTags('restoreInterruptedWatch', channel.cid)
+      .warn('Failed to restore an interrupted channel watch.', { error });
+  });
+};
+
 const updateLists: EventHandlerPipelineHandler<EventHandlerContext> = async ({
   event,
   ctx: { channelManager },
@@ -183,6 +215,13 @@ const updateLists: EventHandlerPipelineHandler<EventHandlerContext> = async ({
     // (`paginator.boost`) for integrators to opt into for specific channels (VIP/mention/deep-link).
     paginator.ingestItem(channel);
   });
+
+  // AFTER routing, and not awaited: the row relocates immediately off the event, and the watch (plus
+  // the state it hydrates) lands whenever it lands. `channel.hidden` is excluded — a channel being
+  // hidden is the one routed event that must not resurrect a watch.
+  if (event.type !== 'channel.hidden') {
+    restoreInterruptedWatch(channel, channelManager.client);
+  }
 };
 
 // we have to make sure that client.activeChannels is always up-to-date
@@ -720,5 +759,36 @@ export class ChannelManager extends WithSubscriptions {
       this.paginators.map(async (paginator) => {
         await paginator.reload();
       }),
+    );
+
+  /**
+   * Re-run every loaded list's own first-page query — the channel-list half of connection recovery,
+   * driven by {@link ConnectionRecoveryManager}.
+   *
+   * Each list re-asserts its *own* `filters` / `sort` / `pageSize` rather than some substitute query,
+   * and because `client.queryChannels` watches by default, that page's channels are re-watched as a
+   * side effect. Channels below the first page are deliberately not touched — see
+   * `restoreInterruptedWatch` for how they come back.
+   *
+   * `{ keepPreviousItems: true, reset: 'yes' }` is the non-destructive refresh: `reset` restarts the
+   * window at page 1, while `keepPreviousItems` merges the fetched page into the loaded list instead
+   * of replacing it and keeps the item index populated — the latter is what stops a concurrent
+   * offline-replay ingest from rebuilding the list out of a cleared index. Notably NOT `silent`: the
+   * `isLoading` transition it would suppress is the in-flight guard that keeps a second overlapping
+   * query from being issued.
+   *
+   * Distinct from {@link ChannelManager.reload}, which is a destructive `reset` that blanks each list
+   * to its loading state.
+   *
+   * Paginators that were never queried are skipped: they run their own first query when they mount,
+   * and querying them here would race it.
+   */
+  recover = async () =>
+    await Promise.allSettled(
+      this.paginators
+        .filter((paginator) => paginator.isInitialized)
+        .map(async (paginator) => {
+          await paginator.toTail({ keepPreviousItems: true, reset: 'yes' });
+        }),
     );
 }

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -212,10 +212,10 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
         `Recovering ${channels.length} active channel(s) and ${threads.length} active thread(s).`,
       );
 
-    // allSettled: one channel or thread failing must not stop the others. Each failure is published
-    // on `channel.state.lastLoadError` / `thread.state.lastLoadError` by the reload itself, so it
-    // is not lost here. Channels and threads are independent requests, so they run together rather
-    // than in sequence.
+    // allSettled: one channel or thread failing must not stop the others. A failed refresh is not
+    // surfaced anywhere — the loaded window simply stays as it was until the next reconnect, or until
+    // a query the consumer itself issues records its own `lastQueryError` on the paginator. Channels
+    // and threads are independent requests, so they run together rather than in sequence.
     await Promise.allSettled([
       ...channels.map((channel) => channel.reload()),
       ...threads.map((thread) => thread.reload()),

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -1,12 +1,28 @@
 import { WithSubscriptions } from './utils/WithSubscriptions';
 import { chatLoggerSystem } from './logger';
 import { runDetached } from './utils';
+import { ConfigController } from './configuration/ConfigController';
+import { deepFreezeConfig } from './configuration/utils/deepFreezeConfig';
 import type { StreamChat } from './client';
 import type { Channel } from './channel';
 import type { Thread } from './thread';
-import type { Unsubscribe } from './store';
+import type { StateStore, Unsubscribe } from './store';
 
 const logger = chatLoggerSystem.getLogger('client');
+
+export type ConnectionRecoveryManagerConfig = {
+  /**
+   * Whether the client recovers its own state when the connection comes back.
+   *
+   * Set it to `false` only if the application recovers state itself — nothing is then re-queried or
+   * re-watched on reconnect, and refreshing whatever is on screen becomes the consumer's job.
+   * Read when a recovery actually runs, so flipping it takes effect from the next reconnect.
+   */
+  enabled: boolean;
+};
+
+export const DEFAULT_CONNECTION_RECOVERY_MANAGER_CONFIG: ConnectionRecoveryManagerConfig =
+  deepFreezeConfig({ enabled: true });
 
 /**
  * Owns connection recovery: after the socket comes back, brings the surfaces the app is actually
@@ -59,6 +75,8 @@ const logger = chatLoggerSystem.getLogger('client');
  */
 export class ConnectionRecoveryManager extends WithSubscriptions {
   client: StreamChat;
+  /** The shared configuration machinery — see {@link ConfigController}. */
+  private readonly configController: ConfigController<ConnectionRecoveryManagerConfig>;
   /** Set while a recovery is in flight; only used to keep the logs readable. */
   private isRecovering = false;
   /** Undone by `unregisterSubscriptions`, so re-registering does not stack listeners. */
@@ -66,7 +84,37 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
 
   constructor({ client }: { client: StreamChat }) {
     super();
+    this.configController = new ConfigController<ConnectionRecoveryManagerConfig>({
+      defaults: DEFAULT_CONNECTION_RECOVERY_MANAGER_CONFIG,
+    });
     this.client = client;
+  }
+
+  /**
+   * Resolved configuration, as a store — the shape every configurable class exposes
+   * (`configState` / `config` / `updateConfig`).
+   */
+  get configState(): StateStore<ConnectionRecoveryManagerConfig> {
+    return this.configController.state;
+  }
+
+  /** The current resolved configuration. `Readonly` — change it through {@link updateConfig}. */
+  public get config(): Readonly<ConnectionRecoveryManagerConfig> {
+    return this.configState.getLatestValue();
+  }
+
+  /** Merges a partial configuration into the resolved config and notifies subscribers. */
+  public updateConfig(config: Partial<ConnectionRecoveryManagerConfig>) {
+    this.configController.patch(config);
+  }
+
+  /**
+   * Rebuilds the resolved configuration from package defaults plus the declarative slice — the
+   * derivation entry point every configurable entity exposes, so the client routes a slice here and
+   * knows nothing about this manager's defaults or merge semantics.
+   */
+  public initializeConfig(config?: Partial<ConnectionRecoveryManagerConfig>) {
+    this.configController.initialize(config);
   }
 
   public registerSubscriptions = () => {
@@ -196,12 +244,12 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
   }
 
   private recoverChannelLists = async () => {
-    if (!this.client.recoverStateOnReconnect) return;
+    if (!this.config.enabled) return;
     await this.client.channelManager.recover();
   };
 
   private recoverActiveChannels = async () => {
-    if (!this.client.recoverStateOnReconnect) return;
+    if (!this.config.enabled) return;
 
     const channels = this.recoverableActiveChannels;
     const threads = this.recoverableActiveThreads;

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -3,6 +3,7 @@ import { chatLoggerSystem } from './logger';
 import { runDetached } from './utils';
 import type { StreamChat } from './client';
 import type { Channel } from './channel';
+import type { Thread } from './thread';
 import type { Unsubscribe } from './store';
 
 const logger = chatLoggerSystem.getLogger('client');
@@ -11,7 +12,7 @@ const logger = chatLoggerSystem.getLogger('client');
  * Owns connection recovery: after the socket comes back, brings the surfaces the app is actually
  * consuming back in line with the server.
  *
- * Recovery is deliberately narrow — two things, and nothing else:
+ * Recovery is deliberately narrow — three things, and nothing else:
  *
  * 1. **Every loaded channel list re-runs its own first-page query** (`ChannelManager.recover`). Since
  *    `queryChannels` watches by default, that also re-establishes the watches for the channels on
@@ -19,6 +20,10 @@ const logger = chatLoggerSystem.getLogger('client');
  * 2. **Every active channel reloads itself** (`Channel.reload`), because a list page carries far fewer
  *    messages per channel than an open channel's loaded window, so the open channel cannot be served
  *    by the list query.
+ * 3. **Every active thread reloads its replies** (`Thread.reload`), because none of the above touches
+ *    them: a channel reload refreshes the main message list, and `ThreadManager`'s own recovery
+ *    refreshes the thread *list*, reusing thread instances without rehydrating them unless something
+ *    separately marked them stale — which only `user.watching.stop` does, never a reconnect.
  *
  * It is explicitly **not** a sweep over `client.activeChannels`. Watches are a bounded server
  * resource, and after any scrolling that cache holds far more channels than a query returns — so
@@ -146,6 +151,50 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
     return channels;
   }
 
+  /**
+   * The threads this recovery reloads: the ones a consumer has declared it is displaying.
+   *
+   * Threads need their own pass because nothing else brings an open thread's replies back — a
+   * channel reload refreshes the main message list, `ChannelManager.recover()` refreshes the channel
+   * lists*, and `ThreadManager`'s own recovery refreshes the thread *list*, reusing existing
+   * instances without rehydrating them unless they were separately marked stale (which only
+   * `user.watching.stop` does, never a reconnect).
+   *
+   * `active` is the filter that matters: `threadsById` holds every thread the list has paged in,
+   * which is not what should be re-fetched on a reconnect — only what someone is actually reading.
+   * Guarded on the owning channel the same way active channels are: a thread whose channel is being
+   * torn down has nothing to recover into.
+   *
+   * NOTE: `threadsById` is the thread LIST, not a thread cache. A thread opened from a message list
+   * is constructed directly (`threadsById[id] ?? new Thread(...)`) and only reaches the list because
+   * the UI SDKs adopt it there — prepended, once its replies have loaded — which is a workaround, not
+   * a contract. Two consequences, both accepted for now and both narrow:
+   *
+   * - A reconnect landing before that adoption misses the thread. Self-limiting: the UI SDKs re-issue
+   *   the load while the reply list is still unloaded, so a thread that failed to load gets adopted on
+   *   the retry.
+   * - `ThreadManager.reload()` rebuilds `state.threads` purely from the query response, so an adopted
+   *   thread absent from that response is evicted while still active. It cannot bite within the
+   *   reconnect that caused it: this getter is read before `connection.recovered` is dispatched, and
+   *   that event is what triggers the UI SDKs' list reload. It would take a LATER reconnect, after an
+   *   eviction, to miss the thread.
+   *
+   * The fix is a real off-list registry — see the commented-out `threadCache` in `ThreadManager` — at
+   * which point this getter reads from that instead, with no change to the `active` filter.
+   */
+  private get recoverableActiveThreads(): Thread[] {
+    const threads: Thread[] = [];
+    for (const thread of Object.values(this.client.threads.threadsById)) {
+      if (!thread) continue;
+      // Read off state rather than a getter: `Thread` has no `active` accessor the way `Channel`
+      // does, and adding one just for this would grow the public surface for a single internal read.
+      const { active } = thread.state.getLatestValue();
+      if (!active || thread.channel.pendingDisposal) continue;
+      threads.push(thread);
+    }
+    return threads;
+  }
+
   private recoverChannelLists = async () => {
     if (!this.client.recoverStateOnReconnect) return;
     await this.client.channelManager.recover();
@@ -155,14 +204,22 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
     if (!this.client.recoverStateOnReconnect) return;
 
     const channels = this.recoverableActiveChannels;
+    const threads = this.recoverableActiveThreads;
     this.isRecovering = true;
     logger
       .withExtraTags('connectionRecovery')
-      .info(`Recovering ${channels.length} active channel(s).`);
+      .info(
+        `Recovering ${channels.length} active channel(s) and ${threads.length} active thread(s).`,
+      );
 
-    // allSettled: one channel failing must not stop the others. Each failure is published on
-    // `channel.state.lastReloadError` by `reload()` itself, so it is not lost here.
-    await Promise.allSettled(channels.map((channel) => channel.reload()));
+    // allSettled: one channel or thread failing must not stop the others. Each failure is published
+    // on `channel.state.lastReloadError` / `thread.state.lastReloadError` by `reload()` itself, so it
+    // is not lost here. Channels and threads are independent requests, so they run together rather
+    // than in sequence.
+    await Promise.allSettled([
+      ...channels.map((channel) => channel.reload()),
+      ...threads.map((thread) => thread.reload()),
+    ]);
 
     this.isRecovering = false;
 

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -1,0 +1,192 @@
+import { WithSubscriptions } from './utils/WithSubscriptions';
+import { chatLoggerSystem } from './logger';
+import type { StreamChat } from './client';
+import type { AbstractOfflineDB } from './offline-support/offline_support_api';
+import type { Channel } from './channel';
+import type { Unsubscribe } from './store';
+
+const logger = chatLoggerSystem.getLogger('client');
+
+/**
+ * Owns connection recovery: after the socket comes back, brings the surfaces the app is actually
+ * consuming back in line with the server.
+ *
+ * Recovery is deliberately narrow — two things, and nothing else:
+ *
+ * 1. **Every loaded channel list re-runs its own first-page query** (`ChannelManager.recover`). Since
+ *    `queryChannels` watches by default, that also re-establishes the watches for the channels on
+ *    that page.
+ * 2. **Every active channel reloads itself** (`Channel.reload`), because a list page carries far fewer
+ *    messages per channel than an open channel's loaded window, so the open channel cannot be served
+ *    by the list query.
+ *
+ * It is explicitly **not** a sweep over `client.activeChannels`. Watches are a bounded server
+ * resource, and after any scrolling that cache holds far more channels than a query returns — so
+ * re-watching all of them would be both wasteful and a watch-limit hazard. Channels outside the
+ * refreshed pages come back demand-driven, when an event proves them relevant (see
+ * `restoreInterruptedWatch` in `ChannelManager`).
+ *
+ * This replaces the old `client.recoverState()` bulk query
+ * (`cid: { $in: activeChannels }, limit: 30`), which invented its own query shape unrelated to any
+ * list's filters and silently dropped everything past the thirtieth channel.
+ *
+ * ### Triggers, and why there are two
+ *
+ * One per surface, mirroring what the React Native SDK arrived at:
+ *
+ * - **Lists** — `connection.changed` with `online: true`. `ChannelPaginator.executeQuery` carries its
+ *   own first-page deferral for the unsynced case, so the list query orders itself against the
+ *   offline sync.
+ * - **Active channels** — the offline DB's *sync-status edge* when offline support is enabled,
+ *   `connection.changed` otherwise. `Channel.reload()` has no deferral of its own, so it has to be
+ *   triggered by something that is already post-sync.
+ *
+ * The edge is what guarantees `executePendingTasks()` → `sync()` → query ordering, on every reconnect
+ * path: `OfflineDBSyncManager` calls `invokeSyncStatusListeners(true)` **unconditionally** after
+ * `syncAndExecutePendingTasks()` on each online transition — it does not require `syncStatus` to have
+ * been `false` first. That matters because the going-offline `connection.changed` is 5s-debounced,
+ * skipped entirely on a quick flap, and never dispatched at all by `closeConnection()` (mobile
+ * backgrounding), so anything derived from *that* event is not a reliable signal. The edge is.
+ *
+ * Recovery deliberately keeps no "did we drop?" flag of its own: `ChannelWatchStatus.WasWatching`
+ * already records exactly that, written from both truthful hooks
+ * (`StableWSConnection._setHealth(false)` and `closeConnection()`).
+ */
+export class ConnectionRecoveryManager extends WithSubscriptions {
+  client: StreamChat;
+  /** Set while a recovery is in flight; only used to keep the logs readable. */
+  private isRecovering = false;
+  /** Undone by `unregisterSubscriptions`, so re-registering does not stack listeners. */
+  private unsubscribeSyncStatus?: Unsubscribe;
+  private unsubscribeOfflineDbInit?: Unsubscribe;
+
+  constructor({ client }: { client: StreamChat }) {
+    super();
+    this.client = client;
+  }
+
+  /**
+   * Whether the offline DB is attached AND finished initializing. Until it is, the sync-status edge
+   * will never fire, so active-channel recovery has to stay on `connection.changed` — an offline DB
+   * whose `init()` failed must not silently cost us recovery altogether.
+   */
+  private get usesSyncStatusTrigger() {
+    const { offlineDb } = this.client;
+    return !!offlineDb && offlineDb.state.getLatestValue().initialized;
+  }
+
+  public registerSubscriptions = () => {
+    if (!this.hasSubscriptions) {
+      this.addUnsubscribeFunction(
+        this.client.on('connection.changed', (event) => {
+          if (!event.online) return;
+
+          // The lists always recover off this event; their own deferral handles offline ordering.
+          this.recoverChannelLists();
+
+          // Active channels recover off the sync-status edge whenever there is one to wait for.
+          if (!this.usesSyncStatusTrigger) {
+            this.recoverActiveChannels();
+          }
+        }).unsubscribe,
+      );
+
+      this.addUnsubscribeFunction(() => {
+        this.unsubscribeSyncStatus?.();
+        this.unsubscribeSyncStatus = undefined;
+        this.unsubscribeOfflineDbInit?.();
+        this.unsubscribeOfflineDbInit = undefined;
+      });
+    }
+
+    this.incrementRefCount();
+    return () => this.unregisterSubscriptions();
+  };
+
+  /**
+   * Called by `client.setOfflineDBApi`, because the offline DB is attached after the client (and this
+   * manager) already exist, and initialized later still. Watches `initialized` rather than assuming,
+   * so the sync-status listener is registered at the first moment it can produce an edge.
+   */
+  public attachOfflineDb = (offlineDb: AbstractOfflineDB) => {
+    this.unsubscribeOfflineDbInit?.();
+    this.unsubscribeOfflineDbInit = offlineDb.state.subscribeWithSelector(
+      (nextValue) => ({ initialized: nextValue.initialized }),
+      ({ initialized }) => {
+        if (!initialized) return;
+        this.subscribeSyncStatus(offlineDb);
+      },
+    );
+  };
+
+  private subscribeSyncStatus = (offlineDb: AbstractOfflineDB) => {
+    // Guard against a re-initialization publishing `initialized: true` twice.
+    if (this.unsubscribeSyncStatus) return;
+
+    const { unsubscribe } = offlineDb.syncManager.onSyncStatusChange((status) => {
+      // `false` is only published when going offline; there is nothing to recover then.
+      if (!status) return;
+      this.recoverActiveChannels();
+    });
+    this.unsubscribeSyncStatus = unsubscribe;
+  };
+
+  /**
+   * The channels this recovery reloads: the ones a consumer has declared it is currently reading.
+   *
+   * Deliberately NOT filtered on `watchStatus`. A channel opened while offline never reached
+   * `Watching` at all (its `watch()` threw, leaving `offlineMode`), so a `WasWatching` filter here
+   * would permanently strand the single most important offline case. `Channel.reload()`'s own
+   * `initialized || offlineMode` guard is the correct gate, and this is not a "restore a lost watch"
+   * decision anyway — it is "the channel being read must show the truth".
+   */
+  private get recoverableActiveChannels(): Channel[] {
+    const channels: Channel[] = [];
+    for (const cid in this.client.activeChannels) {
+      const channel = this.client.activeChannels[cid];
+      if (channel?.active && !channel.pendingDisposal) channels.push(channel);
+    }
+    return channels;
+  }
+
+  private recoverChannelLists = async () => {
+    if (!this.client.recoverStateOnReconnect) return;
+    await this.client.channelManager.recover();
+  };
+
+  private recoverActiveChannels = async () => {
+    if (!this.client.recoverStateOnReconnect) return;
+
+    const channels = this.recoverableActiveChannels;
+    this.isRecovering = true;
+    logger
+      .withExtraTags('connectionRecovery')
+      .info(`Recovering ${channels.length} active channel(s).`);
+
+    // allSettled: one channel failing must not stop the others. Each failure is published on
+    // `channel.state.lastReloadError` by `reload()` itself, so it is not lost here.
+    await Promise.allSettled(channels.map((channel) => channel.reload()));
+
+    this.isRecovering = false;
+
+    // `connection.recovered` means "recovery finished". Dispatched from here rather than from
+    // `recoverState()` so it fires on EVERY reconnect path — `recoverState()` is only ever called by
+    // `StableWSConnection._reconnect()`, so a `closeConnection()` → `openConnection()` cycle (mobile
+    // backgrounding) never produced it. Consumers keying post-recovery work off this event — the UI
+    // SDKs' mark-read-on-catch-up among them — need it after the reload above, not before.
+    this.client.dispatchEvent({ type: 'connection.recovered' });
+  };
+
+  /**
+   * Run a full recovery now, without waiting for a connection event. This is what `recoverState()`
+   * delegates to.
+   */
+  public recover = async () => {
+    if (this.isRecovering) {
+      logger
+        .withExtraTags('connectionRecovery')
+        .debug('A recovery is already in flight.');
+    }
+    await Promise.allSettled([this.recoverChannelLists(), this.recoverActiveChannels()]);
+  };
+}

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -1,7 +1,7 @@
 import { WithSubscriptions } from './utils/WithSubscriptions';
 import { chatLoggerSystem } from './logger';
+import { runDetached } from './utils';
 import type { StreamChat } from './client';
-import type { AbstractOfflineDB } from './offline-support/offline_support_api';
 import type { Channel } from './channel';
 import type { Unsubscribe } from './store';
 
@@ -26,7 +26,7 @@ const logger = chatLoggerSystem.getLogger('client');
  * refreshed pages come back demand-driven, when an event proves them relevant (see
  * `restoreInterruptedWatch` in `ChannelManager`).
  *
- * This replaces the old `client.recoverState()` bulk query
+ * This replaces the removed `client.recoverState()` bulk query
  * (`cid: { $in: activeChannels }, limit: 30`), which invented its own query shape unrelated to any
  * list's filters and silently dropped everything past the thirtieth channel.
  *
@@ -58,21 +58,10 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
   private isRecovering = false;
   /** Undone by `unregisterSubscriptions`, so re-registering does not stack listeners. */
   private unsubscribeSyncStatus?: Unsubscribe;
-  private unsubscribeOfflineDbInit?: Unsubscribe;
 
   constructor({ client }: { client: StreamChat }) {
     super();
     this.client = client;
-  }
-
-  /**
-   * Whether the offline DB is attached AND finished initializing. Until it is, the sync-status edge
-   * will never fire, so active-channel recovery has to stay on `connection.changed` — an offline DB
-   * whose `init()` failed must not silently cost us recovery altogether.
-   */
-  private get usesSyncStatusTrigger() {
-    const { offlineDb } = this.client;
-    return !!offlineDb && offlineDb.state.getLatestValue().initialized;
   }
 
   public registerSubscriptions = () => {
@@ -82,11 +71,18 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
           if (!event.online) return;
 
           // The lists always recover off this event; their own deferral handles offline ordering.
-          this.recoverChannelLists();
+          runDetached(this.recoverChannelLists(), { context: 'recoverChannelLists' });
 
-          // Active channels recover off the sync-status edge whenever there is one to wait for.
-          if (!this.usesSyncStatusTrigger) {
-            this.recoverActiveChannels();
+          // Active channels recover off the offline sync-status edge whenever there is one — it is the
+          // only signal guaranteed to be post-replay-post-sync. Exactly ONE of these two paths runs
+          // per reconnect: binding the subscription is what makes the edge the driver, so the same
+          // call reports which path applies. Deliberately not split into a separate predicate — two
+          // independent reads of "is there an edge?" could disagree with each other.
+          const syncEdgeDrivesActiveChannels = this.ensureSyncStatusSubscription();
+          if (!syncEdgeDrivesActiveChannels) {
+            runDetached(this.recoverActiveChannels(), {
+              context: 'recoverActiveChannels',
+            });
           }
         }).unsubscribe,
       );
@@ -94,8 +90,6 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
       this.addUnsubscribeFunction(() => {
         this.unsubscribeSyncStatus?.();
         this.unsubscribeSyncStatus = undefined;
-        this.unsubscribeOfflineDbInit?.();
-        this.unsubscribeOfflineDbInit = undefined;
       });
     }
 
@@ -104,31 +98,34 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
   };
 
   /**
-   * Called by `client.setOfflineDBApi`, because the offline DB is attached after the client (and this
-   * manager) already exist, and initialized later still. Watches `initialized` rather than assuming,
-   * so the sync-status listener is registered at the first moment it can produce an edge.
+   * Bind to the offline DB's sync-status edge, if there is one to bind to yet.
+   *
+   * Resolved off `this.client` rather than injected: the DB is already reachable there, it is simply
+   * attached after this manager is constructed (and initialized later still), so the binding has to be
+   * deferred rather than handed in. Doing it from the `connection.changed` handler is safe even when
+   * this manager's listener runs before the sync manager's: `OfflineDBSyncManager` awaits
+   * `syncAndExecutePendingTasks()` before publishing, so the edge cannot land in the same synchronous
+   * dispatch that registers us.
+   *
+   * An offline DB whose `init()` never succeeded publishes no edge, so it must not be treated as the
+   * trigger — hence the `initialized` check, which also means a later successful init is picked up on
+   * the next reconnect.
+   *
+   * @returns whether the sync-status edge is now driving active-channel recovery.
    */
-  public attachOfflineDb = (offlineDb: AbstractOfflineDB) => {
-    this.unsubscribeOfflineDbInit?.();
-    this.unsubscribeOfflineDbInit = offlineDb.state.subscribeWithSelector(
-      (nextValue) => ({ initialized: nextValue.initialized }),
-      ({ initialized }) => {
-        if (!initialized) return;
-        this.subscribeSyncStatus(offlineDb);
-      },
-    );
-  };
+  private ensureSyncStatusSubscription = (): boolean => {
+    if (this.unsubscribeSyncStatus) return true;
 
-  private subscribeSyncStatus = (offlineDb: AbstractOfflineDB) => {
-    // Guard against a re-initialization publishing `initialized: true` twice.
-    if (this.unsubscribeSyncStatus) return;
+    const { offlineDb } = this.client;
+    if (!offlineDb?.state.getLatestValue().initialized) return false;
 
     const { unsubscribe } = offlineDb.syncManager.onSyncStatusChange((status) => {
       // `false` is only published when going offline; there is nothing to recover then.
       if (!status) return;
-      this.recoverActiveChannels();
+      runDetached(this.recoverActiveChannels(), { context: 'recoverActiveChannels' });
     });
     this.unsubscribeSyncStatus = unsubscribe;
+    return true;
   };
 
   /**
@@ -169,8 +166,8 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
 
     this.isRecovering = false;
 
-    // `connection.recovered` means "recovery finished". Dispatched from here rather than from
-    // `recoverState()` so it fires on EVERY reconnect path — `recoverState()` is only ever called by
+    // `connection.recovered` means "recovery finished". Dispatched from here so it fires on EVERY
+    // reconnect path — the removed `recoverState()` was only ever called by
     // `StableWSConnection._reconnect()`, so a `closeConnection()` → `openConnection()` cycle (mobile
     // backgrounding) never produced it. Consumers keying post-recovery work off this event — the UI
     // SDKs' mark-read-on-catch-up among them — need it after the reload above, not before.
@@ -178,8 +175,7 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
   };
 
   /**
-   * Run a full recovery now, without waiting for a connection event. This is what `recoverState()`
-   * delegates to.
+   * Run a full recovery now, without waiting for a connection event.
    */
   public recover = async () => {
     if (this.isRecovering) {

--- a/src/ConnectionRecoveryManager.ts
+++ b/src/ConnectionRecoveryManager.ts
@@ -213,7 +213,7 @@ export class ConnectionRecoveryManager extends WithSubscriptions {
       );
 
     // allSettled: one channel or thread failing must not stop the others. Each failure is published
-    // on `channel.state.lastReloadError` / `thread.state.lastReloadError` by `reload()` itself, so it
+    // on `channel.state.lastLoadError` / `thread.state.lastLoadError` by the reload itself, so it
     // is not lost here. Channels and threads are independent requests, so they run together rather
     // than in sequence.
     await Promise.allSettled([

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1897,14 +1897,21 @@ export class Channel extends ChannelApi {
       await this.watch({ messages: { limit: requestedLimit } });
       this.offlineMode = false;
 
-      paginator.batch(
-        () => {
-          for (const failed of failedBefore) {
-            if (!paginator.getItem(failed.id)) paginator.ingestItem(failed);
-          }
-        },
-        { coalesce: true },
-      );
+      if (failedBefore.length) {
+        // Membership is checked against the visible window, NOT `getItem`: that reads the item index,
+        // which can still hold a message the rebuild dropped from the loaded window — so an
+        // index-based guard skips the reingest on exactly the disjoint set rebuild that needs it,
+        // and the user's unsent message silently disappears from the list.
+        const visible = new Set((paginator.items ?? []).map((message) => message.id));
+        paginator.batch(
+          () => {
+            for (const failed of failedBefore) {
+              if (!visible.has(failed.id)) paginator.ingestItem(failed);
+            }
+          },
+          { coalesce: true },
+        );
+      }
     } catch (error) {
       this.state.partialNext({ lastReloadError: error as Error });
       throw error;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1886,10 +1886,8 @@ export class Channel extends ChannelApi {
       this.offlineMode = false;
 
       if (failedBefore.length) {
-        // Membership is checked against the visible window, NOT `getItem`: that reads the item index,
-        // which can still hold a message the rebuild dropped from the loaded window — so an
-        // index-based guard skips the reingest on exactly the disjoint set rebuild that needs it,
-        // and the user's unsent message silently disappears from the list.
+        // Make sure the messages that failed to be sent before the watch() request are
+        // reingested after the watch() query.
         const visible = new Set((paginator.items ?? []).map((message) => message.id));
         paginator.batch(
           () => {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1694,21 +1694,6 @@ export class Channel extends ChannelApi {
   }
 
   /**
-   * The error thrown by the most recent attempt to load this channel's message window, or
-   * `undefined` when it succeeded. Store-backed and reactive — subscribe via
-   * `useStateStore(channel.state, (s) => ({ lastLoadError: s.lastLoadError }))`.
-   *
-   * Read-only on purpose: it is owned by `watch()`, which clears it before it awaits anything and
-   * records a failure before rethrowing. `reload()` goes through `watch()`, so a failed reconnect
-   * reload lands here too — as does the open-while-offline case, where the mount-time `watch()` is
-   * what throws. Nothing else clears it: a load error is invalidated by the next load, not by a
-   * connection event.
-   */
-  get lastLoadError() {
-    return this.state.getLatestValue().lastLoadError;
-  }
-
-  /**
    * Whether this client holds a server-side watch on the channel, and if not, whether it should be
    * restored — see {@link ChannelWatchStatus}. Store-backed and reactive: subscribe via
    * `useStateStore(channel.state, (s) => ({ watchStatus: s.watchStatus }))`.
@@ -1838,8 +1823,8 @@ export class Channel extends ChannelApi {
    * @returns The server response.
    */
   async watch(options?: ChannelGetOrCreateRequest) {
-    if (this.lastLoadError) {
-      this.state.partialNext({ lastLoadError: undefined });
+    if (this.messagePaginator.lastQueryError) {
+      this.messagePaginator.state.partialNext({ lastQueryError: undefined });
     }
 
     const defaultOptions = {
@@ -1856,13 +1841,7 @@ export class Channel extends ChannelApi {
     }
 
     const combined = { ...defaultOptions, ...options };
-    let state;
-    try {
-      state = await this.query(combined, 'latest');
-    } catch (error) {
-      this.state.partialNext({ lastLoadError: error as Error });
-      throw error;
-    }
+    const state = await this.query(combined, 'latest');
     this.initialized = true;
     const previousData = this.data;
     this.data = state.channel;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1872,7 +1872,7 @@ export class Channel extends ChannelApi {
    * This is intentionally thin: it only re-issues `watch()` with a limit sized to the loaded window
    * (`items.length`, so the whole loaded window is refreshed — not the smaller channel-list page). The
    * actual fold + destructive reconciliation happens inside `query()` → `seedFirstPageSync`
-   * (the same path the channel-list re-hydrate and React's `recoverState` use), driven by the loaded-id
+   * (the same path the channel-list re-hydrate and connection recovery use), driven by the loaded-id
    * snapshot `query()` captures before its await. Owning that single path is what lets the SDK stop
    * passing the reconciliation window/snapshot itself.
    *

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1823,10 +1823,6 @@ export class Channel extends ChannelApi {
    * @returns The server response.
    */
   async watch(options?: ChannelGetOrCreateRequest) {
-    if (this.messagePaginator.lastQueryError) {
-      this.messagePaginator.state.partialNext({ lastQueryError: undefined });
-    }
-
     const defaultOptions = {
       state: true,
       watch: true,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1694,6 +1694,18 @@ export class Channel extends ChannelApi {
   }
 
   /**
+   * The error thrown by the most recent {@link Channel.reload}, or `undefined` when it succeeded.
+   * Store-backed and reactive — subscribe via
+   * `useStateStore(channel.state, (s) => ({ lastReloadError: s.lastReloadError }))`.
+   *
+   * Read-only on purpose: it is owned by `reload()`, which clears it on entry and records a failure
+   * before rethrowing.
+   */
+  get lastReloadError() {
+    return this.state.getLatestValue().lastReloadError;
+  }
+
+  /**
    * Whether this client holds a server-side watch on the channel, and if not, whether it should be
    * restored — see {@link ChannelWatchStatus}. Store-backed and reactive: subscribe via
    * `useStateStore(channel.state, (s) => ({ watchStatus: s.watchStatus }))`.
@@ -1871,6 +1883,11 @@ export class Channel extends ChannelApi {
   async reload() {
     if (this._reloading || (!this.initialized && !this.offlineMode)) return;
     this._reloading = true;
+    // Clear before the attempt, so a successful reload dismisses whatever the previous failure
+    // surfaced (mirrors BasePaginator clearing `lastQueryError` before each query).
+    if (this.lastReloadError) {
+      this.state.partialNext({ lastReloadError: undefined });
+    }
     try {
       const paginator = this.messagePaginator;
       const headItems = paginator.headItems;
@@ -1888,6 +1905,9 @@ export class Channel extends ChannelApi {
         },
         { coalesce: true },
       );
+    } catch (error) {
+      this.state.partialNext({ lastReloadError: error as Error });
+      throw error;
     } finally {
       this._reloading = false;
     }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1694,15 +1694,18 @@ export class Channel extends ChannelApi {
   }
 
   /**
-   * The error thrown by the most recent {@link Channel.reload}, or `undefined` when it succeeded.
-   * Store-backed and reactive — subscribe via
-   * `useStateStore(channel.state, (s) => ({ lastReloadError: s.lastReloadError }))`.
+   * The error thrown by the most recent attempt to load this channel's message window, or
+   * `undefined` when it succeeded. Store-backed and reactive — subscribe via
+   * `useStateStore(channel.state, (s) => ({ lastLoadError: s.lastLoadError }))`.
    *
-   * Read-only on purpose: it is owned by `reload()`, which clears it on entry and records a failure
-   * before rethrowing.
+   * Read-only on purpose: it is owned by `watch()`, which clears it before it awaits anything and
+   * records a failure before rethrowing. `reload()` goes through `watch()`, so a failed reconnect
+   * reload lands here too — as does the open-while-offline case, where the mount-time `watch()` is
+   * what throws. Nothing else clears it: a load error is invalidated by the next load, not by a
+   * connection event.
    */
-  get lastReloadError() {
-    return this.state.getLatestValue().lastReloadError;
+  get lastLoadError() {
+    return this.state.getLatestValue().lastLoadError;
   }
 
   /**
@@ -1835,6 +1838,10 @@ export class Channel extends ChannelApi {
    * @returns The server response.
    */
   async watch(options?: ChannelGetOrCreateRequest) {
+    if (this.lastLoadError) {
+      this.state.partialNext({ lastLoadError: undefined });
+    }
+
     const defaultOptions = {
       state: true,
       watch: true,
@@ -1849,7 +1856,13 @@ export class Channel extends ChannelApi {
     }
 
     const combined = { ...defaultOptions, ...options };
-    const state = await this.query(combined, 'latest');
+    let state;
+    try {
+      state = await this.query(combined, 'latest');
+    } catch (error) {
+      this.state.partialNext({ lastLoadError: error as Error });
+      throw error;
+    }
     this.initialized = true;
     const previousData = this.data;
     this.data = state.channel;
@@ -1883,11 +1896,6 @@ export class Channel extends ChannelApi {
   async reload() {
     if (this._reloading || (!this.initialized && !this.offlineMode)) return;
     this._reloading = true;
-    // Clear before the attempt, so a successful reload dismisses whatever the previous failure
-    // surfaced (mirrors BasePaginator clearing `lastQueryError` before each query).
-    if (this.lastReloadError) {
-      this.state.partialNext({ lastReloadError: undefined });
-    }
     try {
       const paginator = this.messagePaginator;
       const headItems = paginator.headItems;
@@ -1913,9 +1921,6 @@ export class Channel extends ChannelApi {
           { coalesce: true },
         );
       }
-    } catch (error) {
-      this.state.partialNext({ lastReloadError: error as Error });
-      throw error;
     } finally {
       this._reloading = false;
     }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1891,7 +1891,8 @@ export class Channel extends ChannelApi {
     try {
       const paginator = this.messagePaginator;
       const headItems = paginator.headItems;
-      const requestedLimit = headItems.length || paginator.pageSize;
+      const requestedLimit =
+        Math.max(headItems.length, paginator.pageSize ?? 0) || undefined;
       const failedBefore = headItems.filter((message) => message.status === 'failed');
 
       await this.watch({ messages: { limit: requestedLimit } });

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -145,15 +145,20 @@ export type ChannelLifecycleState = {
    */
   pendingDisposal: boolean;
   /**
-   * The error from the most recent {@link Channel.reload}, or `undefined` when the last one
-   * succeeded. Mirrors `BasePaginator`'s `lastQueryError` one level up: cleared when a reload starts
-   * and set when it throws, so a UI can surface "could not refresh this channel" without owning the
-   * call. `reload()` still rethrows, so callers that await it are unaffected.
+   * The error from the most recent attempt to load this channel's message window
+   * ({@link Channel.watch}, and so {@link Channel.reload} too), or `undefined` when the last one
+   * succeeded. Mirrors `BasePaginator`'s `lastQueryError` one level up: cleared when an attempt
+   * starts and set when it throws, so a UI can surface "could not load this channel" by reading
+   * state instead of holding a latch of its own. `watch()` still rethrows, so callers that await it
+   * are unaffected.
    *
-   * This exists because the reload is no longer issued by the UI: `ConnectionRecoveryManager` runs it
-   * on reconnect inside a `Promise.allSettled`, which would otherwise swallow the failure silently.
+   * Store-backed because the two failures a UI cares about reach it differently and neither is
+   * catchable at the call site: the reconnect reload is issued by `ConnectionRecoveryManager` inside
+   * a `Promise.allSettled`, and an open-while-offline `watch()` throws at mount, long before
+   * anything that could later prove it stale. Recording it here is what lets it be *invalidated* by
+   * the next attempt rather than guessed at.
    */
-  lastReloadError?: Error;
+  lastLoadError?: Error;
 };
 
 /**
@@ -229,7 +234,7 @@ export class ChannelState extends StateStore<ChannelStateData> {
       initialized: false,
       offlineMode: false,
       pendingDisposal: false,
-      lastReloadError: undefined,
+      lastLoadError: undefined,
       active: false,
       aiState: AIStates.Idle,
     });

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -144,21 +144,6 @@ export type ChannelLifecycleState = {
    * {@link Channel.pendingDisposal}: the instance is never revived.
    */
   pendingDisposal: boolean;
-  /**
-   * The error from the most recent attempt to load this channel's message window
-   * ({@link Channel.watch}, and so {@link Channel.reload} too), or `undefined` when the last one
-   * succeeded. Mirrors `BasePaginator`'s `lastQueryError` one level up: cleared when an attempt
-   * starts and set when it throws, so a UI can surface "could not load this channel" by reading
-   * state instead of holding a latch of its own. `watch()` still rethrows, so callers that await it
-   * are unaffected.
-   *
-   * Store-backed because the two failures a UI cares about reach it differently and neither is
-   * catchable at the call site: the reconnect reload is issued by `ConnectionRecoveryManager` inside
-   * a `Promise.allSettled`, and an open-while-offline `watch()` throws at mount, long before
-   * anything that could later prove it stale. Recording it here is what lets it be *invalidated* by
-   * the next attempt rather than guessed at.
-   */
-  lastLoadError?: Error;
 };
 
 /**
@@ -234,7 +219,6 @@ export class ChannelState extends StateStore<ChannelStateData> {
       initialized: false,
       offlineMode: false,
       pendingDisposal: false,
-      lastLoadError: undefined,
       active: false,
       aiState: AIStates.Idle,
     });

--- a/src/channel_state.ts
+++ b/src/channel_state.ts
@@ -144,6 +144,16 @@ export type ChannelLifecycleState = {
    * {@link Channel.pendingDisposal}: the instance is never revived.
    */
   pendingDisposal: boolean;
+  /**
+   * The error from the most recent {@link Channel.reload}, or `undefined` when the last one
+   * succeeded. Mirrors `BasePaginator`'s `lastQueryError` one level up: cleared when a reload starts
+   * and set when it throws, so a UI can surface "could not refresh this channel" without owning the
+   * call. `reload()` still rethrows, so callers that await it are unaffected.
+   *
+   * This exists because the reload is no longer issued by the UI: `ConnectionRecoveryManager` runs it
+   * on reconnect inside a `Promise.allSettled`, which would otherwise swallow the failure silently.
+   */
+  lastReloadError?: Error;
 };
 
 /**
@@ -219,6 +229,7 @@ export class ChannelState extends StateStore<ChannelStateData> {
       initialized: false,
       offlineMode: false,
       pendingDisposal: false,
+      lastReloadError: undefined,
       active: false,
       aiState: AIStates.Idle,
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -485,10 +485,6 @@ export class StreamChat extends ChatApi {
     }
 
     this.offlineDb = offlineDBInstance;
-    // Recovery of the active channel has to run after pending-task replay and sync, which is what the
-    // DB's sync-status edge signals. The DB arrives after the client was constructed, so this is the
-    // first moment that trigger can be wired up.
-    this.connectionRecovery.attachOfflineDb(offlineDBInstance);
   }
 
   getAuthType() {
@@ -1172,7 +1168,7 @@ export class StreamChat extends ChatApi {
     }
 
     // Current user removed from a channel: evict it like channel.deleted so
-    // recoverState won't re-watch it and no further events reach it (#2599).
+    // connection recovery won't re-watch it and no further events reach it (#2599).
     // Type-agnostic. We skip deleteAllChannelReference (unlike deletion) since
     // the channel still exists for its remaining members.
     if (event.type === 'notification.removed_from_channel' && event.cid) {
@@ -1268,29 +1264,23 @@ export class StreamChat extends ChatApi {
   };
 
   /**
-   * Settles the connect promises after a reconnect.
+   * Settles the connect promises after a successful reconnect, so the `await this.wsPromise` gates
+   * spread across the client stop resolving against a superseded (possibly rejected) attempt.
    *
-   * Recovery itself is owned by {@link ConnectionRecoveryManager}, which is subscribed to the
-   * connection lifecycle and so covers every reconnect path — including
-   * `closeConnection()` → `openConnection()` (mobile backgrounding), which never reaches this method:
-   * `StableWSConnection._reconnect()` is its only caller. That is also why `connection.recovered` is
-   * now dispatched by the manager rather than here.
+   * Called by `StableWSConnection._reconnect()`. Recovery itself is owned by
+   * {@link ConnectionRecoveryManager}, which subscribes to the connection lifecycle and so covers
+   * every reconnect path — including `closeConnection()` → `openConnection()` (mobile backgrounding),
+   * which never reaches `_reconnect()` at all.
    *
-   * What used to live here was a single
-   * `queryChannelsAndHydrate({ cid: { $in: Object.keys(activeChannels) }, limit: 30 })`. It has been
-   * removed: it substituted its own query shape for the ones the application's channel lists actually
-   * use, and silently recovered no more than thirty channels regardless of how many were loaded.
+   * @internal
    */
-  recoverState = () => {
+  _settleConnectPromises = () => {
     logger
-      .withExtraTags('recoverState')
+      .withExtraTags('_settleConnectPromises')
       .info(`Connection re-established with connection ID ${this._getConnectionID()}.`);
 
     this.wsPromise = Promise.resolve();
     this.setUserPromise = Promise.resolve();
-
-    // Still returns a promise: `StableWSConnection._reconnect()` awaits this, and it is public API.
-    return Promise.resolve();
   };
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -64,6 +64,7 @@ import { DEFAULT_QUERY_CHANNELS_MESSAGE_LIST_PAGE_SIZE } from './constants';
 import { PollManager } from './poll_manager';
 import { EntityStore } from './entityStore/EntityStore';
 import { ChannelManager } from './ChannelManager';
+import { ConnectionRecoveryManager } from './ConnectionRecoveryManager';
 import { MessageDeliveryReporter } from './messageDelivery';
 import { NotificationManager } from './notifications';
 import { ReminderManager } from './reminders';
@@ -141,6 +142,14 @@ export class StreamChat extends ChatApi {
    */
   channelManager: ChannelManager;
   /**
+   * Owns connection recovery: on reconnect it re-runs each loaded channel list's own first-page query
+   * and reloads each active channel, then dispatches `connection.recovered`. Instantiated with the
+   * client and subscribed for its lifetime.
+   *
+   * Turn it off with the `recoverStateOnReconnect` option if the application recovers state itself.
+   */
+  connectionRecovery: ConnectionRecoveryManager;
+  /**
    * Client-global, normalized store holding one canonical copy of each message. The channel main
    * list and thread reply paginators read/write message content through it, so a message held in
    * more than one of them stays consistent without copy-to-copy fan-out.
@@ -158,13 +167,13 @@ export class StreamChat extends ChatApi {
   key: string;
   listeners: Map<EventType, Set<EventHandler>>;
   /**
-   * When network is recovered, we re-query the active channels on client. But in single query, you can recover
-   * only 30 channels. So its not guaranteed that all the channels in activeChannels object have updated state.
-   * Thus in UI sdks, state recovery is managed by components themselves, they don't rely on js client for this.
+   * Whether the client recovers its own state when the connection comes back (default `true`).
    *
-   * `recoverStateOnReconnect` parameter can be used in such cases, to disable state recovery within js client.
-   * When false, user/consumer of this client will need to make sure all the channels present on UI by
-   * manually calling queryChannels endpoint.
+   * When enabled, {@link ConnectionRecoveryManager} re-runs each loaded channel list's own first-page
+   * query and reloads each active channel, then dispatches `connection.recovered`.
+   *
+   * Set it to `false` only if the application recovers state itself — nothing will then be re-queried
+   * or re-watched on reconnect, and it becomes the consumer's job to refresh whatever is on screen.
    */
   recoverStateOnReconnect?: boolean;
   /**
@@ -339,6 +348,11 @@ export class StreamChat extends ChatApi {
     this.threads = new ThreadManager({ client: this });
     this.polls = new PollManager({ client: this });
     this.channelManager = new ChannelManager({ client: this });
+    this.connectionRecovery = new ConnectionRecoveryManager({ client: this });
+    // Subscribed here rather than by the consumer: recovery is not an opt-in feature, it is what the
+    // client owes anything reading its state after a reconnect. `recoverStateOnReconnect` is the
+    // opt-out, checked at recovery time.
+    this.connectionRecovery.registerSubscriptions();
     this.reminders = new ReminderManager({ client: this });
     this.messageDeliveryReporter = new MessageDeliveryReporter({ client: this });
     this.messageComposerCache = new FixedSizeQueueCache<string, MessageComposer>(64);
@@ -471,6 +485,10 @@ export class StreamChat extends ChatApi {
     }
 
     this.offlineDb = offlineDBInstance;
+    // Recovery of the active channel has to run after pending-task replay and sync, which is what the
+    // DB's sync-status edge signals. The DB arrives after the client was constructed, so this is the
+    // first moment that trigger can be wired up.
+    this.connectionRecovery.attachOfflineDb(offlineDBInstance);
   }
 
   getAuthType() {
@@ -1249,37 +1267,30 @@ export class StreamChat extends ChatApi {
     );
   };
 
-  recoverState = async () => {
+  /**
+   * Settles the connect promises after a reconnect.
+   *
+   * Recovery itself is owned by {@link ConnectionRecoveryManager}, which is subscribed to the
+   * connection lifecycle and so covers every reconnect path — including
+   * `closeConnection()` → `openConnection()` (mobile backgrounding), which never reaches this method:
+   * `StableWSConnection._reconnect()` is its only caller. That is also why `connection.recovered` is
+   * now dispatched by the manager rather than here.
+   *
+   * What used to live here was a single
+   * `queryChannelsAndHydrate({ cid: { $in: Object.keys(activeChannels) }, limit: 30 })`. It has been
+   * removed: it substituted its own query shape for the ones the application's channel lists actually
+   * use, and silently recovered no more than thirty channels regardless of how many were loaded.
+   */
+  recoverState = () => {
     logger
       .withExtraTags('recoverState')
-      .info(`Starting state recovery with connection ID ${this._getConnectionID()}.`);
-
-    const cids = Object.keys(this.activeChannels);
-    if (cids.length && this.recoverStateOnReconnect) {
-      logger
-        .withExtraTags('recoverState')
-        .info(`Starting the query for ${cids.length} channel(s).`);
-
-      await this.queryChannelsAndHydrate({
-        filter_conditions: {
-          cid: { $in: cids },
-        },
-        limit: 30,
-        sort: [{ field: 'last_message_at', direction: -1 }],
-      });
-
-      logger.withExtraTags('recoverState').info('Finished querying channels.');
-      this.dispatchEvent({
-        type: 'connection.recovered',
-      });
-    } else {
-      this.dispatchEvent({
-        type: 'connection.recovered',
-      });
-    }
+      .info(`Connection re-established with connection ID ${this._getConnectionID()}.`);
 
     this.wsPromise = Promise.resolve();
     this.setUserPromise = Promise.resolve();
+
+    // Still returns a promise: `StableWSConnection._reconnect()` awaits this, and it is public API.
+    return Promise.resolve();
   };
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -146,7 +146,8 @@ export class StreamChat extends ChatApi {
    * and reloads each active channel, then dispatches `connection.recovered`. Instantiated with the
    * client and subscribed for its lifetime.
    *
-   * Turn it off with the `recoverStateOnReconnect` option if the application recovers state itself.
+   * Turn it off through the declarative configuration if the application recovers state itself:
+   * `client.config.set({ client: { connectionRecovery: { enabled: false } } })`.
    */
   connectionRecovery: ConnectionRecoveryManager;
   /**
@@ -166,16 +167,6 @@ export class StreamChat extends ChatApi {
   clientId?: string;
   key: string;
   listeners: Map<EventType, Set<EventHandler>>;
-  /**
-   * Whether the client recovers its own state when the connection comes back (default `true`).
-   *
-   * When enabled, {@link ConnectionRecoveryManager} re-runs each loaded channel list's own first-page
-   * query and reloads each active channel, then dispatches `connection.recovered`.
-   *
-   * Set it to `false` only if the application recovers state itself — nothing will then be re-queried
-   * or re-watched on reconnect, and it becomes the consumer's job to refresh whatever is on screen.
-   */
-  recoverStateOnReconnect?: boolean;
   /**
    * If true, we will not clean up threads when channel state is in initializing state.
    * The main use case for SDKs who do independent state recovery for channels.
@@ -300,7 +291,6 @@ export class StreamChat extends ChatApi {
 
     this.options = {
       warmUp: false,
-      recoverStateOnReconnect: true,
       disableCache: false,
       isLocalUnreadCountEnabled: false,
       wsUrlParams: new URLSearchParams({}),
@@ -341,7 +331,6 @@ export class StreamChat extends ChatApi {
 
     this.defaultWSTimeout = 15 * 1000;
 
-    this.recoverStateOnReconnect = this.options.recoverStateOnReconnect;
     this.messageStore = new EntityStore<LocalMessage>({
       getEntityId: (message) => message.id,
     });
@@ -402,6 +391,7 @@ export class StreamChat extends ChatApi {
   private initializeManagerConfig() {
     const config = this.config.getConfig('client');
 
+    this.connectionRecovery.initializeConfig(config?.connectionRecovery);
     this.reminders.initializeConfig(config?.reminders);
     this.threads.initializeConfig(config?.threads);
     this.messageDeliveryReporter.initializeConfig(config?.messageDelivery);

--- a/src/client.ts
+++ b/src/client.ts
@@ -349,9 +349,6 @@ export class StreamChat extends ChatApi {
     this.polls = new PollManager({ client: this });
     this.channelManager = new ChannelManager({ client: this });
     this.connectionRecovery = new ConnectionRecoveryManager({ client: this });
-    // Subscribed here rather than by the consumer: recovery is not an opt-in feature, it is what the
-    // client owes anything reading its state after a reconnect. `recoverStateOnReconnect` is the
-    // opt-out, checked at recovery time.
     this.connectionRecovery.registerSubscriptions();
     this.reminders = new ReminderManager({ client: this });
     this.messageDeliveryReporter = new MessageDeliveryReporter({ client: this });

--- a/src/configuration/shape.ts
+++ b/src/configuration/shape.ts
@@ -9,6 +9,7 @@ import type { DeclarativePaginatorConfig } from '../pagination/paginators/BasePa
 import type { MessageOperationsConfig } from '../messageOperations/MessageOperations';
 import type { MessageDeliveryReporterConfig } from '../messageDelivery/MessageDeliveryReporter';
 import type { ThreadManagerConfig } from '../thread_manager';
+import type { ConnectionRecoveryManagerConfig } from '../ConnectionRecoveryManager';
 import type { LiveLocationManagerConfig } from '../LiveLocationManager';
 import type { SearchControllerConfig } from '../search/SearchController';
 import type { NotificationManagerConfig } from '../notifications/types';
@@ -437,7 +438,25 @@ const REMINDER_FIELDS: Record<keyof ReminderManagerConfig, ConfigNode> = {
   },
 };
 
+const CONNECTION_RECOVERY_FIELDS: Record<
+  keyof ConnectionRecoveryManagerConfig,
+  ConfigNode
+> = {
+  enabled: {
+    description:
+      'Whether the client recovers its own state on reconnect. Turn it off only if the application re-queries and re-watches everything on screen itself.',
+    kind: 'value',
+    type: 'boolean',
+  },
+};
+
 const CLIENT_FIELDS: Record<keyof ClientDeclarativeConfig, ConfigNode> = {
+  connectionRecovery: {
+    description:
+      'Bringing the channels, lists and threads you are reading back in line after a reconnect.',
+    fields: CONNECTION_RECOVERY_FIELDS,
+    kind: 'group',
+  },
   messageDelivery: {
     description: 'Delivery and read receipt reporting.',
     fields: MESSAGE_DELIVERY_FIELDS,

--- a/src/configuration/types.ts
+++ b/src/configuration/types.ts
@@ -15,6 +15,7 @@ import type { ReminderManagerConfig } from '../reminders/ReminderManager';
 import type { NotificationManagerConfig } from '../notifications/types';
 import type { MessageDeliveryReporterConfig } from '../messageDelivery/MessageDeliveryReporter';
 import type { ThreadManagerConfig } from '../thread_manager';
+import type { ConnectionRecoveryManagerConfig } from '../ConnectionRecoveryManager';
 import type { MessageOperationsConfig } from '../messageOperations/MessageOperations';
 import type { DeclarativePaginatorConfig as ImportedDeclarativePaginatorConfig } from '../pagination/paginators/BasePaginator';
 import type { DeepPartial } from '../types.utility';
@@ -136,6 +137,7 @@ export type ClientDeclarativeConfig = {
    * Nested rather than top-level keys: each of these managers has exactly one parent — the client — so
    * there is nothing to say once and reuse, which is what a top-level key buys (**DEC-25**).
    */
+  connectionRecovery?: Partial<ConnectionRecoveryManagerConfig>;
   messageDelivery?: Partial<MessageDeliveryReporterConfig>;
   threads?: Partial<ThreadManagerConfig>;
   notifications?: DeepPartial<NotificationManagerConfig>;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -453,9 +453,7 @@ export class StableWSConnection {
 
     try {
       await this._connect();
-      logger.withExtraTags('_reconnect').debug('Waiting for the recover callback.');
-      await this.client.recoverState();
-      logger.withExtraTags('_reconnect').debug('Finished the recover callback.');
+      this.client._settleConnectPromises();
 
       this.consecutiveFailures = 0;
     } catch (error: any) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -42,6 +42,21 @@ export function isAPIError(error: Error): error is APIError {
   return (error as APIError).code !== undefined;
 }
 
+/**
+ * Whether the server answered "this does not exist" — a definitive, expected answer rather than a
+ * failure. Distinct from a network error: the request succeeded, the resource simply is not there.
+ * Use it to avoid surfacing an error state for something a caller can legitimately ask about before
+ * it exists (a thread on a parent that has no replies yet, say).
+ *
+ * Resolved through {@link APIErrorCodes} rather than comparing the numeric code, so the table stays
+ * the single place the mapping lives.
+ */
+export function isDoesNotExistError(error: Error): boolean {
+  return (
+    isAPIError(error) && APIErrorCodes[`${error.code}`]?.name === 'DoesNotExistError'
+  );
+}
+
 export function isErrorRetryable(error: APIError) {
   if (!error.code) return false;
   const err = APIErrorCodes[`${error.code}`];

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,4 +108,5 @@ export {
 } from './utils';
 export { FixedSizeQueueCache } from './utils/FixedSizeQueueCache';
 export * from './ChannelManager';
+export * from './ConnectionRecoveryManager';
 export * from './EventHandlerPipeline';

--- a/src/pagination/paginators/MessageIntervalPaginator.ts
+++ b/src/pagination/paginators/MessageIntervalPaginator.ts
@@ -706,7 +706,46 @@ export class MessageIntervalPaginator extends BasePaginator<
    */
   mergeNewestPage = (page: LocalMessage[], options?: MergeNewestPageOptions) => {
     const headInterval = this.itemIntervals[0] as Interval | undefined;
-    if (!headInterval?.isHead) return;
+    if (!headInterval?.isHead) {
+      // Live content no page has anchored yet, the first query came back empty and the reply the
+      // user then sent went to the logical head (a thread/channel creation for example). Returning would
+      // discard the fetched page, so the window could never catch up. We anchor it, so `ingestPage` folds
+      // overlapping logical intervals in, absorbing those items.
+      //
+      // It's narrow on purpose, `liveHeadLogical` rather than `itemIntervals[0]`, which is only the head
+      // by convention and could be a logical tail and no anchored head, whose presence would mean
+      // this window is anchored with an older island merely in view. Keeps both neighbouring no-op
+      // contracts, so nothing loaded has no logical head (seeding is `postQueryReconcile`'s job).
+      const logicalHead = this.liveHeadLogical;
+      const hasAnchoredHead = this.itemIntervals.some(
+        (interval) => !isLogicalInterval(interval) && interval.isHead,
+      );
+      if (!logicalHead || hasAnchoredHead || !page?.length) return;
+
+      // Take over the view only if the reader is on the live content being absorbed, so if they jumped
+      // to another interval, anchor for their return and leave them there (the rule the jumped away
+      // branch below enforces).
+      const takeOverView = this.isActiveInterval(logicalHead);
+
+      const anchored = this.ingestPage({ page, isHead: true, setActive: false });
+      if (!anchored || !takeOverView) return;
+
+      const hasMoreTailFromLogical = !this.pageReachedChannelStart(page, options);
+      anchored.hasMoreTail = hasMoreTailFromLogical;
+      anchored.isTail = !hasMoreTailFromLogical;
+
+      this.setActiveInterval(anchored, { updateState: false });
+      this.state.partialNext({
+        items: this.intervalToItems(anchored),
+        hasMoreHead: false,
+        hasMoreTail: hasMoreTailFromLogical,
+        cursor: {
+          headward: null,
+          tailward: hasMoreTailFromLogical ? (anchored.itemIds[0] ?? null) : null,
+        },
+      });
+      return;
+    }
     // Captured BEFORE the merge overwrites state — inputs for the below-window reached-start probe
     // (overlap branch only): did we believe we were at the channel start, and how much was loaded.
     const wasAtChannelStart = !this.state.getLatestValue().hasMoreTail;

--- a/src/pagination/paginators/MessageIntervalPaginator.ts
+++ b/src/pagination/paginators/MessageIntervalPaginator.ts
@@ -528,6 +528,13 @@ export class MessageIntervalPaginator extends BasePaginator<
     const isJump = this.isJumpQueryShape(queryShape);
 
     if (options?.reconcile && !isJump && typeof this.items !== 'undefined') {
+      // The page came back, so whatever the last query failure was, it is no longer the truth. The
+      // branch below inherits this from `postQueryReconcile`, which this one deliberately skips —
+      // without it a failed "load older" would keep a UI's error surface latched through an
+      // otherwise successful reconnect refresh.
+      if (this.state.getLatestValue().lastQueryError) {
+        this.state.partialNext({ lastQueryError: undefined });
+      }
       this.mergeNewestPage(messages, {
         candidateIds: options.candidateIds,
         requestedLimit: requestedPageSize,
@@ -730,18 +737,18 @@ export class MessageIntervalPaginator extends BasePaginator<
       const anchored = this.ingestPage({ page, isHead: true, setActive: false });
       if (!anchored || !takeOverView) return;
 
-      const hasMoreTailFromLogical = !this.pageReachedChannelStart(page, options);
-      anchored.hasMoreTail = hasMoreTailFromLogical;
-      anchored.isTail = !hasMoreTailFromLogical;
+      const hasMoreTail = !this.pageReachedChannelStart(page, options);
+      anchored.hasMoreTail = hasMoreTail;
+      anchored.isTail = !hasMoreTail;
 
       this.setActiveInterval(anchored, { updateState: false });
       this.state.partialNext({
         items: this.intervalToItems(anchored),
         hasMoreHead: false,
-        hasMoreTail: hasMoreTailFromLogical,
+        hasMoreTail,
         cursor: {
           headward: null,
-          tailward: hasMoreTailFromLogical ? (anchored.itemIds[0] ?? null) : null,
+          tailward: hasMoreTail ? (anchored.itemIds[0] ?? null) : null,
         },
       });
       return;

--- a/src/pagination/paginators/MessageIntervalPaginator.ts
+++ b/src/pagination/paginators/MessageIntervalPaginator.ts
@@ -190,7 +190,7 @@ export type SeedFirstPageOptions = {
    * {@link MessageIntervalPaginator.mergeNewestPage} — merge in place, reconcile offline hard-deletes,
    * re-derive the tail cursor, rebuild on a disjoint window, and skip when jumped away from the head —
    * instead of a plain first-page ingest. Lets callers (channel.reload, the channel-list hydrate,
-   * React's `recoverState`) share one reconciling seed path. Left false for the differently-sorted
+   * connection recovery) share one reconciling seed path. Left false for the differently-sorted
    * pinned list, and a no-op on a cold open (nothing loaded to fold).
    */
   reconcile?: boolean;

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -458,9 +458,6 @@ export class Thread extends WithSubscriptions {
       return;
     }
 
-    if (this.messagePaginator.lastQueryError) {
-      this.messagePaginator.state.partialNext({ lastQueryError: undefined });
-    }
     this.state.partialNext({ isLoading: true });
 
     try {

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -59,10 +59,10 @@ export type ThreadState = {
   isStateStale: boolean;
   /**
    * The error thrown by the most recent {@link Thread.reload}, or `undefined` when it succeeded.
-   * Mirrors `channel.state.lastReloadError`: connection recovery runs reloads inside
+   * Mirrors `channel.state.lastLoadError`: connection recovery runs reloads inside
    * `Promise.allSettled`, so a failure has to be published rather than only thrown.
    */
-  lastReloadError?: Error;
+  lastLoadError?: Error;
   /**
    * Thread is identified by and has a one-to-one relation with its parent message.
    * We use parent message id as a thread id.
@@ -457,7 +457,7 @@ export class Thread extends WithSubscriptions {
    * reconcile's provenance guard never prunes a non-server message); only a disjoint rebuild can drop
    * them, so any that actually fell out are re-ingested below.
    *
-   * Publishes a failure on `state.lastReloadError` **and** rethrows: recovery runs this inside a
+   * Publishes a failure on `state.lastLoadError` **and** rethrows: recovery runs this inside a
    * `Promise.allSettled`, so a consumer that wants to surface the failure has to read it from state.
    */
   public reload = async () => {
@@ -467,7 +467,7 @@ export class Thread extends WithSubscriptions {
 
     // Cleared before the attempt, so a successful reload dismisses whatever the previous failure
     // surfaced (mirrors `Channel.reload` and `BasePaginator`'s `lastQueryError`).
-    this.state.partialNext({ isLoading: true, lastReloadError: undefined });
+    this.state.partialNext({ isLoading: true, lastLoadError: undefined });
 
     try {
       const loadedReplies = this.messagePaginator.items ?? [];
@@ -511,7 +511,7 @@ export class Thread extends WithSubscriptions {
       // deleted replies will simply not throw.
       if (neverExisted) return;
 
-      this.state.partialNext({ lastReloadError: error as Error });
+      this.state.partialNext({ lastLoadError: error as Error });
       throw error;
     } finally {
       this.state.partialNext({ isLoading: false });

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -472,7 +472,8 @@ export class Thread extends WithSubscriptions {
     try {
       const loadedReplies = this.messagePaginator.items ?? [];
       const loadedReplyCount = loadedReplies.length;
-      const requestedReplyLimit = loadedReplyCount || this.messagePaginator.pageSize;
+      const requestedReplyLimit =
+        Math.max(loadedReplyCount, this.messagePaginator.pageSize ?? 0) || undefined;
       const reconcileCandidateIds = new Set(loadedReplies.map((reply) => reply.id));
       const failedBefore = loadedReplies.filter((reply) => reply.status === 'failed');
       const thread = await this.client.getThreadAndHydrate(this.id, {

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -20,7 +20,7 @@ import type {
   ThreadStateResponse,
   UserResponse,
 } from './types';
-import { isEphemeral } from './errors';
+import { isDoesNotExistError, isEphemeral } from './errors';
 import type {
   Channel,
   DeleteMessageWithStateUpdateParams,
@@ -502,6 +502,15 @@ export class Thread extends WithSubscriptions {
         );
       }
     } catch (error) {
+      const notFound =
+        isDoesNotExistError(error as Error) ||
+        (error as { status?: number })?.status === 404;
+      const neverExisted = notFound && this.state.getLatestValue().replyCount === 0;
+      // Do not throw an error if we haven't created the thread yet, the tiebreaker
+      // being whether the parent message has any replies or not. A thread with all hard
+      // deleted replies will simply not throw.
+      if (neverExisted) return;
+
       this.state.partialNext({ lastReloadError: error as Error });
       throw error;
     } finally {

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -58,12 +58,6 @@ export type ThreadState = {
   isLoading: boolean;
   isStateStale: boolean;
   /**
-   * The error thrown by the most recent {@link Thread.reload}, or `undefined` when it succeeded.
-   * Mirrors `channel.state.lastLoadError`: connection recovery runs reloads inside
-   * `Promise.allSettled`, so a failure has to be published rather than only thrown.
-   */
-  lastLoadError?: Error;
-  /**
    * Thread is identified by and has a one-to-one relation with its parent message.
    * We use parent message id as a thread id.
    */
@@ -457,17 +451,17 @@ export class Thread extends WithSubscriptions {
    * reconcile's provenance guard never prunes a non-server message); only a disjoint rebuild can drop
    * them, so any that actually fell out are re-ingested below.
    *
-   * Publishes a failure on `state.lastLoadError` **and** rethrows: recovery runs this inside a
-   * `Promise.allSettled`, so a consumer that wants to surface the failure has to read it from state.
+   * Rethrows, except for a not-found answer on a thread that never had replies (see the catch).
    */
   public reload = async () => {
     if (this.state.getLatestValue().isLoading) {
       return;
     }
 
-    // Cleared before the attempt, so a successful reload dismisses whatever the previous failure
-    // surfaced (mirrors `Channel.reload` and `BasePaginator`'s `lastQueryError`).
-    this.state.partialNext({ isLoading: true, lastLoadError: undefined });
+    if (this.messagePaginator.lastQueryError) {
+      this.messagePaginator.state.partialNext({ lastQueryError: undefined });
+    }
+    this.state.partialNext({ isLoading: true });
 
     try {
       const loadedReplies = this.messagePaginator.items ?? [];
@@ -511,7 +505,6 @@ export class Thread extends WithSubscriptions {
       // deleted replies will simply not throw.
       if (neverExisted) return;
 
-      this.state.partialNext({ lastLoadError: error as Error });
       throw error;
     } finally {
       this.state.partialNext({ isLoading: false });

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -58,6 +58,12 @@ export type ThreadState = {
   isLoading: boolean;
   isStateStale: boolean;
   /**
+   * The error thrown by the most recent {@link Thread.reload}, or `undefined` when it succeeded.
+   * Mirrors `channel.state.lastReloadError`: connection recovery runs reloads inside
+   * `Promise.allSettled`, so a failure has to be published rather than only thrown.
+   */
+  lastReloadError?: Error;
+  /**
    * Thread is identified by and has a one-to-one relation with its parent message.
    * We use parent message id as a thread id.
    */
@@ -114,6 +120,8 @@ export class Thread extends WithSubscriptions {
 
   private client: StreamChat;
   private failedRepliesMap: Map<string, LocalMessage> = new Map();
+  /** How many consumers have called `activate()` without a matching `deactivate()`. */
+  private _activeRefCount = 0;
 
   constructor({
     client,
@@ -408,27 +416,65 @@ export class Thread extends WithSubscriptions {
     return ownUnreadCountSelector(this.client.userId)(this.state.getLatestValue());
   }
 
+  /**
+   * Declares that a consumer is displaying this thread (mirrors `channel.activate()`).
+   *
+   * `active` is also what {@link ConnectionRecoveryManager} filters on to decide which threads to
+   * reload on reconnect, so an unbalanced `deactivate()` now costs more than a missed auto-read —
+   * hence the refcount, matching `channel.activate()`. A thread held by more than one mount stays
+   * active until the last holder releases it.
+   */
   public activate = () => {
-    this.state.partialNext({ active: true });
+    this._activeRefCount += 1;
+    if (this._activeRefCount === 1) {
+      this.state.partialNext({ active: true });
+    }
   };
 
+  /**
+   * Declares that a consumer has stopped displaying this thread (mirrors `channel.deactivate()`).
+   * Only flips `active` back to `false` once the last holder deactivates.
+   */
   public deactivate = () => {
-    this.state.partialNext({ active: false });
+    if (this._activeRefCount === 0) return;
+    this._activeRefCount -= 1;
+    if (this._activeRefCount === 0) {
+      this.state.partialNext({ active: false });
+    }
   };
 
+  /**
+   * Re-queries this thread's replies, sized to the loaded window, and reconciles them in place — the
+   * thread analogue of {@link Channel.reload}, and what connection recovery calls for every active
+   * thread.
+   *
+   * Preserves failed (unsent) replies. They are read out of the reply paginator rather than out of
+   * `failedRepliesMap`, because that map is only written by `upsertReplyLocally`, whose callers are
+   * this thread's own subscriptions and the offline-DB path keyed on `ThreadManager.threadsById` —
+   * neither of which covers a thread constructed directly and never registered (the common path in
+   * the React Native SDK, which resolves `threadsById[id] ?? new Thread(...)`). Reading the paginator
+   * is true for managed and unmanaged threads alike. An overlap merge keeps them anyway (the
+   * reconcile's provenance guard never prunes a non-server message); only a disjoint rebuild can drop
+   * them, so any that actually fell out are re-ingested below.
+   *
+   * Publishes a failure on `state.lastReloadError` **and** rethrows: recovery runs this inside a
+   * `Promise.allSettled`, so a consumer that wants to surface the failure has to read it from state.
+   */
   public reload = async () => {
     if (this.state.getLatestValue().isLoading) {
       return;
     }
 
-    this.state.partialNext({ isLoading: true });
+    // Cleared before the attempt, so a successful reload dismisses whatever the previous failure
+    // surfaced (mirrors `Channel.reload` and `BasePaginator`'s `lastQueryError`).
+    this.state.partialNext({ isLoading: true, lastReloadError: undefined });
 
     try {
-      const loadedReplyCount = this.messagePaginator.items?.length ?? 0;
+      const loadedReplies = this.messagePaginator.items ?? [];
+      const loadedReplyCount = loadedReplies.length;
       const requestedReplyLimit = loadedReplyCount || this.messagePaginator.pageSize;
-      const reconcileCandidateIds = new Set(
-        (this.messagePaginator.items ?? []).map((reply) => reply.id),
-      );
+      const reconcileCandidateIds = new Set(loadedReplies.map((reply) => reply.id));
+      const failedBefore = loadedReplies.filter((reply) => reply.status === 'failed');
       const thread = await this.client.getThreadAndHydrate(this.id, {
         watch: true,
         reply_limit: requestedReplyLimit,
@@ -439,6 +485,24 @@ export class Thread extends WithSubscriptions {
           candidateIds: reconcileCandidateIds,
         },
       });
+
+      if (failedBefore.length) {
+        // Membership is checked against the visible window, NOT `getItem`: that reads the item
+        // index, which can still hold a message the rebuild dropped from the loaded window — so an
+        // index-based guard skips the re-ingest on exactly the path that needs it.
+        const visible = new Set((this.messagePaginator.items ?? []).map((r) => r.id));
+        this.messagePaginator.batch(
+          () => {
+            for (const failed of failedBefore) {
+              if (!visible.has(failed.id)) this.messagePaginator.ingestItem(failed);
+            }
+          },
+          { coalesce: true },
+        );
+      }
+    } catch (error) {
+      this.state.partialNext({ lastReloadError: error as Error });
+      throw error;
     } finally {
       this.state.partialNext({ isLoading: false });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,13 +196,13 @@ export type StreamChatOptions = {
    */
   persistUserOnConnectionFailure?: boolean;
   /**
-   * When network is recovered, we re-query the active channels on client. But in single query, you can recover
-   * only 30 channels. So its not guaranteed that all the channels in activeChannels object have updated state.
-   * Thus in UI sdks, state recovery is managed by components themselves, they don't rely on js client for this.
+   * Whether the client recovers its own state when the connection comes back (default `true`).
    *
-   * `recoverStateOnReconnect` parameter can be used in such cases, to disable state recovery within js client.
-   * When false, user/consumer of this client will need to make sure all the channels present on UI by
-   * manually calling queryChannels endpoint.
+   * When enabled, `ConnectionRecoveryManager` re-runs each loaded channel list's own first-page query
+   * and reloads each active channel, then dispatches `connection.recovered`.
+   *
+   * Set it to `false` only if the application recovers state itself — nothing will then be re-queried
+   * or re-watched on reconnect, and it becomes the consumer's job to refresh whatever is on screen.
    */
   recoverStateOnReconnect?: boolean;
   warmUp?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -195,16 +195,6 @@ export type StreamChatOptions = {
    * persist even if connectUser call fails.
    */
   persistUserOnConnectionFailure?: boolean;
-  /**
-   * Whether the client recovers its own state when the connection comes back (default `true`).
-   *
-   * When enabled, `ConnectionRecoveryManager` re-runs each loaded channel list's own first-page query
-   * and reloads each active channel, then dispatches `connection.recovered`.
-   *
-   * Set it to `false` only if the application recovers state itself — nothing will then be re-queried
-   * or re-watched on reconnect, and it becomes the consumer's job to refresh whatever is on screen.
-   */
-  recoverStateOnReconnect?: boolean;
   warmUp?: boolean;
   /**
    * Sets the instance of `StableWSConnection` on the chat client. Intended purely for testing and

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -182,7 +182,6 @@ const event: Event = {
   online: true,
 };
 voidReturn = client.dispatchEvent(event);
-voidPromise = client.recoverState();
 
 const channels: Promise<Channel[]> = client.queryChannels({}, {}, {});
 channels.then((response) => {

--- a/test/unit/ChannelManager.test.ts
+++ b/test/unit/ChannelManager.test.ts
@@ -4,6 +4,7 @@ import {
   type Channel,
   ChannelPaginator,
   ChannelResponse,
+  ChannelWatchStatus,
   EventTypes,
   type StreamChat,
 } from '../../src';
@@ -1071,6 +1072,159 @@ describe('ChannelManager', () => {
       const p1 = channelManager.ensurePipeline('channel.updated');
       const p2 = channelManager.ensurePipeline('channel.updated');
       expect(p1).toBe(p2);
+    });
+  });
+
+  describe('recover', () => {
+    /**
+     * The channel-list half of connection recovery. Each list re-asserts its OWN query rather than
+     * some substitute, and non-destructively: the point is that a reconnect never blanks a list.
+     */
+    it('re-runs each loaded list as a non-destructive first-page refresh', async () => {
+      const paginator = new ChannelPaginator({ client });
+      // `isInitialized` means "has queried"; fake that without a network round trip.
+      vi.spyOn(paginator, 'isInitialized', 'get').mockReturnValue(true);
+      const toTail = vi.spyOn(paginator, 'toTail').mockResolvedValue(undefined);
+      const channelManager = new ChannelManager({ client, paginators: [paginator] });
+
+      await channelManager.recover();
+
+      expect(toTail).toHaveBeenCalledTimes(1);
+      expect(toTail).toHaveBeenCalledWith({ keepPreviousItems: true, reset: 'yes' });
+    });
+
+    it('does not pass `silent`, which would disable the in-flight guard', async () => {
+      // `silent` suppresses the `isLoading` transition, and `isLoading` is the only thing stopping a
+      // second overlapping query from being issued for the same list (`canExecuteQuery`).
+      const paginator = new ChannelPaginator({ client });
+      vi.spyOn(paginator, 'isInitialized', 'get').mockReturnValue(true);
+      const toTail = vi.spyOn(paginator, 'toTail').mockResolvedValue(undefined);
+
+      await new ChannelManager({ client, paginators: [paginator] }).recover();
+
+      expect(toTail.mock.calls[0][0]).not.to.have.property('silent');
+    });
+
+    it('skips a list that has never queried, so it cannot race its own first query', async () => {
+      const paginator = new ChannelPaginator({ client });
+      expect(paginator.isInitialized).to.equal(false);
+      const toTail = vi.spyOn(paginator, 'toTail').mockResolvedValue(undefined);
+
+      await new ChannelManager({ client, paginators: [paginator] }).recover();
+
+      expect(toTail).not.toHaveBeenCalled();
+    });
+
+    it('does not stop at the first list that fails', async () => {
+      const failing = new ChannelPaginator({ client });
+      const healthy = new ChannelPaginator({ client });
+      [failing, healthy].forEach((p) =>
+        vi.spyOn(p, 'isInitialized', 'get').mockReturnValue(true),
+      );
+      vi.spyOn(failing, 'toTail').mockRejectedValue(new Error('nope'));
+      const healthyToTail = vi.spyOn(healthy, 'toTail').mockResolvedValue(undefined);
+
+      await new ChannelManager({ client, paginators: [failing, healthy] }).recover();
+
+      expect(healthyToTail).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('restoring an interrupted watch', () => {
+    /**
+     * Recovery re-watches page 1 of each list plus the active channel. Everything else stays
+     * `WasWatching` — pages 2+ of a scrolled list, channels visited and navigated away from, channels
+     * matching no mounted list. Those still receive member-level events, which relocate the row but
+     * carry no message body, so the preview would sit frozen until the channel was opened. Re-watching
+     * on the event that proves relevance is what closes that, with no eager sweep.
+     */
+    const routeEventFor = (channel: Channel) => {
+      client.activeChannels[channel.cid] = channel;
+      const paginator = new ChannelPaginator({ client });
+      const channelManager = new ChannelManager({ client, paginators: [paginator] });
+      channelManager.registerSubscriptions();
+      // `ingestItem` runs inside the same handler, immediately BEFORE the re-watch would fire. It is
+      // therefore the anchor a negative assertion needs: waiting on it proves the handler has reached
+      // the decision point, so "not called" means "decided not to" rather than "not yet".
+      return { channelManager, ingestItem: vi.spyOn(paginator, 'ingestItem') };
+    };
+
+    it('re-watches a channel whose watch was interrupted', async () => {
+      const ch = makeChannel('messaging:interrupted');
+      ch.watchStatus = ChannelWatchStatus.WasWatching;
+      routeEventFor(ch);
+
+      client.dispatchEvent({ type: 'message.new', cid: ch.cid });
+
+      await vi.waitFor(() =>
+        expect(mockGetChannel).toHaveBeenCalledWith(
+          expect.objectContaining({ channel: ch }),
+        ),
+      );
+    });
+
+    it('leaves a channel that was never watched, or deliberately unwatched, alone', async () => {
+      // This is what keeps it narrower than v9's unconditional re-watch: only a watch we previously
+      // HELD is restored, so the client's watch count can never exceed what it already had.
+      const ch = makeChannel('messaging:not-watching');
+      expect(ch.watchStatus).to.equal(ChannelWatchStatus.NotWatching);
+      const { ingestItem } = routeEventFor(ch);
+
+      client.dispatchEvent({ type: 'message.new', cid: ch.cid });
+
+      await vi.waitFor(() => expect(ingestItem).toHaveBeenCalledWith(ch));
+      expect(mockGetChannel).not.toHaveBeenCalled();
+    });
+
+    it('never re-watches a channel pending disposal', async () => {
+      const ch = makeChannel('messaging:disposing');
+      ch.watchStatus = ChannelWatchStatus.WasWatching;
+      const { ingestItem } = routeEventFor(ch);
+      ch.pendingDisposal = true;
+
+      client.dispatchEvent({ type: 'message.new', cid: ch.cid });
+
+      await vi.waitFor(() => expect(ingestItem).toHaveBeenCalledWith(ch));
+      expect(mockGetChannel).not.toHaveBeenCalled();
+    });
+
+    it('does not re-watch a channel that is being hidden', async () => {
+      const ch = makeChannel('messaging:hidden');
+      ch.watchStatus = ChannelWatchStatus.WasWatching;
+      client.activeChannels[ch.cid] = ch;
+      const paginator = new ChannelPaginator({ client });
+      // A hidden channel drops OUT of a list that does not filter for hidden, so `removeItem` — not
+      // `ingestItem` — is the anchor proving the handler reached the re-watch decision.
+      const removeItem = vi.spyOn(paginator, 'removeItem');
+      new ChannelManager({ client, paginators: [paginator] }).registerSubscriptions();
+
+      client.dispatchEvent({ type: 'channel.hidden', cid: ch.cid });
+
+      await vi.waitFor(() =>
+        expect(removeItem).toHaveBeenCalledWith(expect.objectContaining({ item: ch })),
+      );
+      expect(mockGetChannel).not.toHaveBeenCalled();
+    });
+
+    it('places the channel in the list without waiting for the watch to resolve', async () => {
+      // The row has to relocate off the event itself; the watch (and the state it hydrates) lands
+      // whenever it lands.
+      const ch = makeChannel('messaging:ordering');
+      ch.watchStatus = ChannelWatchStatus.WasWatching;
+      let resolveWatch: () => void = () => {};
+      (mockGetChannel as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        () => new Promise<void>((resolve) => (resolveWatch = resolve)),
+      );
+      client.activeChannels[ch.cid] = ch;
+      const paginator = new ChannelPaginator({ client });
+      const ingestItem = vi.spyOn(paginator, 'ingestItem');
+      const channelManager = new ChannelManager({ client, paginators: [paginator] });
+      channelManager.registerSubscriptions();
+
+      client.dispatchEvent({ type: 'message.new', cid: ch.cid });
+
+      await vi.waitFor(() => expect(ingestItem).toHaveBeenCalledWith(ch));
+      resolveWatch();
     });
   });
 

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -282,9 +282,11 @@ describe('ConnectionRecoveryManager', () => {
     });
   });
 
-  describe('recoverStateOnReconnect: false', () => {
+  describe('connectionRecovery.enabled: false', () => {
     it('recovers nothing', async () => {
-      client.recoverStateOnReconnect = false;
+      // The kill switch is declarative configuration now, read when a recovery actually runs — so it
+      // is honoured from the next reconnect without the manager being re-wired.
+      client.config.set({ client: { connectionRecovery: { enabled: false } } });
       const { reload } = activeChannel('active');
       const recoverLists = vi
         .spyOn(client.channelManager, 'recover')

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -103,6 +103,19 @@ describe('ConnectionRecoveryManager', () => {
       expect(reload).toHaveBeenCalledTimes(1);
     });
 
+    it('reloads exactly once per reconnect (offline support off)', async () => {
+      // Mirror of the offline-on case: with no offline DB there is no sync edge, so the direct call
+      // is the only path. Settle before re-asserting — a late duplicate would satisfy a bare count.
+      const { reload } = activeChannel('active');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+
     it('does not stop at the first channel that fails', async () => {
       const { reload: failing } = activeChannel('failing');
       const { reload: healthy } = activeChannel('healthy');
@@ -254,6 +267,23 @@ describe('ConnectionRecoveryManager', () => {
       online();
 
       await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    });
+
+    it('reloads exactly once per reconnect, and stays at once', async () => {
+      // Exactly one of the two paths in `registerSubscriptions` may run: binding the sync-status
+      // subscription is what hands active-channel recovery to the edge, so the direct call must be
+      // skipped. Asserting only "was called" would not catch a double, and neither would asserting
+      // the count immediately — a duplicate arriving late would still satisfy it. So settle first,
+      // then re-assert.
+      await attachDb();
+      const { reload } = activeChannel('active');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      expect(reload).toHaveBeenCalledTimes(1);
     });
 
     it('recovers again on a second reconnect', async () => {

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ChannelWatchStatus, type Channel, type StreamChat } from '../../src';
+import {
+  ChannelWatchStatus,
+  Thread,
+  type Channel,
+  type MessageResponse,
+  type StreamChat,
+} from '../../src';
+import { generateMsg } from './test-utils/generateMessage';
 // @ts-expect-error - untyped test helper
 import { getClientWithUser } from './test-utils/getClient';
 import { MockOfflineDB } from './offline-support/MockOfflineDB';
@@ -27,6 +34,39 @@ describe('ConnectionRecoveryManager', () => {
     return { channel, reload };
   };
 
+  /** Builds a thread the way a UI SDK does, without activating or adopting it. */
+  const buildThread = (id: string) => {
+    const channel = client.channel('messaging', `channel-for-${id}`);
+    channel.initialized = true;
+    const thread = new Thread({
+      client,
+      channel,
+      parentMessage: channel.state.formatMessage(
+        generateMsg({ id, cid: channel.cid }) as MessageResponse,
+      ),
+    });
+    const reload = vi.spyOn(thread, 'reload').mockResolvedValue(undefined);
+    return { thread, reload, channel };
+  };
+
+  /** Mirrors what the UI SDKs do once a thread's replies have loaded: put it in the manager's list. */
+  const adopt = (thread: Thread) =>
+    client.threads.state.next((current) => ({
+      ...current,
+      threads: [thread, ...current.threads],
+    }));
+
+  /**
+   * A thread a consumer is displaying: adopted into the manager (so it is reachable through
+   * `threadsById`) and activated (so recovery selects it out of everything else in the list).
+   */
+  const activeThread = (id: string) => {
+    const built = buildThread(id);
+    adopt(built.thread);
+    built.thread.activate();
+    return built;
+  };
+
   beforeEach(() => {
     client = getClientWithUser({ id: 'me' }) as StreamChat;
   });
@@ -45,6 +85,79 @@ describe('ConnectionRecoveryManager', () => {
       online();
       await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
       expect(recoverLists).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads the thread a consumer is displaying, not every thread in the list', async () => {
+      const { reload } = activeThread('open-thread');
+      // Also in the list, but nobody is reading it: reloading every paged-in thread on reconnect
+      // would be a burst of `getThreadAndHydrate` calls for rows on a screen, which is exactly what
+      // the `active` filter exists to prevent. `ThreadManager.reload()` refreshes the list itself.
+      const idle = buildThread('idle-thread');
+      adopt(idle.thread);
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+      expect(idle.reload).not.toHaveBeenCalled();
+    });
+
+    it('KNOWN GAP: skips an active thread that has not been adopted into the manager', async () => {
+      // Not desired behaviour — a pin on an accepted trade-off. Recovery finds threads through
+      // `threadsById`, i.e. the thread LIST, and a thread opened from a message list only lands there
+      // once the UI SDK adopts it (after its replies load). A reconnect inside that window misses it,
+      // as does one after `ThreadManager.reload()` evicts it. Fixing this means giving `ThreadManager`
+      // a real off-list registry (its commented-out `threadCache`); when that lands, this test should
+      // be inverted rather than deleted.
+      const { thread, reload } = buildThread('active-but-unadopted');
+      thread.activate();
+      expect(client.threads.threadsById[thread.id]).toBeUndefined();
+      const { reload: channelReload } = activeChannel('still-open');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      // Anchored on a reload that provably happens in the same pass.
+      await vi.waitFor(() => expect(channelReload).toHaveBeenCalledTimes(1));
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('leaves a thread nobody is displaying alone', async () => {
+      const { thread, reload } = activeThread('closed-thread');
+      // Closing the thread screen deactivates it; recovery must then skip it entirely.
+      thread.deactivate();
+      const { reload: channelReload } = activeChannel('still-open');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      // Anchored on a reload that provably happens in the same pass, so the negative cannot pass
+      // merely by being asserted before anything ran.
+      await vi.waitFor(() => expect(channelReload).toHaveBeenCalledTimes(1));
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('skips a thread whose channel is being torn down', async () => {
+      const { thread, reload, channel } = activeThread('doomed-thread');
+      channel.pendingDisposal = true;
+      const { reload: channelReload } = activeChannel('still-open');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(channelReload).toHaveBeenCalledTimes(1));
+      expect(reload).not.toHaveBeenCalled();
+      expect(thread.state.getLatestValue().active).toBe(true);
+    });
+
+    it('one thread failing does not stop the channels or the other threads', async () => {
+      const { reload: failing } = activeThread('failing-thread');
+      failing.mockRejectedValue(new Error('thread reload failed'));
+      const { reload: healthy } = activeThread('healthy-thread');
+      const { reload: channelReload } = activeChannel('active');
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => {
+        expect(healthy).toHaveBeenCalledTimes(1);
+        expect(channelReload).toHaveBeenCalledTimes(1);
+      });
     });
 
     it('leaves channels nobody is reading alone', async () => {

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -1,0 +1,270 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChannelWatchStatus, type Channel, type StreamChat } from '../../src';
+// @ts-expect-error - untyped test helper
+import { getClientWithUser } from './test-utils/getClient';
+import { MockOfflineDB } from './offline-support/MockOfflineDB';
+
+/**
+ * Connection recovery is the reconnect contract: after the socket comes back, the surfaces the app is
+ * consuming have to be brought back in line with the server. These tests pin the two things that make
+ * it correct rather than merely present — WHICH surfaces are refreshed, and WHEN relative to the
+ * offline pending-task replay and sync.
+ */
+describe('ConnectionRecoveryManager', () => {
+  let client: StreamChat;
+
+  const online = () => client.dispatchEvent({ type: 'connection.changed', online: true });
+  const offline = () =>
+    client.dispatchEvent({ type: 'connection.changed', online: false });
+
+  /** A channel a consumer has declared it is reading, i.e. what recovery reloads. */
+  const activeChannel = (id: string) => {
+    const channel = client.channel('messaging', id);
+    channel.initialized = true;
+    channel.activate();
+    const reload = vi.spyOn(channel, 'reload').mockResolvedValue(undefined);
+    return { channel, reload };
+  };
+
+  beforeEach(() => {
+    client = getClientWithUser({ id: 'me' }) as StreamChat;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('what it recovers', () => {
+    it('reloads active channels and re-runs the channel lists', async () => {
+      const { reload } = activeChannel('active');
+      const recoverLists = vi
+        .spyOn(client.channelManager, 'recover')
+        .mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+      expect(recoverLists).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves channels nobody is reading alone', async () => {
+      const idle = client.channel('messaging', 'idle');
+      idle.initialized = true;
+      // Watched before the drop, but not active — it must NOT be eagerly re-queried. Such channels
+      // come back demand-driven, when an event proves them relevant.
+      idle.watchStatus = ChannelWatchStatus.WasWatching;
+      const reload = vi.spyOn(idle, 'reload').mockResolvedValue(undefined);
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      online();
+      await vi.waitFor(() => expect(client.channelManager.recover).toHaveBeenCalled());
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('never sends a bulk `cid: { $in: … }` query', async () => {
+      // The removed `recoverState()` recovered by querying the whole instance cache with a hardcoded
+      // limit of 30. Nothing may reintroduce that: recovery is each list's own query plus the active
+      // channels' own reloads.
+      activeChannel('active');
+      const queryChannels = vi
+        .spyOn(client, 'queryChannels')
+        .mockResolvedValue({ channels: [] } as never);
+
+      online();
+      await client.connectionRecovery.recover();
+
+      expect(queryChannels).not.toHaveBeenCalled();
+    });
+
+    it('skips a channel pending disposal', async () => {
+      const { channel, reload } = activeChannel('disposing');
+      channel.pendingDisposal = true;
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      await client.connectionRecovery.recover();
+
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('reloads an active channel that was never watched, e.g. opened while offline', async () => {
+      // Regression guard. Opening a channel with no connection leaves it `offlineMode` with
+      // `watchStatus: NotWatching`, because its `watch()` threw before recording a watch. Filtering
+      // recovery on `WasWatching` would strand exactly that channel forever — it would never load its
+      // messages, on any subsequent reconnect. `Channel.reload()`'s own `initialized || offlineMode`
+      // check is the correct gate.
+      const channel = client.channel('messaging', 'opened-offline');
+      channel.offlineMode = true;
+      channel.activate();
+      expect(channel.watchStatus).to.equal(ChannelWatchStatus.NotWatching);
+      const reload = vi.spyOn(channel, 'reload').mockResolvedValue(undefined);
+
+      await client.connectionRecovery.recover();
+
+      expect(reload).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not stop at the first channel that fails', async () => {
+      const { reload: failing } = activeChannel('failing');
+      const { reload: healthy } = activeChannel('healthy');
+      failing.mockRejectedValue(new Error('nope'));
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      await client.connectionRecovery.recover();
+
+      expect(failing).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('connection.recovered', () => {
+    it('is dispatched after the reload, on a path `recoverState()` never runs on', async () => {
+      // `recoverState()` is only ever called by `StableWSConnection._reconnect()`, so a
+      // `closeConnection()` → `openConnection()` cycle (mobile backgrounding) used to produce no
+      // `connection.recovered` at all. Consumers that key post-recovery work off it — marking a
+      // caught-up channel read, for one — silently did nothing there.
+      const order: string[] = [];
+      const { channel } = activeChannel('active');
+      vi.spyOn(channel, 'reload').mockImplementation(async () => {
+        order.push('reload');
+      });
+      client.on('connection.recovered', () => order.push('recovered'));
+
+      online();
+
+      await vi.waitFor(() => expect(order).to.deep.equal(['reload', 'recovered']));
+    });
+
+    it('is dispatched once per recovery', async () => {
+      const recovered = vi.fn();
+      client.on('connection.recovered', recovered);
+      activeChannel('active');
+
+      await client.connectionRecovery.recover();
+
+      expect(recovered).toHaveBeenCalledTimes(1);
+    });
+
+    it('is still dispatched when a reload fails', async () => {
+      const recovered = vi.fn();
+      client.on('connection.recovered', recovered);
+      const { reload } = activeChannel('failing');
+      reload.mockRejectedValue(new Error('nope'));
+
+      await client.connectionRecovery.recover();
+
+      expect(recovered).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('recoverStateOnReconnect: false', () => {
+    it('recovers nothing', async () => {
+      client.recoverStateOnReconnect = false;
+      const { reload } = activeChannel('active');
+      const recoverLists = vi
+        .spyOn(client.channelManager, 'recover')
+        .mockResolvedValue([]);
+
+      online();
+      await client.connectionRecovery.recover();
+
+      expect(reload).not.toHaveBeenCalled();
+      expect(recoverLists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('offline support: ordering', () => {
+    let db: MockOfflineDB;
+
+    const attachDb = async () => {
+      db = new MockOfflineDB({ client });
+      db.getPendingTasks.mockResolvedValue([]);
+      db.getAllChannelCids.mockResolvedValue([]);
+      db.getLastSyncedAt.mockResolvedValue(new Date().toString());
+      db.initializeDB.mockResolvedValue(true);
+      client.setOfflineDBApi(db);
+      await db.init('me');
+      return db;
+    };
+
+    it('waits for pending-task replay and sync before reloading, on the closeConnection path', async () => {
+      // The path worth pinning: `closeConnection()` sets `isHealthy` directly, so no offline
+      // `connection.changed` is ever dispatched and `syncStatus` stays stale-true across the outage.
+      // Anything that polled that flag would conclude "already synced" and query ahead of the replay.
+      // The sync-status EDGE has no such problem: the sync manager publishes it unconditionally after
+      // `executePendingTasks()` → `sync()` on every online transition.
+      const order: string[] = [];
+      await attachDb();
+
+      const { channel } = activeChannel('active');
+      vi.spyOn(channel, 'reload').mockImplementation(async () => {
+        order.push('reload');
+      });
+      vi.spyOn(client, 'sync').mockImplementation(async () => {
+        order.push('sync');
+        return { events: [] } as never;
+      });
+      db.getAllChannelCids.mockResolvedValue([channel.cid]);
+      db.executePendingTasks = vi.fn().mockImplementation(async () => {
+        order.push('executePendingTasks');
+      });
+
+      online();
+
+      await vi.waitFor(() => expect(order).to.contain('reload'));
+      expect(order).to.deep.equal(['executePendingTasks', 'sync', 'reload']);
+    });
+
+    it('still reloads when the sync fails', async () => {
+      // The sync manager isolates replay and sync so the status edge is published either way. A
+      // failed sync must degrade to possibly-stale data, never to a recovery that never happens.
+      await attachDb();
+      const { reload } = activeChannel('active');
+      db.executePendingTasks = vi.fn().mockRejectedValue(new Error('replay failed'));
+      vi.spyOn(client, 'sync').mockRejectedValue(new Error('sync failed'));
+
+      online();
+
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    });
+
+    it('does not reload off connection.changed once the DB is initialized', async () => {
+      // Two triggers would mean two reloads per reconnect: the raw event and the post-sync edge.
+      await attachDb();
+      const { reload } = activeChannel('active');
+      // Never resolve the sync, so the edge never arrives.
+      db.executePendingTasks = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+      online();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(reload).not.toHaveBeenCalled();
+    });
+
+    it('falls back to connection.changed when the DB never initializes', async () => {
+      // An offline DB whose `init()` failed publishes no sync-status edge, so keying recovery solely
+      // on it would cost recovery altogether.
+      const failing = new MockOfflineDB({ client });
+      failing.initializeDB.mockResolvedValue(false);
+      client.setOfflineDBApi(failing);
+      await failing.init('me');
+      expect(failing.state.getLatestValue().initialized).to.equal(false);
+
+      const { reload } = activeChannel('active');
+
+      online();
+
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+    });
+
+    it('recovers again on a second reconnect', async () => {
+      await attachDb();
+      const { reload } = activeChannel('active');
+
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(1));
+      offline();
+      online();
+      await vi.waitFor(() => expect(reload).toHaveBeenCalledTimes(2));
+    });
+  });
+});

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -298,38 +298,6 @@ describe('ConnectionRecoveryManager', () => {
     });
   });
 
-  /**
-   * Nothing clears a load error on a connection event — a failure is invalidated by the next load
-   * attempt, exactly as v9's `resyncChannel` did on its first line and as `BasePaginator` does for
-   * `lastQueryError`. What makes that enough is WHERE the clear sits: `watch()` does it above its
-   * first `await`, so on reconnect it runs inside this dispatch rather than a microtask later. A UI
-   * that masks the error behind its own "online" flag flips that flag on this same event, so the two
-   * land in one render and the error is never shown.
-   */
-  describe('a latched load error', () => {
-    it('is dropped within the connection.changed dispatch, before the reload settles', async () => {
-      const channel = client.channel('messaging', 'active');
-      channel.initialized = true;
-      channel.activate();
-      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
-
-      // A real failure, recorded by the real watch() — not written into state by hand.
-      const getOrCreate = vi
-        .spyOn(channel, 'getOrCreate')
-        .mockRejectedValueOnce(new Error('opened while offline'));
-      await expect(channel.watch()).rejects.toThrow();
-      expect(channel.lastLoadError).toBeDefined();
-
-      // The re-attempt never comes back, so nothing about its outcome can be what clears this.
-      getOrCreate.mockReturnValue(new Promise(() => undefined));
-
-      online();
-
-      // No await: asserted in the same tick the event was dispatched in.
-      expect(channel.lastLoadError).toBeUndefined();
-    });
-  });
-
   describe('offline support: ordering', () => {
     let db: MockOfflineDB;
 

--- a/test/unit/ConnectionRecoveryManager.test.ts
+++ b/test/unit/ConnectionRecoveryManager.test.ts
@@ -298,6 +298,38 @@ describe('ConnectionRecoveryManager', () => {
     });
   });
 
+  /**
+   * Nothing clears a load error on a connection event — a failure is invalidated by the next load
+   * attempt, exactly as v9's `resyncChannel` did on its first line and as `BasePaginator` does for
+   * `lastQueryError`. What makes that enough is WHERE the clear sits: `watch()` does it above its
+   * first `await`, so on reconnect it runs inside this dispatch rather than a microtask later. A UI
+   * that masks the error behind its own "online" flag flips that flag on this same event, so the two
+   * land in one render and the error is never shown.
+   */
+  describe('a latched load error', () => {
+    it('is dropped within the connection.changed dispatch, before the reload settles', async () => {
+      const channel = client.channel('messaging', 'active');
+      channel.initialized = true;
+      channel.activate();
+      vi.spyOn(client.channelManager, 'recover').mockResolvedValue([]);
+
+      // A real failure, recorded by the real watch() — not written into state by hand.
+      const getOrCreate = vi
+        .spyOn(channel, 'getOrCreate')
+        .mockRejectedValueOnce(new Error('opened while offline'));
+      await expect(channel.watch()).rejects.toThrow();
+      expect(channel.lastLoadError).toBeDefined();
+
+      // The re-attempt never comes back, so nothing about its outcome can be what clears this.
+      getOrCreate.mockReturnValue(new Promise(() => undefined));
+
+      online();
+
+      // No await: asserted in the same tick the event was dispatched in.
+      expect(channel.lastLoadError).toBeUndefined();
+    });
+  });
+
   describe('offline support: ordering', () => {
     let db: MockOfflineDB;
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4058,6 +4058,55 @@ describe('Channel.reload', () => {
 
 		expect(watchSpy).toHaveBeenCalledTimes(1);
 	});
+
+	// A reload is no longer necessarily issued by the code that renders the channel: connection
+	// recovery runs it inside a `Promise.allSettled`, which absorbs rejections. Publishing the failure
+	// on the channel is what keeps a failed refresh visible to a UI ("could not load messages for this
+	// channel") without that UI having to own the call.
+	describe('lastReloadError', () => {
+		it('is undefined until a reload fails', () => {
+			expect(channel.lastReloadError).toBeUndefined();
+		});
+
+		it('records the failure and still rethrows', async () => {
+			seedLatestWindow(channel, [msg('m1', 1)]);
+			const failure = new Error('watch failed');
+			vi.spyOn(channel, 'watch').mockRejectedValue(failure);
+
+			await expect(channel.reload()).rejects.toThrow('watch failed');
+
+			expect(channel.lastReloadError).toBe(failure);
+			// Reactive, so a UI can subscribe rather than poll.
+			expect(channel.state.getLatestValue().lastReloadError).toBe(failure);
+		});
+
+		it('clears on the next successful reload', async () => {
+			seedLatestWindow(channel, [msg('m1', 1)]);
+			vi.spyOn(channel, 'watch').mockRejectedValueOnce(new Error('watch failed'));
+			await expect(channel.reload()).rejects.toThrow();
+			expect(channel.lastReloadError).toBeDefined();
+
+			channel.watch.mockResolvedValue({ messages: [msg('m1', 1)] });
+			await channel.reload();
+
+			expect(channel.lastReloadError).toBeUndefined();
+		});
+
+		it('releases the re-entrancy guard when a reload fails', async () => {
+			// Without the `finally`, one failure would wedge `reload()` for the channel's lifetime — no
+			// later reconnect could ever refresh it again.
+			seedLatestWindow(channel, [msg('m1', 1)]);
+			const watchSpy = vi
+				.spyOn(channel, 'watch')
+				.mockRejectedValueOnce(new Error('watch failed'));
+			await expect(channel.reload()).rejects.toThrow();
+
+			watchSpy.mockResolvedValue({ messages: [msg('m1', 1)] });
+			await channel.reload();
+
+			expect(watchSpy).toHaveBeenCalledTimes(2);
+		});
+	});
 });
 describe('Channel active flag (mark-read stays UI-driven)', () => {
 	let client;

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4025,8 +4025,10 @@ describe('Channel.reload', () => {
 	it('preserves a failed (unsent) message that a disjoint rebuild would otherwise drop', async () => {
 		seedLatestWindow(channel, [
 			msg('m1', 1),
-			msg('failed', 2, { status: 'failed' }),
 			msg('m3', 3),
+			// A just-attempted send that failed is the NEWEST thing in the channel — position it that
+			// way, or the scenario is not one that can actually occur.
+			msg('failed', 10, { status: 'failed' }),
 		]);
 		// A page that shares no id with the loaded window is disjoint, so the fold rebuilds and discards
 		// local-only messages — reload must re-ingest the failed one so it is not lost.
@@ -4039,7 +4041,7 @@ describe('Channel.reload', () => {
 
 		await channel.reload();
 
-		expect(channel.messagePaginator.getItem('failed')).toBeDefined();
+		expect(channel.messagePaginator.items.map((m) => m.id)).toContain('failed');
 	});
 
 	it('ignores a re-entrant reload while one is already in flight', async () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4104,74 +4104,39 @@ describe('Channel.reload', () => {
 		expect(watchSpy).toHaveBeenCalledTimes(1);
 	});
 
-	// Neither failure a UI cares about is catchable where it happens: the reconnect reload is issued by
-	// `ConnectionRecoveryManager` inside a `Promise.allSettled`, and the mount-time `watch()` of a
-	// channel opened with no connection throws before anything holds a handle on it. Both are recorded
-	// on the channel so a UI can read "could not load this channel" instead of latching a flag of its
-	// own that nothing can later invalidate.
-	describe('lastLoadError', () => {
-		it('is undefined until a load fails', () => {
-			expect(channel.lastLoadError).toBeUndefined();
-		});
-
+	// `watch()` and `reload()` both reject rather than recording anything: a load failure is the
+	// caller's to handle, and the one caller that cannot handle it — `ConnectionRecoveryManager`,
+	// which reloads inside a `Promise.allSettled` — deliberately does not surface it.
+	describe('load failures', () => {
 		// The case the UI SDKs used to hold local state for: opening a channel while offline. No reload
 		// is involved — `watch()` itself is what throws.
-		it('records a failed watch() and still rethrows', async () => {
-			const failure = new Error('watch failed');
-			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(failure);
+		it('rethrows a failed watch()', async () => {
+			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(new Error('watch failed'));
 
 			await expect(channel.watch()).rejects.toThrow('watch failed');
-
-			expect(channel.lastLoadError).toBe(failure);
-			// Reactive, so a UI can subscribe rather than poll.
-			expect(channel.state.getLatestValue().lastLoadError).toBe(failure);
 		});
 
-		it('records a failed reload and still rethrows', async () => {
+		it('rethrows a failed reload()', async () => {
 			seedLatestWindow(channel, [msg('m1', 1)]);
-			const failure = new Error('watch failed');
-			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(failure);
+			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(new Error('watch failed'));
 
 			await expect(channel.reload()).rejects.toThrow('watch failed');
-
-			expect(channel.lastLoadError).toBe(failure);
 		});
 
-		it('clears on the next successful load', async () => {
+		it('clears the message-window error before it awaits anything', async () => {
+			// Above the first await on purpose: a reconnect reload gets here inside the synchronous
+			// `connection.changed` dispatch, so a UI that flips its own online flag on that same event
+			// never renders the stale error over content that is about to refresh.
 			seedLatestWindow(channel, [msg('m1', 1)]);
-			const getOrCreate = vi
-				.spyOn(channel, 'getOrCreate')
-				.mockRejectedValueOnce(new Error('watch failed'));
-			await expect(channel.reload()).rejects.toThrow();
-			expect(channel.lastLoadError).toBeDefined();
+			channel.messagePaginator.state.partialNext({
+				lastQueryError: new Error('load older failed'),
+			});
 
-			getOrCreate.mockResolvedValue(
-				generateChannel({
-					channel: { id: channel.id, type: channel.type },
-					messages: [msg('m1', 1)],
-				}),
-			);
-			await channel.reload();
-
-			expect(channel.lastLoadError).toBeUndefined();
-		});
-
-		// The clear sits ABOVE watch()'s first await, so it is observable before the request settles.
-		// That is what lets it land in the same synchronous dispatch as the connection event that
-		// triggered the reload, which is what keeps a UI from flashing the error (see the
-		// ConnectionRecoveryManager suite for the end-to-end version).
-		it('clears before it awaits anything, not when the request comes back', async () => {
-			const getOrCreate = vi
-				.spyOn(channel, 'getOrCreate')
-				.mockRejectedValueOnce(new Error('watch failed'));
-			await expect(channel.watch()).rejects.toThrow();
-			expect(channel.lastLoadError).toBeDefined();
-
-			// Never settles, so only a clear that happened before the await can be seen.
-			getOrCreate.mockReturnValue(new Promise(() => {}));
+			// Never settles, so only a clear that ran BEFORE the await can be observed.
+			vi.spyOn(channel, 'getOrCreate').mockReturnValue(new Promise(() => {}));
 			channel.watch();
 
-			expect(channel.lastLoadError).toBeUndefined();
+			expect(channel.messagePaginator.lastQueryError).toBeUndefined();
 		});
 
 		it('releases the re-entrancy guard when a reload fails', async () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4061,6 +4061,32 @@ describe('Channel.reload', () => {
 		expect(channel.messagePaginator.items.map((m) => m.id)).toContain('failed');
 	});
 
+	it('merges the fetched page into a channel whose only message was ingested live', async () => {
+		// The thread defect from the channel side: a brand-new channel has an EMPTY first page, so the
+		// sent message lands in a LOGICAL head and `reload()` used to discard the server's page whole.
+		// `reload()` bails unless the channel is initialized; a real one is by the time it renders.
+		channel.initialized = true;
+		const mine = msg('mine', 1);
+		channel.messagePaginator.ingestItem(channel.state.formatMessage(mine));
+		expect(channel.messagePaginator.items.map((m) => m.id)).toEqual(['mine']);
+
+		// Mock the transport, not `watch`: mocking `watch` skips `seedFirstPageSync`, so no fold runs.
+		vi.spyOn(channel, 'getOrCreate').mockImplementation(async () =>
+			generateChannel({
+				channel: { id: channel.id, type: channel.type },
+				messages: [mine, msg('peer1', 2), msg('peer2', 3)],
+			}),
+		);
+
+		await channel.reload();
+
+		expect(channel.messagePaginator.items.map((m) => m.id)).toEqual([
+			'mine',
+			'peer1',
+			'peer2',
+		]);
+	});
+
 	it('ignores a re-entrant reload while one is already in flight', async () => {
 		seedLatestWindow(channel, [msg('m1', 1)]);
 		let resolveWatch;

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -3993,7 +3993,7 @@ describe('Channel.reload', () => {
 		expect(channel.messagePaginator.items.map((m) => m.id)).toEqual(['m1', 'm2', 'm3']);
 
 		// The fold + reconcile now lives in query() → seedFirstPageSync (shared with the channel-list
-		// re-hydrate and React's recoverState); reload() is just watch() with the full-window limit.
+		// re-hydrate and connection recovery); reload() is just watch() with the full-window limit.
 		// query() snapshots the loaded ids BEFORE this fetch, so a brand-new message that lands via WS
 		// DURING it (below) — absent from the server page — must survive. This exercises the whole
 		// snapshot-before-await + reconcile chain end to end, not the paginator in isolation.

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4104,37 +4104,74 @@ describe('Channel.reload', () => {
 		expect(watchSpy).toHaveBeenCalledTimes(1);
 	});
 
-	// A reload is no longer necessarily issued by the code that renders the channel: connection
-	// recovery runs it inside a `Promise.allSettled`, which absorbs rejections. Publishing the failure
-	// on the channel is what keeps a failed refresh visible to a UI ("could not load messages for this
-	// channel") without that UI having to own the call.
-	describe('lastReloadError', () => {
-		it('is undefined until a reload fails', () => {
-			expect(channel.lastReloadError).toBeUndefined();
+	// Neither failure a UI cares about is catchable where it happens: the reconnect reload is issued by
+	// `ConnectionRecoveryManager` inside a `Promise.allSettled`, and the mount-time `watch()` of a
+	// channel opened with no connection throws before anything holds a handle on it. Both are recorded
+	// on the channel so a UI can read "could not load this channel" instead of latching a flag of its
+	// own that nothing can later invalidate.
+	describe('lastLoadError', () => {
+		it('is undefined until a load fails', () => {
+			expect(channel.lastLoadError).toBeUndefined();
 		});
 
-		it('records the failure and still rethrows', async () => {
+		// The case the UI SDKs used to hold local state for: opening a channel while offline. No reload
+		// is involved — `watch()` itself is what throws.
+		it('records a failed watch() and still rethrows', async () => {
+			const failure = new Error('watch failed');
+			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(failure);
+
+			await expect(channel.watch()).rejects.toThrow('watch failed');
+
+			expect(channel.lastLoadError).toBe(failure);
+			// Reactive, so a UI can subscribe rather than poll.
+			expect(channel.state.getLatestValue().lastLoadError).toBe(failure);
+		});
+
+		it('records a failed reload and still rethrows', async () => {
 			seedLatestWindow(channel, [msg('m1', 1)]);
 			const failure = new Error('watch failed');
-			vi.spyOn(channel, 'watch').mockRejectedValue(failure);
+			vi.spyOn(channel, 'getOrCreate').mockRejectedValue(failure);
 
 			await expect(channel.reload()).rejects.toThrow('watch failed');
 
-			expect(channel.lastReloadError).toBe(failure);
-			// Reactive, so a UI can subscribe rather than poll.
-			expect(channel.state.getLatestValue().lastReloadError).toBe(failure);
+			expect(channel.lastLoadError).toBe(failure);
 		});
 
-		it('clears on the next successful reload', async () => {
+		it('clears on the next successful load', async () => {
 			seedLatestWindow(channel, [msg('m1', 1)]);
-			vi.spyOn(channel, 'watch').mockRejectedValueOnce(new Error('watch failed'));
+			const getOrCreate = vi
+				.spyOn(channel, 'getOrCreate')
+				.mockRejectedValueOnce(new Error('watch failed'));
 			await expect(channel.reload()).rejects.toThrow();
-			expect(channel.lastReloadError).toBeDefined();
+			expect(channel.lastLoadError).toBeDefined();
 
-			channel.watch.mockResolvedValue({ messages: [msg('m1', 1)] });
+			getOrCreate.mockResolvedValue(
+				generateChannel({
+					channel: { id: channel.id, type: channel.type },
+					messages: [msg('m1', 1)],
+				}),
+			);
 			await channel.reload();
 
-			expect(channel.lastReloadError).toBeUndefined();
+			expect(channel.lastLoadError).toBeUndefined();
+		});
+
+		// The clear sits ABOVE watch()'s first await, so it is observable before the request settles.
+		// That is what lets it land in the same synchronous dispatch as the connection event that
+		// triggered the reload, which is what keeps a UI from flashing the error (see the
+		// ConnectionRecoveryManager suite for the end-to-end version).
+		it('clears before it awaits anything, not when the request comes back', async () => {
+			const getOrCreate = vi
+				.spyOn(channel, 'getOrCreate')
+				.mockRejectedValueOnce(new Error('watch failed'));
+			await expect(channel.watch()).rejects.toThrow();
+			expect(channel.lastLoadError).toBeDefined();
+
+			// Never settles, so only a clear that happened before the await can be seen.
+			getOrCreate.mockReturnValue(new Promise(() => {}));
+			channel.watch();
+
+			expect(channel.lastLoadError).toBeUndefined();
 		});
 
 		it('releases the re-entrancy guard when a reload fails', async () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4011,7 +4011,22 @@ describe('Channel.reload', () => {
 		expect(channel.messagePaginator.items.map((m) => m.id)).toEqual(['m1', 'm2', 'm4']);
 	});
 
-	it('requests the full loaded window (items.length), not the channel-list page size', async () => {
+	it('requests the full loaded window when it is larger than a page', async () => {
+		const wide = channel.messagePaginator.pageSize + 7;
+		const loaded = Array.from({ length: wide }, (_, i) => msg(`m${i}`, i));
+		seedLatestWindow(channel, loaded);
+		const watchSpy = vi.spyOn(channel, 'watch').mockResolvedValue({ messages: loaded });
+
+		await channel.reload();
+
+		// Larger than pageSize, so the whole loaded window refreshes rather than just a page.
+		expect(watchSpy).toHaveBeenCalledWith({ messages: { limit: wide } });
+	});
+
+	it('requests at least a page when the loaded window is smaller, so new messages are discoverable', async () => {
+		// Regression guard. Sizing the request to the loaded count alone means asking the server for
+		// exactly what we already hold: messages that arrived while offline can never come back, and
+		// the returned page is disjoint from the loaded window so the fold rebuilds and drops the rest.
 		seedLatestWindow(channel, [msg('m1', 1), msg('m2', 2), msg('m3', 3)]);
 		const watchSpy = vi
 			.spyOn(channel, 'watch')
@@ -4019,7 +4034,9 @@ describe('Channel.reload', () => {
 
 		await channel.reload();
 
-		expect(watchSpy).toHaveBeenCalledWith({ messages: { limit: 3 } });
+		expect(watchSpy).toHaveBeenCalledWith({
+			messages: { limit: channel.messagePaginator.pageSize },
+		});
 	});
 
 	it('preserves a failed (unsent) message that a disjoint rebuild would otherwise drop', async () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4123,22 +4123,6 @@ describe('Channel.reload', () => {
 			await expect(channel.reload()).rejects.toThrow('watch failed');
 		});
 
-		it('clears the message-window error before it awaits anything', async () => {
-			// Above the first await on purpose: a reconnect reload gets here inside the synchronous
-			// `connection.changed` dispatch, so a UI that flips its own online flag on that same event
-			// never renders the stale error over content that is about to refresh.
-			seedLatestWindow(channel, [msg('m1', 1)]);
-			channel.messagePaginator.state.partialNext({
-				lastQueryError: new Error('load older failed'),
-			});
-
-			// Never settles, so only a clear that ran BEFORE the await can be observed.
-			vi.spyOn(channel, 'getOrCreate').mockReturnValue(new Promise(() => {}));
-			channel.watch();
-
-			expect(channel.messagePaginator.lastQueryError).toBeUndefined();
-		});
-
 		it('releases the re-entrancy guard when a reload fails', async () => {
 			// Without the `finally`, one failure would wedge `reload()` for the channel's lifetime — no
 			// later reconnect could ever refresh it again.

--- a/test/unit/client.construction.test.ts
+++ b/test/unit/client.construction.test.ts
@@ -73,7 +73,10 @@ describe('StreamChat construction', () => {
       const client = new StreamChat(API_KEY);
 
       expect(client.listeners).to.be.instanceOf(Map);
-      expect(client.listeners.size).to.equal(0);
+      // The only listener a freshly constructed client registers is the connection-recovery
+      // subscription, which is wired up in the constructor because recovery is not opt-in
+      // (`recoverStateOnReconnect` is the opt-out, checked when a recovery actually runs).
+      expect([...client.listeners.keys()]).to.deep.equal(['connection.changed']);
       expect(client.mutedChannels).to.deep.equal([]);
       expect(client.mutedUsers).to.deep.equal([]);
       expect(client.activeChannels).to.deep.equal({});

--- a/test/unit/client.construction.test.ts
+++ b/test/unit/client.construction.test.ts
@@ -63,7 +63,6 @@ describe('StreamChat construction', () => {
     it('treats an omitted options argument as an empty options object', () => {
       const client = new StreamChat(API_KEY);
       expect(client.options.warmUp).to.equal(false);
-      expect(client.options.recoverStateOnReconnect).to.equal(true);
       expect(client.options.disableCache).to.equal(false);
     });
   });
@@ -75,7 +74,7 @@ describe('StreamChat construction', () => {
       expect(client.listeners).to.be.instanceOf(Map);
       // The only listener a freshly constructed client registers is the connection-recovery
       // subscription, which is wired up in the constructor because recovery is not opt-in
-      // (`recoverStateOnReconnect` is the opt-out, checked when a recovery actually runs).
+      // (`client.connectionRecovery` config is the opt-out, read when a recovery actually runs).
       expect([...client.listeners.keys()]).to.deep.equal(['connection.changed']);
       expect(client.mutedChannels).to.deep.equal([]);
       expect(client.mutedUsers).to.deep.equal([]);
@@ -116,23 +115,24 @@ describe('StreamChat construction', () => {
       const client = new StreamChat(API_KEY);
 
       expect(client.options.warmUp).to.equal(false);
-      expect(client.options.recoverStateOnReconnect).to.equal(true);
       expect(client.options.disableCache).to.equal(false);
       expect(client.options.wsUrlParams).to.be.instanceOf(URLSearchParams);
-      expect(client.recoverStateOnReconnect).to.equal(true);
+      // Recovery is on by default, and now says so through its own configuration rather than a
+      // client option.
+      expect(client.connectionRecovery.config.enabled).to.equal(true);
     });
 
     it('honors user-provided overrides', () => {
       const client = new StreamChat(API_KEY, {
         warmUp: true,
         disableCache: true,
-        recoverStateOnReconnect: false,
+        config: { client: { connectionRecovery: { enabled: false } } },
       });
 
       expect(client.options.warmUp).to.equal(true);
       expect(client.options.disableCache).to.equal(true);
-      expect(client.options.recoverStateOnReconnect).to.equal(false);
-      expect(client.recoverStateOnReconnect).to.equal(false);
+      // Seeded from `options.config` before the managers are wired, so it applies from construction.
+      expect(client.connectionRecovery.config.enabled).to.equal(false);
     });
 
     it('passes persistUserOnConnectionFailure through to the client', () => {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1815,8 +1815,8 @@ describe('X-Stream-Client header', () => {
 // `notification.removed_from_channel` event. Previously the client only evicted
 // channels from `activeChannels` on deletion, so a removed-from channel lingered:
 // later `message.new` / `notification.message_new` events were still delivered to
-// it, and on reconnect `recoverState()` re-watched it (because it re-watches every
-// cid still in `activeChannels`), re-promoting it in downstream lists.
+// it, and connection recovery refreshed it, re-promoting it in downstream lists.
+// Eviction is what keeps it out of both paths.
 describe('activeChannels eviction when the current user is removed (#2599)', () => {
 	let client;
 	const currentUserId = 'current-user';
@@ -1888,21 +1888,21 @@ describe('activeChannels eviction when the current user is removed (#2599)', () 
 		expect(client.activeChannels[channel.cid]).to.be.undefined;
 	});
 
-	it('does not re-watch the evicted channel on recoverState', async () => {
+	it('does not reload the evicted channel on connection recovery', async () => {
 		const removed = client.channel('messaging', 'removed');
 		const kept = client.channel('messaging', 'kept');
-		const queryChannelsStub = vi
-			.spyOn(client, 'queryChannels')
-			.mockResolvedValue({ channels: [] });
+		// Recovery only reloads channels a consumer declared it is reading.
+		removed.activate();
+		kept.activate();
+		const removedReload = vi.spyOn(removed, 'reload').mockResolvedValue(undefined);
+		const keptReload = vi.spyOn(kept, 'reload').mockResolvedValue(undefined);
 
 		client.dispatchEvent(removedFromChannelEvent(removed));
 
-		await client.recoverState();
+		await client.connectionRecovery.recover();
 
-		expect(queryChannelsStub).toHaveBeenCalledTimes(1);
-		const [options] = queryChannelsStub.mock.calls[0];
-		expect(options.filter_conditions.cid.$in).to.contain(kept.cid);
-		expect(options.filter_conditions.cid.$in).not.to.contain(removed.cid);
+		expect(keptReload).toHaveBeenCalledTimes(1);
+		expect(removedReload).not.toHaveBeenCalled();
 	});
 
 	it('does not evict when another user is removed (member.removed for a different user)', () => {

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -130,7 +130,6 @@ describe('connection', function () {
 		client.clientID = 'clientID';
 		client.insightMetrics = new InsightMetrics();
 		client.dispatchEvent = () => null;
-		client.recoverState = () => null;
 		return client;
 	};
 

--- a/test/unit/pagination/paginators/MessagePaginator.test.ts
+++ b/test/unit/pagination/paginators/MessagePaginator.test.ts
@@ -2948,6 +2948,26 @@ describe('MessagePaginator', () => {
     const ids = (paginator: MessagePaginator) =>
       paginator.items?.map((message) => message.id);
 
+    it('clears a previous query error when a reconciling seed lands', () => {
+      // This branch returns before `postQueryReconcile`, which is the only other thing that resets
+      // `lastQueryError`. Without a clear here a failed "load older" stays latched through an
+      // otherwise successful reconnect refresh, and any UI reading the paginator keeps its error up.
+      const paginator = loadHead([msg('m1', 1), msg('m2', 2)]);
+      paginator.state.partialNext({ lastQueryError: new Error('load older failed') });
+
+      paginator.seedFirstPageSync(
+        [msg('m1', 1), msg('m2', 2), msg('m3', 3)],
+        25,
+        undefined,
+        {
+          reconcile: true,
+        },
+      );
+
+      expect(paginator.lastQueryError).toBeUndefined();
+      expect(ids(paginator)).toEqual(['m1', 'm2', 'm3']);
+    });
+
     it('REPRO(interval): reconnect re-establishes hasMoreTail over a stale "complete" INTERVAL (offline DB)', () => {
       const paginator = makePaginator();
       // Offline-DB window persisted as "complete" — the INTERVAL itself has isTail=true / hasMoreTail

--- a/test/unit/pagination/paginators/MessagePaginator.test.ts
+++ b/test/unit/pagination/paginators/MessagePaginator.test.ts
@@ -519,6 +519,51 @@ describe('MessagePaginator', () => {
       expect(paginator.items?.map((message) => message.id)).toEqual(['m1', 'm2']);
     });
 
+    it('loads and anchors the real head when only live content is loaded', async () => {
+      const paginator = new MessagePaginator({
+        channel,
+        itemIndex,
+        parentMessageId: 'parent-1',
+      });
+      // Only live-ingested content: a logical head, nothing anchored (a thread created this session).
+      paginator.ingestItem(
+        createMessage({
+          id: 'mine',
+          cid: 'channel-id',
+          parent_id: 'parent-1',
+          created_at: '2020-01-05T00:00:00.000Z',
+        }),
+      );
+      (channel as unknown as { getClient: () => unknown }).getClient = () => ({
+        user: undefined,
+        getReplies: channel.getReplies,
+      });
+      (channel.getReplies as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
+        messages: [
+          createMessage({
+            id: 'mine',
+            cid: 'channel-id',
+            parent_id: 'parent-1',
+            created_at: '2020-01-05T00:00:00.000Z',
+          }),
+          createMessage({
+            id: 'peer',
+            cid: 'channel-id',
+            parent_id: 'parent-1',
+            created_at: '2020-01-06T00:00:00.000Z',
+          }),
+        ],
+      });
+
+      const result = await paginator.jumpToTheLatestMessage();
+
+      // One headward query anchors the real head, so scroll-to-bottom out of an un-anchored window
+      // lands on the true newest messages rather than the lone live item. Self-correcting.
+      expect(result).toBe(true);
+      expect(channel.getReplies).toHaveBeenCalledTimes(1);
+      expect(paginator.items?.map((i) => i.id)).toEqual(['mine', 'peer']);
+    });
+
     it('succeeds when a headward query hits the dataset edge (empty) - "all loaded" case', async () => {
       const paginator = new MessagePaginator({
         channel,
@@ -1809,6 +1854,69 @@ describe('MessagePaginator', () => {
       // m6 not merged; the loaded window is unchanged.
       expect(paginator.items?.map((message) => message.id)).toEqual(['m4', 'm5']);
       expect(paginator.getItem('m6')).toBeUndefined();
+    });
+
+    it('anchors a newest page beside a middle island without welding it or stealing the view', () => {
+      // The branch's entry condition in its riskiest shape: only a middle island loaded, plus a live
+      // arrival — logical head, no anchored head. Must not weld across the gap or move the reader.
+      const paginator = new MessagePaginator({
+        channel,
+        itemIndex,
+        parentMessageId: 'parent-1',
+      });
+      paginator.ingestPage({
+        page: [m('m4', '04'), m('m5', '05')],
+        isHead: false,
+        isTail: false,
+        setActive: true,
+      });
+      // Arrived live while the reader sits on the middle island → logical head.
+      paginator.ingestItem(m('live', '20', { parent_id: 'parent-1' }));
+
+      paginator.mergeNewestPage([m('m30', '30'), m('m31', '31')]);
+
+      // Reader stays put; the page is anchored as its own island for their return, not welded in.
+      expect(paginator.items?.map((message) => message.id)).toEqual(['m4', 'm5']);
+      expect(paginator.getItem('m30')).toBeDefined();
+    });
+
+    it('never strands a live item that is older than the fetched page', () => {
+      const paginator = new MessagePaginator({
+        channel,
+        itemIndex,
+        parentMessageId: 'parent-1',
+      });
+      // Unsent local message, older than anything the server has.
+      paginator.ingestItem(m('local-old', '01', { parent_id: 'parent-1' }));
+      // Newest page, short — so it reads as "reached the start" — and all newer than local-old.
+      paginator.mergeNewestPage([m('s1', '05'), m('s2', '06')]);
+
+      // The worry was that anchoring a SHORT page (which looks like "reached the channel start")
+      // while holding an older live item would strand it: invisible, with "load older" switched off
+      // so it could never be reached. It does not — the item stays indexed and the tail stays open.
+      // The worry: a short page reads as "reached the start", so an older live item could be dropped
+      // from view AND cut off by "load older" being disabled. It is not — still indexed, tail open.
+      expect(paginator.items?.map((i) => i.id)).toEqual(['s1', 's2']);
+      expect(paginator.getItem('local-old')).toBeDefined();
+      expect(paginator.state.getLatestValue().hasMoreTail).toBe(true);
+    });
+
+    it('keeps a live item that arrived during the fetch, alongside the anchored page', () => {
+      const paginator = new MessagePaginator({
+        channel,
+        itemIndex,
+        parentMessageId: 'parent-1',
+      });
+      // Two live items: one the page also has, one that arrived DURING the fetch (newer).
+      paginator.ingestItem(m('mine', '05', { parent_id: 'parent-1' }));
+      paginator.ingestItem(m('during-fetch', '30', { parent_id: 'parent-1' }));
+
+      paginator.mergeNewestPage([m('mine', '05'), m('s2', '06')]);
+
+      // The fold absorbs the shared item and keeps the newer one above the page rather than losing
+      // it. `hasMoreHead` false because the head is now anchored.
+      expect(paginator.items?.map((i) => i.id)).toEqual(['mine', 's2', 'during-fetch']);
+      expect(paginator.state.getLatestValue().hasMoreHead).toBe(false);
     });
 
     it('is a no-op when nothing is loaded', () => {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -712,7 +712,7 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((r) => r.id)).to.eql(activeBefore);
         });
 
-        it('does not publish lastReloadError when the thread does not exist yet', async () => {
+        it('does not publish lastLoadError when the thread does not exist yet', async () => {
           // Opening a parent that has no replies means there is no server-side thread, so `getThread`
           // answers DoesNotExist (16). That is an expected answer, not a failed refresh: publishing it
           // raises the consumer's error state (the RN SDK ORs it into `ChannelContext.error`) just for
@@ -731,7 +731,7 @@ describe('Threads 2.0', () => {
           // make every caller log "reload failed" on a brand-new thread.
           await expect(thread.reload()).resolves.toBeUndefined();
 
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
         });
 
         it('treats a bare 404 as not-found even without the Stream code', async () => {
@@ -748,10 +748,10 @@ describe('Threads 2.0', () => {
 
           await expect(thread.reload()).resolves.toBeUndefined();
 
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
         });
 
-        it('publishes lastReloadError when a thread we HAD comes back not-found', async () => {
+        it('publishes lastLoadError when a thread we HAD comes back not-found', async () => {
           // Deleted while we were offline: the `message.deleted` event was missed, so `deletedAt` is
           // still null and the 404 is the only signal we get. `replyCount > 0` says we had something,
           // so this is a real failure to refresh, not a thread that never existed.
@@ -774,17 +774,17 @@ describe('Threads 2.0', () => {
 
           await expect(thread.reload()).rejects.toThrow(notFound);
 
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(notFound);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(notFound);
         });
 
-        it('still publishes lastReloadError for a real failure', async () => {
+        it('still publishes lastLoadError for a real failure', async () => {
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const failure = Object.assign(new Error('boom'), { code: 9, StatusCode: 500 });
           sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
 
           await expect(thread.reload()).rejects.toThrow(failure);
 
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(failure);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(failure);
         });
 
         it('falls back to the server default when the paginator has no page size', async () => {
@@ -877,15 +877,15 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((reply) => reply.id)).to.contain('failed-1');
         });
 
-        it('publishes a reload failure on state.lastReloadError and rethrows it', async () => {
+        it('publishes a reload failure on state.lastLoadError and rethrows it', async () => {
           // Connection recovery runs `reload()` inside `Promise.allSettled`, so the throw never
-          // reaches a UI. Mirrors `channel.state.lastReloadError`.
+          // reaches a UI. Mirrors `channel.state.lastLoadError`.
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const failure = new Error('thread reload failed');
           const stub = sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
 
           await expect(thread.reload()).rejects.toThrow(failure);
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(failure);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(failure);
           // Not left mid-flight — otherwise the isLoading guard would swallow every later reload.
           expect(thread.state.getLatestValue().isLoading).to.equal(false);
 
@@ -895,7 +895,7 @@ describe('Threads 2.0', () => {
             .stub(client, 'getThreadAndHydrate')
             .resolves(createTestThread({ latest_replies: [], reply_count: 0 }));
           await thread.reload();
-          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
         });
       });
 

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -649,6 +649,62 @@ describe('Threads 2.0', () => {
           // r4 (arrived AFTER the snapshot) → not in the snapshot → kept.
           expect(repliesOf(thread).map((reply) => reply.id)).to.eql(['r1', 'r2', 'r4']);
         });
+
+        it('preserves a failed (unsent) reply across a rebuild', async () => {
+          // The failed reply is read out of the reply PAGINATOR, not out of `failedRepliesMap`. That
+          // map is only written by `upsertReplyLocally`, whose callers are this thread's own
+          // subscriptions and the offline-DB path keyed on `ThreadManager.threadsById` — so for a
+          // thread constructed directly and never registered (what the React Native SDK does via
+          // `threadsById[id] ?? new Thread(...)`) it is always empty, and relying on it would drop the
+          // user's unsent reply on every reconnect.
+          const r1 = makeReply({ id: 'r1', created_at: '2020-01-01T00:00:01.000Z' });
+          const thread = createTestThread({ latest_replies: [r1], reply_count: 1 });
+          expect(thread.hasSubscriptions).to.equal(false);
+
+          // A reply the user sent while offline, which failed. It only exists locally, and like any
+          // just-attempted send it is the newest thing in the thread.
+          const failed = formatMessage(
+            makeReply({ id: 'failed-1', created_at: '2021-06-01T00:00:09.000Z' }),
+          );
+          failed.status = 'failed';
+          thread.messagePaginator.ingestItem(failed);
+          expect(repliesOf(thread).map((reply) => reply.id)).to.contain('failed-1');
+
+          // Server page is disjoint from the loaded window, which forces a rebuild — the one case the
+          // reconcile's provenance guard does not cover.
+          const far1 = makeReply({ id: 'far1', created_at: '2021-06-01T00:00:01.000Z' });
+          const far2 = makeReply({ id: 'far2', created_at: '2021-06-01T00:00:02.000Z' });
+          const hydrationThread = createTestThread({
+            latest_replies: [far1, far2],
+            reply_count: 2,
+          });
+          sinon.stub(client, 'getThreadAndHydrate').resolves(hydrationThread);
+
+          await thread.reload();
+
+          expect(repliesOf(thread).map((reply) => reply.id)).to.contain('failed-1');
+        });
+
+        it('publishes a reload failure on state.lastReloadError and rethrows it', async () => {
+          // Connection recovery runs `reload()` inside `Promise.allSettled`, so the throw never
+          // reaches a UI. Mirrors `channel.state.lastReloadError`.
+          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
+          const failure = new Error('thread reload failed');
+          const stub = sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
+
+          await expect(thread.reload()).rejects.toThrow(failure);
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(failure);
+          // Not left mid-flight — otherwise the isLoading guard would swallow every later reload.
+          expect(thread.state.getLatestValue().isLoading).to.equal(false);
+
+          // A later success clears it, so a stale banner cannot outlive the failure it described.
+          stub.restore();
+          sinon
+            .stub(client, 'getThreadAndHydrate')
+            .resolves(createTestThread({ latest_replies: [], reply_count: 0 }));
+          await thread.reload();
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+        });
       });
 
       describe('deleteReplyLocally', () => {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -712,6 +712,81 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((r) => r.id)).to.eql(activeBefore);
         });
 
+        it('does not publish lastReloadError when the thread does not exist yet', async () => {
+          // Opening a parent that has no replies means there is no server-side thread, so `getThread`
+          // answers DoesNotExist (16). That is an expected answer, not a failed refresh: publishing it
+          // raises the consumer's error state (the RN SDK ORs it into `ChannelContext.error`) just for
+          // opening a brand-new thread.
+          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
+          const notFound = Object.assign(
+            new Error('Request failed with status code 404'),
+            {
+              code: 16,
+              StatusCode: 404,
+            },
+          );
+          sinon.stub(client, 'getThreadAndHydrate').rejects(notFound);
+
+          // Resolves rather than rejecting: nothing to reload is not a failure, and rethrowing would
+          // make every caller log "reload failed" on a brand-new thread.
+          await expect(thread.reload()).resolves.toBeUndefined();
+
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+        });
+
+        it('treats a bare 404 as not-found even without the Stream code', async () => {
+          // The guard must not hinge on the API choosing code 16 — a 404 from `getThread` means the
+          // thread is not there whatever the body says.
+          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
+          const notFound = Object.assign(
+            new Error('Request failed with status code 404'),
+            {
+              status: 404,
+            },
+          );
+          sinon.stub(client, 'getThreadAndHydrate').rejects(notFound);
+
+          await expect(thread.reload()).resolves.toBeUndefined();
+
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(undefined);
+        });
+
+        it('publishes lastReloadError when a thread we HAD comes back not-found', async () => {
+          // Deleted while we were offline: the `message.deleted` event was missed, so `deletedAt` is
+          // still null and the 404 is the only signal we get. `replyCount > 0` says we had something,
+          // so this is a real failure to refresh, not a thread that never existed.
+          const thread = createTestThread({
+            latest_replies: [makeReply({ created_at: '2020-01-01T00:00:01.000Z' })],
+            // `replyCount` is read off the PARENT message, not the thread response's own count.
+            parentMessageOverrides: { reply_count: 4 },
+          });
+          expect(thread.state.getLatestValue().replyCount).to.equal(4);
+          expect(thread.state.getLatestValue().deletedAt).to.equal(null);
+          const notFound = Object.assign(
+            new Error('Request failed with status code 404'),
+            {
+              code: 16,
+              StatusCode: 404,
+              status: 404,
+            },
+          );
+          sinon.stub(client, 'getThreadAndHydrate').rejects(notFound);
+
+          await expect(thread.reload()).rejects.toThrow(notFound);
+
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(notFound);
+        });
+
+        it('still publishes lastReloadError for a real failure', async () => {
+          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
+          const failure = Object.assign(new Error('boom'), { code: 9, StatusCode: 500 });
+          sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
+
+          await expect(thread.reload()).rejects.toThrow(failure);
+
+          expect(thread.state.getLatestValue().lastReloadError).to.equal(failure);
+        });
+
         it('falls back to the server default when the paginator has no page size', async () => {
           // `pageSize` is optional on the paginator config. Guarding it matters: `Math.max(n,
           // undefined)` is NaN, and a zero page size would ask for no replies at all.

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -428,11 +428,17 @@ describe('Threads 2.0', () => {
         it('retains failed replies after hydration', () => {
           const thread = createTestThread();
           const hydrationThread = createTestThread({
-            latest_replies: [makeReply()],
+            latest_replies: [makeReply({ created_at: '2020-01-01T00:00:01.000Z' })],
             reply_count: 1,
           });
 
-          const failedMessage = makeReply({ status: 'failed' });
+          // Pinned, failed reply NEWEST: `makeReply()` reads `created_at` from the clock, so implicit
+          // timestamps landed in random order and an older-than-window reply sits below it, not in
+          // view — ~50% flaky. A just-attempted send is the newest thing anyway.
+          const failedMessage = makeReply({
+            created_at: '2020-01-01T00:00:09.000Z',
+            status: 'failed',
+          });
           thread.upsertReplyLocally({ message: failedMessage });
 
           thread.hydrateState(hydrationThread);
@@ -625,6 +631,85 @@ describe('Threads 2.0', () => {
           });
           await narrow.reload();
           expect(stub.thirdCall.args[0]?.reply_limit).to.equal(pageSize);
+        });
+
+        it('merges the fetched page into a thread whose only reply was ingested live', async () => {
+          // A thread created this session has an EMPTY first reply page, so nothing anchors its
+          // window and the sent reply lands in a LOGICAL head. `mergeNewestPage` used to require an
+          // ANCHORED head, silently discarding every reply the server returned on reconnect — and
+          // re-entering never healed it, since the instance is reused with `items` already defined.
+          const thread = createMinimalThread();
+          expect(thread.messagePaginator.state.getLatestValue().items).to.be.undefined;
+
+          // The sent reply — live-ingested, no page behind it.
+          const mine = formatMessage(
+            makeReply({ id: 'mine', created_at: '2020-01-01T00:00:01.000Z' }),
+          );
+          thread.messagePaginator.ingestItem(mine);
+          expect(repliesOf(thread).map((r) => r.id)).to.eql(['mine']);
+
+          // Two replies from someone else while offline; the server returns all three.
+          const peer1 = makeReply({
+            id: 'peer1',
+            created_at: '2020-01-01T00:00:02.000Z',
+          });
+          const peer2 = makeReply({
+            id: 'peer2',
+            created_at: '2020-01-01T00:00:03.000Z',
+          });
+          sinon.stub(client, 'getThreadAndHydrate').resolves(
+            createTestThread({
+              latest_replies: [
+                makeReply({ id: 'mine', created_at: '2020-01-01T00:00:01.000Z' }),
+                peer1,
+                peer2,
+              ],
+              reply_count: 3,
+            }),
+          );
+
+          await thread.reload();
+
+          expect(repliesOf(thread).map((r) => r.id)).to.eql(['mine', 'peer1', 'peer2']);
+        });
+
+        it('anchors the fetched page without yanking the view when the caller has jumped away', async () => {
+          // Same rule as the jumped-away branch: anchor for later, never switch the active window
+          // out from under someone reading an older island.
+          const thread = createMinimalThread();
+          const mine = formatMessage(
+            makeReply({ id: 'mine', created_at: '2020-01-01T00:00:05.000Z' }),
+          );
+          thread.messagePaginator.ingestItem(mine);
+
+          // Simulate a jump: an older, separately-anchored island that is the active window.
+          const older = [
+            makeReply({ id: 'old1', created_at: '2019-01-01T00:00:01.000Z' }),
+            makeReply({ id: 'old2', created_at: '2019-01-01T00:00:02.000Z' }),
+          ].map((r) => formatMessage(r));
+          const jumped = thread.messagePaginator.ingestPage({
+            page: older,
+            isHead: false,
+            setActive: true,
+          });
+          expect(jumped).to.not.equal(undefined);
+          const activeBefore = repliesOf(thread).map((r) => r.id);
+          expect(activeBefore).to.eql(['old1', 'old2']);
+
+          sinon.stub(client, 'getThreadAndHydrate').resolves(
+            createTestThread({
+              latest_replies: [
+                makeReply({ id: 'mine', created_at: '2020-01-01T00:00:05.000Z' }),
+                makeReply({ id: 'peer1', created_at: '2020-01-01T00:00:06.000Z' }),
+              ],
+              reply_count: 2,
+            }),
+          );
+
+          await thread.reload();
+
+          // Still reading the old island — not relocated to the newest page.
+          expect(repliesOf(thread).map((r) => r.id)).to.eql(activeBefore);
         });
 
         it('falls back to the server default when the paginator has no page size', async () => {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -585,12 +585,12 @@ describe('Threads 2.0', () => {
       });
 
       describe('reload', () => {
-        it('sizes getThread reply_limit to the loaded reply count, falling back to pageSize when unloaded', async () => {
+        it('sizes getThread reply_limit to the loaded window, but never below a page', async () => {
           const stub = sinon.stub(client, 'getThread').resolves({
             thread: generateThreadResponse(channelResponse, parentMessageResponse),
           });
 
-          // Unloaded (minimal) thread → falls back to pageSize.
+          // Unloaded (minimal) thread → a page.
           const minimalThread = createMinimalThread();
           expect(minimalThread.messagePaginator.state.getLatestValue().items).to.be
             .undefined;
@@ -599,19 +599,51 @@ describe('Threads 2.0', () => {
             minimalThread.messagePaginator.pageSize,
           );
 
-          // Loaded thread → sized to the loaded reply count (so the whole loaded window reconciles),
-          // NOT the paginator pageSize.
-          const loadedThread = createTestThread({
+          // Loaded window LARGER than a page → sized to it, so the whole window reconciles.
+          const pageSize = minimalThread.messagePaginator.pageSize;
+          const wide = createTestThread({
             latest_replies: Array.from(
-              { length: 7 },
+              { length: pageSize + 7 },
               () =>
                 generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
             ),
-            reply_count: 20,
+            reply_count: pageSize + 20,
           });
-          await loadedThread.reload();
-          expect(stub.secondCall.args[0]?.reply_limit).to.equal(7);
-          expect(loadedThread.messagePaginator.pageSize).to.not.equal(7);
+          await wide.reload();
+          expect(stub.secondCall.args[0]?.reply_limit).to.equal(pageSize + 7);
+
+          // ⚠️ Loaded window SMALLER than a page → still a page. Regression guard: a thread created in
+          // the current session holds exactly one reply (the one just sent), and sizing the request to
+          // that asks the server for one reply — so replies added while offline can never be
+          // discovered, and the single reply that comes back is disjoint from the loaded window, so
+          // the fold rebuilds and drops the user's own reply too.
+          const narrow = createTestThread({
+            latest_replies: [
+              generateMsg({ parent_id: parentMessageResponse.id }) as MessageResponse,
+            ],
+            reply_count: 40,
+          });
+          await narrow.reload();
+          expect(stub.thirdCall.args[0]?.reply_limit).to.equal(pageSize);
+        });
+
+        it('falls back to the server default when the paginator has no page size', async () => {
+          // `pageSize` is optional on the paginator config. Guarding it matters: `Math.max(n,
+          // undefined)` is NaN, and a zero page size would ask for no replies at all.
+          const stub = sinon.stub(client, 'getThread').resolves({
+            thread: generateThreadResponse(channelResponse, parentMessageResponse),
+          });
+          const thread = createTestThread({
+            latest_replies: [],
+            reply_count: 0,
+          });
+          thread.messagePaginator.updateConfig({ pageSize: undefined });
+
+          await thread.reload();
+
+          const limit = stub.firstCall.args[0]?.reply_limit;
+          expect(limit).to.equal(undefined);
+          expect(Number.isNaN(limit as number)).to.equal(false);
         });
 
         it('removes a reply hard-deleted while offline and keeps one that arrived during the fetch', async () => {

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -712,11 +712,10 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((r) => r.id)).to.eql(activeBefore);
         });
 
-        it('does not publish lastLoadError when the thread does not exist yet', async () => {
+        it('resolves quietly when the thread does not exist yet', async () => {
           // Opening a parent that has no replies means there is no server-side thread, so `getThread`
-          // answers DoesNotExist (16). That is an expected answer, not a failed refresh: publishing it
-          // raises the consumer's error state (the RN SDK ORs it into `ChannelContext.error`) just for
-          // opening a brand-new thread.
+          // answers DoesNotExist (16). That is an expected answer, not a failed refresh: rethrowing it
+          // would make every caller report a failure just for opening a brand-new thread.
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const notFound = Object.assign(
             new Error('Request failed with status code 404'),
@@ -730,8 +729,6 @@ describe('Threads 2.0', () => {
           // Resolves rather than rejecting: nothing to reload is not a failure, and rethrowing would
           // make every caller log "reload failed" on a brand-new thread.
           await expect(thread.reload()).resolves.toBeUndefined();
-
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
         });
 
         it('treats a bare 404 as not-found even without the Stream code', async () => {
@@ -747,11 +744,9 @@ describe('Threads 2.0', () => {
           sinon.stub(client, 'getThreadAndHydrate').rejects(notFound);
 
           await expect(thread.reload()).resolves.toBeUndefined();
-
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
         });
 
-        it('publishes lastLoadError when a thread we HAD comes back not-found', async () => {
+        it('rethrows when a thread we HAD comes back not-found', async () => {
           // Deleted while we were offline: the `message.deleted` event was missed, so `deletedAt` is
           // still null and the 404 is the only signal we get. `replyCount > 0` says we had something,
           // so this is a real failure to refresh, not a thread that never existed.
@@ -773,18 +768,14 @@ describe('Threads 2.0', () => {
           sinon.stub(client, 'getThreadAndHydrate').rejects(notFound);
 
           await expect(thread.reload()).rejects.toThrow(notFound);
-
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(notFound);
         });
 
-        it('still publishes lastLoadError for a real failure', async () => {
+        it('still rethrows a real failure', async () => {
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const failure = Object.assign(new Error('boom'), { code: 9, StatusCode: 500 });
           sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
 
           await expect(thread.reload()).rejects.toThrow(failure);
-
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(failure);
         });
 
         it('falls back to the server default when the paginator has no page size', async () => {
@@ -877,25 +868,38 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((reply) => reply.id)).to.contain('failed-1');
         });
 
-        it('publishes a reload failure on state.lastLoadError and rethrows it', async () => {
-          // Connection recovery runs `reload()` inside `Promise.allSettled`, so the throw never
-          // reaches a UI. Mirrors `channel.state.lastLoadError`.
+        it('clears a previous reply-window error before it awaits anything', async () => {
+          // The thread twin of `Channel.watch()`'s clear-before-attempt, and above the first await
+          // for the same reason: a recovery reaches here inside the dispatch that flips a UI's own
+          // online flag, so a stale error is never rendered over replies about to refresh.
+          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
+          thread.messagePaginator.state.partialNext({
+            lastQueryError: new Error('load older failed'),
+          });
+
+          // Never settles, so only a clear that ran BEFORE the await can be observed.
+          sinon.stub(client, 'getThreadAndHydrate').returns(new Promise(() => {}));
+          void thread.reload();
+
+          expect(thread.messagePaginator.lastQueryError).to.equal(undefined);
+        });
+
+        it('rethrows a reload failure and releases isLoading', async () => {
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const failure = new Error('thread reload failed');
           const stub = sinon.stub(client, 'getThreadAndHydrate').rejects(failure);
 
           await expect(thread.reload()).rejects.toThrow(failure);
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(failure);
           // Not left mid-flight — otherwise the isLoading guard would swallow every later reload.
           expect(thread.state.getLatestValue().isLoading).to.equal(false);
 
-          // A later success clears it, so a stale banner cannot outlive the failure it described.
+          // Which is exactly what a later reload proves: it must reach the client again.
           stub.restore();
-          sinon
+          const succeeding = sinon
             .stub(client, 'getThreadAndHydrate')
             .resolves(createTestThread({ latest_replies: [], reply_count: 0 }));
           await thread.reload();
-          expect(thread.state.getLatestValue().lastLoadError).to.equal(undefined);
+          expect(succeeding.calledOnce).to.equal(true);
         });
       });
 

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -868,22 +868,6 @@ describe('Threads 2.0', () => {
           expect(repliesOf(thread).map((reply) => reply.id)).to.contain('failed-1');
         });
 
-        it('clears a previous reply-window error before it awaits anything', async () => {
-          // The thread twin of `Channel.watch()`'s clear-before-attempt, and above the first await
-          // for the same reason: a recovery reaches here inside the dispatch that flips a UI's own
-          // online flag, so a stale error is never rendered over replies about to refresh.
-          const thread = createTestThread({ latest_replies: [], reply_count: 0 });
-          thread.messagePaginator.state.partialNext({
-            lastQueryError: new Error('load older failed'),
-          });
-
-          // Never settles, so only a clear that ran BEFORE the await can be observed.
-          sinon.stub(client, 'getThreadAndHydrate').returns(new Promise(() => {}));
-          void thread.reload();
-
-          expect(thread.messagePaginator.lastQueryError).to.equal(undefined);
-        });
-
         it('rethrows a reload failure and releases isLoading', async () => {
           const thread = createTestThread({ latest_replies: [], reply_count: 0 });
           const failure = new Error('thread reload failed');


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

The client handles connection recovery now, so the UI SDKs don't have to.

`recoverState()` was unusable, because of the fact that it never guaranteed proper rewatching of channels (nor reordering of the channel list properly and so we had an implementation that ended up spread across three places that didn't know about each other.

What was wrong with the old one:

- one `queryChannelsAndHydrate({ cid: { $in: activeChannels }, limit: 30 })`, so it used a query shape no list actually had, and quietly stopped at 30 channels
- never looked at `watchStatus`
- wasn't ordered against offline pending-task replay or `sync()`
- only called from `_reconnect()`, so it never ran when the app backgrounded (`closeConnection()` → `openConnection()`), which is the common case on mobile

`ChannelWatchStatus.WasWatching` and `channel.active` were already there and read by nothing. They were
added for this.

### What recovery does

`ConnectionRecoveryManager` does three things:

1. every loaded channel list re-runs its own first-page query (`ChannelManager.recover()`). Since `queryChannels` watches by default, that re-watches the channels on that page too. Non-destructive, the list never blanks.
2. every active channel reloads (`channel.reload()`). A list page carries far fewer messages per channel than an open channel's window, so the list query can't cover it.
3. every active thread reloads its replies (`thread.reload()`). 

It doesn't loop over `activeChannels`. That cache gets large after any scrolling and watches are a limited server-side resource. Channels outside the refreshed pages come back when an event proves them relevant: `ChannelManager` re-watches a routed channel marked `WasWatching`.

Triggers differ per surface, so lists use `connection.changed { online: true }`, because `ChannelPaginator.executeQuery` already defers its own first page. Channels and threads use the offline DB's sync-status edge case when offline support is on and `connection.changed` otherwise, because `reload()` has no deferral of its own and has to run after replay and `sync()`. `OfflineDBSyncManager` publishes that edge unconditionally after `syncAndExecutePendingTasks()`, which is what makes the ordering hold on every path.

`connection.recovered` now fires from the manager once the reloads settle, on every reconnect path rather than only from `_reconnect()`.

### Bug fixes

Three, all pre-existing, found while testing the above. Each has regression tests.

**Reload asked for as many items as were already loaded.** A thread with one reply asked the server for one reply, so anything that arrived while offline couldn't be discovered, and the single result was disjoint from the loaded window so the merge rebuilt and dropped what was there. Asks for at least a page now.

**`mergeNewestPage` returned early when there was no anchored head interval,** throwing away the page it had just been handed. Happens when the first query comes back empty and the only content was ingested live, i.e. a thread or channel created in the same session. It anchors the page now, and doesn't move the view if the reader has jumped somewhere else.

**Opening a thread on a parent with no replies 404s,** since there's no thread server-side yet. That was published as `lastReloadError`, and RN ORs that into its channel error state, so a brand-new thread looked broken. Treated as the expected answer now: `reload()` resolves quietly. A thread that *did* have replies and comes back 404 still reports it. `replyCount` tells the two apart, and unlike `deletedAt` it still works when you missed the delete event while offline.

### Breaking

`client.recoverState()` is gone rather than a no-op, so callers fail loudly. Use. `client.connectionRecovery.recover()`. The one thing it did that mattered, resetting `wsPromise`/`setUserPromise`, moved to `client._settleConnectPromises()` and is called from `_reconnect()` in the same place.

`recoverStateOnReconnect` keeps its name, type and `true` default. It gates the new flow instead of the old bulk query. If you set it `false` and recover yourself, nothing changes.

### Added

`client.connectionRecovery` · `ChannelManager.recover()` · `channel.state.lastReloadError` (plus the `channel.lastReloadError` getter) · `thread.state.lastReloadError` · `isDoesNotExistError` in `errors.ts`. `Thread.activate()`/`deactivate()` are refcounted now, like `Channel.activate()`.

The `lastReloadError` fields exist because the manager runs reloads inside `Promise.allSettled`, so a failure never reaches the UI as a throw. Cleared on entry, set in the catch, and still rethrown.

### Testing

### Known gaps

Recovery finds threads via `client.threads.threadsById` filtered on `state.active`. That's the thread *list*, not a cache - a thread opened from a message list only gets there because the UI SDKs adopt it once its replies load. A reconnect before that, or after `ThreadManager.reload()` evicts a thread the user doesn't participate in, misses it. There's a test named `KNOWN GAP` pinning this. The fix is `ThreadManager`'s commented-out `threadCache` (probably in the form of a `StoreBackedItemIndex` or something) that is anyway in our todo list.

Underneath that: live-ingested content produces a window with no head interval at all. It renders fine and `hasMoreHead` says `true`, which isn't true. Three places each work around it differently (`mergeNewestPage` got it wrong, `jumpToTheLatestMessage` queries to recover, `reconcileHeadAgainstPage` returns early). Anchoring at ingest time instead was tried and reverted: it breaks optimistic message placement, since an unsent message would claim it came from a fetched page, and it stops scroll-to-bottom loading the real head. The fix within the page merging mechanism should still stay for a variety of different edge cases, but this one should also be addressed. Needs its own PR.

`isDoesNotExistError` looks the code up in `APIErrorCodes` by name instead of comparing to `16`, so the table stays the only place that mapping lives. `name` is typed `string` there, so a typo compiles and silently returns false. Making those names a union would be nice.

## Changelog

- Added `client.connectionRecovery`. On reconnect it re-runs each loaded channel list's first-page query,reloads every active channel and thread, then dispatches `connection.recovered`. Runs after offline replay and `sync()` on every reconnect path, including backgrounding.
- Added `ChannelManager.recover()`, a non-destructive re-query of every initialized list.
- Added `channel.state.lastReloadError` (and `channel.lastReloadError`) and `thread.state.lastReloadError` so a failed reconnect refresh stays visible to the UI.
- Added `isDoesNotExistError` to `errors.ts`.
- `ChannelManager` re-watches a routed channel whose `watchStatus` is `WasWatching`, restoring a watchlost with the socket. Narrower than v9, which re-watched any routed channel. Skipped for`channel.hidden`, pending disposal and `NotWatching`.
- `connection.recovered` is dispatched by `ConnectionRecoveryManager` after the reloads, so it fires onevery reconnect path instead of only from `_reconnect()`.
- `Thread.activate()`/`deactivate()` are refcounted, matching `Channel.activate()`.
- Fixed the reconnect refresh requesting only as many items as were loaded, which hid messages that arrived while offline and could drop the loaded window.
- Fixed `mergeNewestPage` discarding the fetched page when no page had ever anchored the window.
- Fixed opening a thread on a reply-less parent raising an error state.
- [BREAKING CHANGE] Removed `client.recoverState()`. Use `client.connectionRecovery.recover()`.
- [BREAKING CHANGE] `recoverStateOnReconnect` now gates `client.connectionRecovery` instead of the removed bulk query. Same name, type and default.
