### PR TITLE
fix: adjust paginator offset when items are removed

### DIFF
--- a/src/ChannelManager.ts
+++ b/src/ChannelManager.ts
@@ -12,6 +12,7 @@ import type {
   LabeledEventHandler,
   PipelineEvent,
 } from './EventHandlerPipeline';
+import { filterConstrainsField } from './pagination/filterCompiler';
 import { getChannel } from './pagination/utility.queryChannel';
 import type { Channel } from './channel';
 
@@ -227,6 +228,50 @@ const messageNewHandler: LabeledEventHandler<EventHandlerContext> = {
   id: 'ChannelManager:default-handler:message.new',
 };
 
+/**
+ * Sort fields `channelSortPathResolver` resolves from read state. `SortParamRequest.field` is an open
+ * string, so there is no type enumerating them.
+ */
+const READ_STATE_SORT_FIELDS: string[] = ['has_unread', 'unread_count'];
+
+/**
+ * Whether a read can change this list at all: its membership (`has_unread` filter) or its order
+ * (`has_unread` / `unread_count` sort). Unread badges read `channel.state` directly, so nothing else
+ * about the list depends on it.
+ */
+const dependsOnReadState = (paginator: ChannelPaginator) =>
+  paginator.effectiveSort.some(
+    ({ field }) => !!field && READ_STATE_SORT_FIELDS.includes(field),
+  ) || filterConstrainsField(paginator.buildMatchFilters(), 'has_unread');
+
+/**
+ * Re-routes a channel whose read state changed. `message.read` only reaches watchers, so
+ * `notification.mark_*` is the only signal for channels the user is not watching.
+ *
+ * Never fetches, unlike `updateLists`: a read cannot make an unknown channel belong to a list, and
+ * these events are far too frequent to query on.
+ */
+const readStateChangedHandler: LabeledEventHandler<EventHandlerContext> = {
+  handle: ({ event, ctx: { channelManager } }) => {
+    const { client } = channelManager;
+    // another member's read receipt says nothing about this user's unread state
+    if (event.type === 'message.read' && event.user?.id !== client.userId) return;
+
+    // a thread read says nothing about the channel's own read state
+    if (event.thread_id) return;
+
+    // a mark-all-read names no channel, so there is no target to route
+    const channel = getCachedChannelFromEvent(event, client.activeChannels);
+    if (!channel) return;
+
+    // hot path: `message.read` fires on every channel the user opens
+    if (!channelManager.paginators.some(dependsOnReadState)) return;
+
+    channelManager.ingestChannel(channel);
+  },
+  id: 'ChannelManager:default-handler:read-state-changed',
+};
+
 const notificationAddedToChannelHandler: LabeledEventHandler<EventHandlerContext> = {
   handle: updateLists,
   id: 'ChannelManager:default-handler:notification.added_to_channel',
@@ -351,8 +396,12 @@ export class ChannelManager extends WithSubscriptions {
     'channel.visible': [channelVisibleHandler],
     'member.updated': [memberUpdatedHandler],
     'message.new': [messageNewHandler],
+    'message.read': [readStateChangedHandler],
+    'message.read_locally': [readStateChangedHandler],
     'notification.added_to_channel': [notificationAddedToChannelHandler],
     'notification.channel_mutes_updated': [notificationChannelMutesUpdatedHandler],
+    'notification.mark_read': [readStateChangedHandler],
+    'notification.mark_unread': [readStateChangedHandler],
     'notification.message_new': [notificationMessageNewHandler],
     'notification.removed_from_channel': [notificationRemovedFromChannelHandler],
     'user.presence.changed': [userPresenceChangedHandler],
@@ -463,6 +512,20 @@ export class ChannelManager extends WithSubscriptions {
         // Not a match, or matched but not the selected owner — enforce exclusivity.
         paginator.removeItem({ item: channel });
       }
+    });
+  }
+
+  /**
+   * Drops a channel from the lists whose filters it no longer matches, adding it nowhere.
+   *
+   * For state the client changes without an event naming the channel — zeroing every unread count on a
+   * global read. Removal-only: the backend rejects `has_unread: false`, so becoming read can never make
+   * a channel belong to a list, and `ingestChannel` would pull unloaded channels into matching ones.
+   */
+  dropFromUnmatchedLists(channel: Channel) {
+    this.paginators.forEach((paginator) => {
+      if (paginator.matchesFilter(channel)) return;
+      paginator.removeItem({ item: channel });
     });
   }
 

--- a/src/EventHandlerPipeline.ts
+++ b/src/EventHandlerPipeline.ts
@@ -1,32 +1,22 @@
 import { generateUUIDv4 } from './utils';
-import type {
-  ChannelResponse,
-  Event,
-  EventType,
-  MessageResponse,
-  ReactionResponse,
-  UserResponse,
-} from './types';
+import type { Event, EventType } from './types';
+import type { KeysOfUnion, ValueOfUnion } from './types.utility';
 import type { Unsubscribe } from './store';
 
 /**
- * Flat routing view of an event, as seen by pipeline handlers. The public `Event` type is now a
- * discriminated union (each WS event exposes only its own fields) and also admits bare custom-event
- * name strings — neither is convenient for the generic routers here, which only read a bounded set of
- * common optional fields. Dispatched event *values* are always objects, so the pipeline casts to
- * this view at the boundary (see `processOne`).
+ * Flat routing view of an event: every field any event can carry, all optional, on one object.
+ *
+ * Handlers route without narrowing, which `Event` does not allow — it is a discriminated union whose
+ * `{ type: '*' } & CustomEvent` member has none of the channel fields, and it admits bare custom-event
+ * strings (hence the `unknown` hop in `processOne`). Derived from that union, so a new generated field
+ * is routable without widening anything by hand.
  */
+type EventObject = Extract<Event, object>;
+
 export type PipelineEvent = {
   type: EventType | (string & {});
-  channel?: ChannelResponse;
-  channel_id?: string;
-  channel_type?: string;
-  cid?: string;
-  created_at?: string | Date;
-  hard_delete?: boolean;
-  message?: MessageResponse;
-  reaction?: ReactionResponse;
-  user?: UserResponse;
+} & {
+  [Key in KeysOfUnion<EventObject>]?: ValueOfUnion<EventObject, Key>;
 };
 
 type MatchById = { id: string | RegExp; regexMatch?: boolean };

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2487,16 +2487,17 @@ export class Channel extends ChannelApi {
    * `state.unreadCount` derives from — so channel-wide resets (`channel.truncated`, "all channels
    * read") must route through here rather than writing a count of their own.
    */
-  _setOwnUnreadCount(unreadCount: number) {
-    if (this.pendingDisposal) return;
+  /** @returns whether the count actually changed, so callers can react only to the channels it did. */
+  _setOwnUnreadCount(unreadCount: number): boolean {
+    if (this.pendingDisposal) return false;
 
     const userId = this.getClient().userId;
-    if (!userId) return;
+    if (!userId) return false;
 
     const currentUserReadState = this.state.read[userId];
     // only reconcile an existing read entry; never fabricate one just to store a count
     if (!currentUserReadState || currentUserReadState.unread_messages === unreadCount) {
-      return;
+      return false;
     }
 
     this._upsertReadState(
@@ -2504,6 +2505,8 @@ export class Channel extends ChannelApi {
       () => ({ ...currentUserReadState, unread_messages: unreadCount }),
       { changedUserIds: [userId] },
     );
+
+    return true;
   }
 
   _handleChannelEvent(event: Event) {
@@ -2536,13 +2539,18 @@ export class Channel extends ChannelApi {
       case 'ai_indicator.stop':
         channelState.partialNext({ aiState: AIStates.Stop });
         break;
-      // `message.read_locally` is the client-only event dispatched by `markReadLocally()` when read
-      // events are disabled (e.g. livestreams with `isLocalUnreadCountEnabled`). It reuses the exact
-      // `message.read` state logic so the read-state update lives in one place — only the
-      // delivery-report network sync below is skipped for it.
+      // `notification.mark_read` is the only read signal for a channel the user is not watching, since
+      // `message.read` goes to watchers only. `message.read_locally` is the local stand-in when read
+      // events are disabled (livestreams). Both reuse the `message.read` logic, minus its delivery sync.
+      case 'notification.mark_read':
       case 'message.read_locally':
       case 'message.read':
-        if (event.user?.id && event.created_at) {
+        if (
+          event.user?.id &&
+          event.created_at &&
+          // the same event announces a thread read, which says nothing about the channel
+          !(event.type === 'notification.mark_read' && event.thread_id)
+        ) {
           const eventUser = event.user;
           const readAtDate = new Date(event.created_at);
           const toDate = (value?: string | Date) =>

--- a/src/client.ts
+++ b/src/client.ts
@@ -1129,12 +1129,13 @@ export class StreamChat extends ChatApi {
     }
 
     if (event.type === 'notification.mark_read' && event.unread_channels === 0) {
-      const activeChannelKeys = Object.keys(this.activeChannels);
-      activeChannelKeys.forEach((activeChannelKey) =>
+      Object.values(this.activeChannels).forEach((channel) => {
         // resets `read[userId].unread_messages`, which is what the unread badge reads, so it does
         // not stay stale.
-        this.activeChannels[activeChannelKey]._setOwnUnreadCount(0),
-      );
+        if (!channel._setOwnUnreadCount(0)) return;
+        // the event may name no channel (mark-all-read), but here we know which ones changed
+        this.channelManager.dropFromUnmatchedLists(channel);
+      });
     }
 
     if (

--- a/src/pagination/filterCompiler.ts
+++ b/src/pagination/filterCompiler.ts
@@ -194,3 +194,20 @@ function autoCompleteOp(value: any, query: any): boolean {
     return value.some((v) => typeof v === 'string' && matchOneString(v));
   return false;
 }
+
+const LOGICAL_FILTER_OPERATORS = ['$and', '$or', '$nor'] as const;
+
+/**
+ * Whether a filter constrains `field`, at the top level or inside a logical operator. Nothing else is
+ * recursed into: the same key elsewhere (`{ custom: { hidden: … } }`) is a different field.
+ */
+export const filterConstrainsField = (filters: unknown, field: string): boolean => {
+  if (!filters || typeof filters !== 'object') return false;
+  if (Array.isArray(filters))
+    return filters.some((entry) => filterConstrainsField(entry, field));
+  const node = filters as Record<string, unknown>;
+  if (field in node) return true;
+  return LOGICAL_FILTER_OPERATORS.some((operator) =>
+    filterConstrainsField(node[operator], field),
+  );
+};

--- a/src/pagination/paginators/BasePaginator.ts
+++ b/src/pagination/paginators/BasePaginator.ts
@@ -2226,6 +2226,8 @@ export abstract class BasePaginator<T, Q> {
 
     // 3. If it no longer matches the filter, we’re done (it has been removed above).
     if (!this.matchesFilter(ingestedItem)) {
+      // left the result set, not just this list
+      this.shrinkOffsetAfterRemoval(removedItemCoordinates);
       // Throttled: the removal above deferred its emit — publish the (settled) window once.
       // Suspended (coalescing batch): removeItemAtCoordinates recorded it; batch() emits once on exit.
       if (!this.isWindowPublishSuspended && this.isStateThrottled && itemHasBeenRemoved)
@@ -2482,6 +2484,22 @@ export abstract class BasePaginator<T, Q> {
   }
 
   /**
+   * Keeps `offset` addressing the same position in the *server's* result set after an item left the
+   * loaded window.
+   */
+  protected shrinkOffsetAfterRemoval(coordinates?: ItemCoordinates) {
+    // cursor pagination does not address items by position, so nothing can drift
+    if (this.isCursorPagination) return;
+    // not part of the loaded window, so no page ever counted it
+    if ((coordinates?.state?.currentIndex ?? -1) < 0) return;
+
+    const { offset } = this.state.getLatestValue();
+    if (typeof offset !== 'number') return;
+
+    this.state.partialNext({ offset: Math.max(0, offset - 1) });
+  }
+
+  /**
    * Meaning of location values
    * - currentIndex === -1 could not be found
    * - insertionIndex === -1 insertion index was no intended to be determined
@@ -2501,6 +2519,7 @@ export abstract class BasePaginator<T, Q> {
       if (!coords.state && !coords.interval) return noAction;
       const result = this.removeItemAtCoordinates(coords);
       this._itemIndex.remove(this.getItemId(item));
+      this.shrinkOffsetAfterRemoval(result);
       // Throttled: removeItemAtCoordinates deferred its emit — publish the (settled) window once.
       if (!this.isWindowPublishSuspended && this.isStateThrottled)
         this.scheduleWindowPublish();

--- a/src/pagination/paginators/ChannelPaginator.ts
+++ b/src/pagination/paginators/ChannelPaginator.ts
@@ -14,7 +14,7 @@ import { chatLoggerSystem } from '../../logger';
 import type { FilterBuilderOptions } from '../FilterBuilder';
 import { FilterBuilder } from '../FilterBuilder';
 import { makeComparator } from '../sortCompiler';
-import { itemMatchesFilter } from '../filterCompiler';
+import { filterConstrainsField, itemMatchesFilter } from '../filterCompiler';
 import { StoreBackedItemIndex } from '../../entityStore/StoreBackedItemIndex';
 import { generateUUIDv4 } from '../../utils';
 import type { StreamChat } from '../../client';
@@ -452,32 +452,12 @@ export class ChannelPaginator extends BasePaginator<Channel, ChannelQueryShape> 
   matchesFilter(channel: Channel): boolean {
     const filters = this.buildMatchFilters();
 
-    const LOGICAL_FILTER_OPERATORS = ['$and', '$or', '$nor'] as const;
-
-    /**
-     * Whether a filter constrains `hidden` anywhere — at the top level or nested inside a logical
-     * operator, both of which the filter compiler evaluates. A filter that mentions `hidden` at all opts
-     * out of the "exclude hidden channels" default (see `ChannelPaginator.matchesFilter`), so
-     * `{ $or: [{ hidden: true }, …] }` is not silently overruled by it.
-     *
-     * Recursion is limited to logical operators on purpose: a `hidden` key anywhere else (e.g. inside
-     * `{ custom: { hidden: … } }`) is a different field, not a constraint on the channel's hidden state.
-     */
-    const filterConstrainsHidden = (filters: unknown): boolean => {
-      if (!filters || typeof filters !== 'object') return false;
-      if (Array.isArray(filters)) return filters.some(filterConstrainsHidden);
-      const node = filters as Record<string, unknown>;
-      if ('hidden' in node) return true;
-      return LOGICAL_FILTER_OPERATORS.some((operator) =>
-        filterConstrainsHidden(node[operator]),
-      );
-    };
     // Mirror `queryChannels`, which excludes hidden channels unless the filter asks for them —
     // otherwise a channel hidden while the list is open keeps matching and stays visible until the next
     // query. Applied here rather than as a synthetic `hidden: false` filter entry so the default also
     // holds for a paginator whose filter resolvers were replaced (`setFilterResolvers`), which would
     // otherwise leave `hidden` unresolvable and reject every channel.
-    if (channel.data?.hidden && !filterConstrainsHidden(filters)) return false;
+    if (channel.data?.hidden && !filterConstrainsField(filters, 'hidden')) return false;
     return itemMatchesFilter<Channel>(channel, filters, {
       resolvers: this._filterFieldToDataResolvers,
     });

--- a/src/pagination/paginators/MessageIntervalPaginator.ts
+++ b/src/pagination/paginators/MessageIntervalPaginator.ts
@@ -1400,7 +1400,7 @@ export class MessageIntervalPaginator extends BasePaginator<
       enforceUnique,
       reaction,
       removed,
-      userId: this.channel.getClient().userID,
+      userId: this.channel.getClient().userId,
     });
     this.ingestItem({ ...formatted, own_reactions });
   };

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -803,7 +803,7 @@ export class Thread extends WithSubscriptions {
               enforceUnique: eventType === 'reaction.updated',
               reaction,
               removed: eventType === 'reaction.deleted',
-              userId: this.client.userID,
+              userId: this.client.userId,
             });
             this.updateParentMessageLocally({ message: { ...message, own_reactions } });
           }

--- a/src/types.utility.ts
+++ b/src/types.utility.ts
@@ -1,3 +1,17 @@
 export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };
+
+/**
+ * The keys of every union member, not only those common to all — which is what `keyof (A | B)` gives.
+ * Distribution needs a naked type parameter: the same conditional written inline over a concrete union
+ * silently yields the common keys instead.
+ */
+export type KeysOfUnion<T> = T extends unknown ? keyof T : never;
+
+/** The type `Key` has in each union member declaring it; members without it drop out as `never`. */
+export type ValueOfUnion<T, Key extends PropertyKey> = T extends unknown
+  ? Key extends keyof T
+    ? T[Key]
+    : never
+  : never;

--- a/test/unit/ChannelManager.test.ts
+++ b/test/unit/ChannelManager.test.ts
@@ -1184,7 +1184,7 @@ describe('ChannelManager', () => {
     it('a message.new in an archived channel does not add it to a list the backend filtered to { archived: false }', async () => {
       const archived = makeChannel('messaging:archived-1');
       archived.state.membership = {
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
         archived_at: '2025-09-03T12:19:39.101089Z',
       };
       client.activeChannels[archived.cid] = archived;
@@ -1903,6 +1903,241 @@ describe('ChannelManager', () => {
       expect(primary.items?.map((c) => c.cid)).toEqual(['messaging:201']);
       // A channel that matches only the catch-all lands in the fallback.
       expect(fallback.items?.map((c) => c.cid)).toEqual(['team:202']);
+    });
+  });
+  // A channel becoming read has to leave an unread list, and the offset has to follow it.
+  describe('read state events', () => {
+    const seedUnread = (channel: Channel, unreadMessages = 1) => {
+      channel.state.read = {
+        [client.userId as string]: {
+          last_read: new Date(0),
+          unread_messages: unreadMessages,
+          user: { id: client.userId as string },
+        },
+      };
+    };
+
+    const loadedUnreadList = (channel: Channel) => {
+      client.activeChannels[channel.cid] = channel;
+      const paginator = new ChannelPaginator({ client, filters: { has_unread: true } });
+      paginator.setItems({ valueOrFactory: [channel], isFirstPage: true });
+      const channelManager = new ChannelManager({ client, paginators: [paginator] });
+      channelManager.registerSubscriptions();
+      return { channelManager, paginator };
+    };
+
+    const markReadEvent = (channel: Channel, payload = {}) => ({
+      channel_id: channel.id,
+      channel_type: channel.type,
+      cid: channel.cid,
+      created_at: new Date(),
+      type: 'notification.mark_read' as const,
+      user: { id: client.userId as string },
+      ...payload,
+    });
+
+    it('drops a channel the user read elsewhere, and shrinks the offset with it', async () => {
+      const channel = makeChannel('messaging:300');
+      seedUnread(channel);
+      const { paginator } = loadedUnreadList(channel);
+
+      expect(paginator.items).toHaveLength(1);
+      expect(paginator.offset).toBe(1);
+
+      client.dispatchEvent(markReadEvent(channel));
+
+      await vi.waitFor(() => {
+        expect(paginator.items).toHaveLength(0);
+        expect(paginator.offset).toBe(0);
+      });
+    });
+
+    it('puts a channel back when it is marked unread again', async () => {
+      const channel = makeChannel('messaging:301');
+      seedUnread(channel, 0);
+      client.activeChannels[channel.cid] = channel;
+      const paginator = new ChannelPaginator({ client, filters: { has_unread: true } });
+      paginator.setItems({ valueOrFactory: [], isFirstPage: true });
+      new ChannelManager({ client, paginators: [paginator] }).registerSubscriptions();
+
+      seedUnread(channel, 1);
+      client.dispatchEvent(
+        markReadEvent(channel, { type: 'notification.mark_unread' as const }),
+      );
+
+      await vi.waitFor(() => {
+        expect(paginator.items?.map((c) => c.cid)).toEqual([channel.cid]);
+      });
+    });
+
+    it('ignores a read receipt from another member', async () => {
+      const channel = makeChannel('messaging:302');
+      seedUnread(channel);
+      const { paginator } = loadedUnreadList(channel);
+      const ingest = vi.spyOn(paginator, 'ingestItem');
+
+      client.dispatchEvent({
+        channel_id: channel.id,
+        channel_type: channel.type,
+        cid: channel.cid,
+        created_at: new Date(),
+        type: 'message.read',
+        user: { id: 'somebody-else' },
+      });
+
+      await vi.waitFor(() => {
+        expect(ingest).not.toHaveBeenCalled();
+        expect(paginator.items).toHaveLength(1);
+      });
+    });
+
+    it('ignores a thread being read', async () => {
+      const channel = makeChannel('messaging:303');
+      seedUnread(channel);
+      const { paginator } = loadedUnreadList(channel);
+
+      client.dispatchEvent(markReadEvent(channel, { thread_id: 'thread-1' }));
+
+      await vi.waitFor(() => {
+        expect(paginator.items).toHaveLength(1);
+        expect(paginator.offset).toBe(1);
+      });
+    });
+
+    it('does nothing when the event names no channel', async () => {
+      const channel = makeChannel('messaging:308');
+      seedUnread(channel);
+      const { paginator } = loadedUnreadList(channel);
+      const ingest = vi.spyOn(paginator, 'ingestItem');
+      const remove = vi.spyOn(paginator, 'removeItem');
+
+      // a mark-all-read; without a target there is nothing to route, so the list is left as it is and
+      // reconciles on the next event naming a channel, or the next query
+      seedUnread(channel, 0);
+      client.dispatchEvent({
+        created_at: new Date(),
+        type: 'notification.mark_read',
+        unread_channels: 0,
+        user: { id: client.userId as string },
+      });
+
+      await vi.waitFor(() => {
+        expect(ingest).not.toHaveBeenCalled();
+        expect(remove).not.toHaveBeenCalled();
+        expect(paginator.items).toHaveLength(1);
+      });
+    });
+
+    it('drops every channel the client marked read, not only the one the event names', async () => {
+      const named = makeChannel('messaging:310');
+      const other = makeChannel('messaging:311');
+      seedUnread(named);
+      seedUnread(other);
+      client.activeChannels[named.cid] = named;
+      client.activeChannels[other.cid] = other;
+
+      // the client reconciles the lists it owns, so this one is registered on `client.channelManager`
+      const paginator = new ChannelPaginator({ client, filters: { has_unread: true } });
+      paginator.setItems({ valueOrFactory: [named, other], isFirstPage: true });
+      client.channelManager.insertPaginator({ paginator });
+      client.channelManager.registerSubscriptions();
+
+      // `unread_channels: 0` makes the client zero every active channel, so both stop matching
+      client.dispatchEvent(markReadEvent(named, { unread_channels: 0 }));
+
+      await vi.waitFor(() => {
+        expect(paginator.items).toHaveLength(0);
+        expect(paginator.offset).toBe(0);
+      });
+    });
+
+    it('drops channels a mark-all-read leaves read, though it names none', async () => {
+      const channel = makeChannel('messaging:312');
+      seedUnread(channel);
+      client.activeChannels[channel.cid] = channel;
+
+      const paginator = new ChannelPaginator({ client, filters: { has_unread: true } });
+      paginator.setItems({ valueOrFactory: [channel], isFirstPage: true });
+      client.channelManager.insertPaginator({ paginator });
+      client.channelManager.registerSubscriptions();
+
+      client.dispatchEvent({
+        created_at: new Date(),
+        type: 'notification.mark_read',
+        unread_channels: 0,
+        user: { id: client.userId as string },
+      });
+
+      await vi.waitFor(() => {
+        expect(paginator.items).toHaveLength(0);
+        expect(paginator.offset).toBe(0);
+      });
+    });
+
+    it('skips lists that neither filter nor sort on read state', async () => {
+      const channel = makeChannel('messaging:313');
+      seedUnread(channel);
+      client.activeChannels[channel.cid] = channel;
+
+      const plainList = new ChannelPaginator({ client, filters: { type: 'messaging' } });
+      plainList.setItems({ valueOrFactory: [channel], isFirstPage: true });
+      new ChannelManager({ client, paginators: [plainList] }).registerSubscriptions();
+
+      const ingest = vi.spyOn(plainList, 'ingestItem');
+      const remove = vi.spyOn(plainList, 'removeItem');
+
+      client.dispatchEvent(markReadEvent(channel));
+
+      await vi.waitFor(() => {
+        // nothing here is derived from read state, so the read never reaches this list
+        expect(ingest).not.toHaveBeenCalled();
+        expect(remove).not.toHaveBeenCalled();
+        expect(plainList.items?.map((c) => c.cid)).toEqual([channel.cid]);
+      });
+    });
+
+    it('still routes to a list that only sorts on read state', async () => {
+      const channel = makeChannel('messaging:314');
+      seedUnread(channel);
+      client.activeChannels[channel.cid] = channel;
+
+      const sortedList = new ChannelPaginator({
+        client,
+        filters: { type: 'messaging' },
+        sort: [{ direction: -1, field: 'unread_count' }],
+      });
+      sortedList.setItems({ valueOrFactory: [channel], isFirstPage: true });
+      new ChannelManager({ client, paginators: [sortedList] }).registerSubscriptions();
+
+      const ingest = vi.spyOn(sortedList, 'ingestItem');
+
+      client.dispatchEvent(markReadEvent(channel));
+
+      // still matches, but its sort key changed, so it has to be re-placed
+      await vi.waitFor(() => {
+        expect(ingest).toHaveBeenCalledOnce();
+      });
+    });
+
+    it('does not fetch a channel this client never loaded', async () => {
+      const channel = makeChannel('messaging:305');
+      seedUnread(channel);
+      const { paginator } = loadedUnreadList(channel);
+      delete client.activeChannels['messaging:306'];
+
+      client.dispatchEvent({
+        channel_id: '306',
+        channel_type: 'messaging',
+        cid: 'messaging:306',
+        created_at: new Date(),
+        type: 'notification.mark_read',
+        user: { id: client.userId as string },
+      });
+
+      await vi.waitFor(() => {
+        expect(mockGetChannel).not.toHaveBeenCalled();
+        expect(paginator.items).toHaveLength(1);
+      });
     });
   });
 });

--- a/test/unit/CooldownTimer.test.ts
+++ b/test/unit/CooldownTimer.test.ts
@@ -166,7 +166,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: lastOwnMessageAt,
         updated_at: lastOwnMessageAt,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -203,7 +203,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: now,
         updated_at: now,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -218,7 +218,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: now,
         updated_at: now,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -233,7 +233,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: now,
         updated_at: now,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -266,7 +266,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: lastOwnMessageAt,
         updated_at: lastOwnMessageAt,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -293,7 +293,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: now,
         updated_at: now,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -317,7 +317,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: lastOwnMessageAt,
         updated_at: lastOwnMessageAt,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -352,7 +352,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: lastOwnMessageAt,
         updated_at: lastOwnMessageAt,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -387,7 +387,7 @@ describe('CooldownTimer', () => {
       generateMsg({
         created_at: lastOwnMessageAt,
         updated_at: lastOwnMessageAt,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     );
 
@@ -420,12 +420,12 @@ describe('CooldownTimer', () => {
 
     channel._handleChannelEvent({
       type: 'message.new',
-      user: { id: client.userID as string },
+      user: { id: client.userId as string },
       message: generateMsg({
         cid: channel.cid, // must match the paginator filter so message.new ingests into an interval
         created_at: now,
         updated_at: now,
-        user: { id: client.userID as string },
+        user: { id: client.userId as string },
       }),
     } as Event);
 

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -2219,8 +2219,10 @@ describe('AttachmentManager', () => {
       const ensureLocalUploadAttachment = (attachmentManager as any)
         .ensureLocalUploadAttachment;
 
-      // Set a fileUploadFilter that blocks all files
-      attachmentManager.fileUploadFilter = () => false;
+      // Block all files
+      attachmentManager.composer.updateConfig({
+        attachments: { fileUploadFilter: () => false },
+      });
 
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
       const result = await ensureLocalUploadAttachment({
@@ -2244,7 +2246,9 @@ describe('AttachmentManager', () => {
         'fileToLocalUploadAttachment',
       );
 
-      attachmentManager.fileUploadFilter = () => true;
+      attachmentManager.composer.updateConfig({
+        attachments: { fileUploadFilter: () => true },
+      });
 
       const file = new File([''], 'test.jpg', { type: 'image/jpeg' });
       await ensureLocalUploadAttachment({
@@ -2264,8 +2268,10 @@ describe('AttachmentManager', () => {
       const ensureLocalUploadAttachment = (attachmentManager as any)
         .ensureLocalUploadAttachment;
 
-      // Set a fileUploadFilter that allows all files
-      attachmentManager.fileUploadFilter = () => true;
+      // Allow all files
+      attachmentManager.composer.updateConfig({
+        attachments: { fileUploadFilter: () => true },
+      });
 
       const expectedAttachment = {
         type: 'image',
@@ -2298,8 +2304,10 @@ describe('AttachmentManager', () => {
       const ensureLocalUploadAttachment = (attachmentManager as any)
         .ensureLocalUploadAttachment;
 
-      // Set a fileUploadFilter that allows all files
-      attachmentManager.fileUploadFilter = () => true;
+      // Allow all files
+      attachmentManager.composer.updateConfig({
+        attachments: { fileUploadFilter: () => true },
+      });
 
       // Create an attachment with an ID
       const originalId = 'original-test-id';

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -2476,12 +2476,12 @@ describe('MessageComposer', () => {
     });
 
     describe('subscribeMessageComposerSetupStateChange', () => {
-      it('calls setupFunction with { composer } when client setMessageComposerSetupFunction is invoked', () => {
+      it('calls setupFunction with { composer } when the client registers one', () => {
         const { messageComposer, mockClient } = setup();
         const setupFn = vi.fn();
 
         messageComposer.registerSubscriptions();
-        mockClient.setMessageComposerSetupFunction(setupFn);
+        mockClient.config.setSetupFunction('messageComposer', setupFn);
 
         expect(setupFn).toHaveBeenCalledWith({ composer: messageComposer });
       });
@@ -2493,10 +2493,10 @@ describe('MessageComposer', () => {
         const setup2 = vi.fn();
 
         messageComposer.registerSubscriptions();
-        mockClient.setMessageComposerSetupFunction(setup1);
+        mockClient.config.setSetupFunction('messageComposer', setup1);
         expect(tearDown1).not.toHaveBeenCalled();
 
-        mockClient.setMessageComposerSetupFunction(setup2);
+        mockClient.config.setSetupFunction('messageComposer', setup2);
         expect(tearDown1).toHaveBeenCalledOnce();
         expect(setup2).toHaveBeenCalledWith({ composer: messageComposer });
       });

--- a/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
@@ -46,7 +46,7 @@ describe('stream-io/message-composer-middleware/attachments', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
       notifications: {
         addWarning: vi.fn(),
@@ -387,7 +387,7 @@ describe('stream-io/message-composer-middleware/draft-attachments', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 

--- a/test/unit/MessageComposer/middleware/messageComposer/commandInjection.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/commandInjection.test.ts
@@ -45,7 +45,7 @@ describe('stream-io/message-composer-middleware/command-injection', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 
@@ -215,7 +215,7 @@ describe('stream-io/message-composer-middleware/draft-command-injection', () => 
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 

--- a/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/compositionValidation.test.ts
@@ -664,7 +664,7 @@ describe('stream-io/message-composer-middleware/draft-data-validation', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 

--- a/test/unit/MessageComposer/middleware/messageComposer/messageComposerState.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/messageComposerState.test.ts
@@ -380,7 +380,7 @@ describe('stream-io/message-composer-middleware/draft-own-state', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 

--- a/test/unit/MessageComposer/middleware/messageComposer/textComposer.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/textComposer.test.ts
@@ -44,7 +44,7 @@ describe('stream-io/message-composer-middleware/text-composition', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 
@@ -460,7 +460,7 @@ describe('stream-io/message-composer-middleware/draft-text-composition', () => {
 
   beforeEach(() => {
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       user: { id: 'currentUser' },
     } as any;
 

--- a/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
+++ b/test/unit/MessageComposer/middleware/textComposer/MentionsSearchSource.test.ts
@@ -115,7 +115,7 @@ describe('MentionsSearchSource', () => {
     ];
 
     client = {
-      userID: 'currentUser',
+      userId: 'currentUser',
       userId: 'currentUser',
       searchRoles: vi.fn().mockImplementation(async ({ query }: { query: string }) => ({
         roles: [

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -1049,7 +1049,7 @@ describe('Channel _handleChannelEvent', function () {
 				unread_messages: 2,
 			};
 
-			const message = generateMsg({ user: { id: client.userID } });
+			const message = generateMsg({ user: { id: client.userId } });
 
 			const events = [
 				'message.read',
@@ -2045,6 +2045,52 @@ describe('Channel _handleChannelEvent', function () {
 			expect(new Date(changes[0].next.last_read).getTime()).toBe(
 				new Date(messageReadEvent.created_at).getTime(),
 			);
+		});
+	});
+
+	describe('notification.mark_read', () => {
+		let markReadEvent;
+
+		beforeEach(() => {
+			channel.state.read[user.id] = {
+				last_read: new Date(1500).toISOString(),
+				last_read_message_id: '6',
+				first_unread_message_id: 'first-unread-msg-id',
+				user,
+				unread_messages: 100,
+			};
+			markReadEvent = {
+				type: 'notification.mark_read',
+				created_at: new Date(2000).toISOString(),
+				cid: channel.cid,
+				channel_type: channel.type,
+				channel_id: channel.id,
+				user,
+				last_read_message_id: '6b1006ad-7a6d-49d1-82d9-5ee5e8167e49',
+				unread_channels: 3,
+			};
+		});
+
+		// the only read signal for a channel the user is not watching, which is most of a long list
+		it('should reset the unread count of a channel read elsewhere', () => {
+			channel._handleChannelEvent(markReadEvent);
+
+			expect(channel.state.read[user.id].unread_messages).toBe(0);
+			expect(channel.state.unreadCount).toBe(0);
+			expect(new Date(channel.state.read[user.id].last_read).getTime()).toBe(
+				new Date(markReadEvent.created_at).getTime(),
+			);
+			expect(channel.state.read[user.id].last_read_message_id).toBe(
+				markReadEvent.last_read_message_id,
+			);
+			expect(channel.state.read[user.id].first_unread_message_id).toBeUndefined();
+		});
+
+		it('should leave the channel read state untouched when a thread was read', () => {
+			channel._handleChannelEvent({ ...markReadEvent, thread_id: 'thread-1' });
+
+			expect(channel.state.read[user.id].unread_messages).toBe(100);
+			expect(new Date(channel.state.read[user.id].last_read).getTime()).toBe(1500);
 		});
 	});
 
@@ -3455,7 +3501,7 @@ describe('send reaction flow', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		channel = client.channel('messaging', 'test');
 
@@ -3578,7 +3624,7 @@ describe('delete reaction flow', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		channel = client.channel('messaging', 'test');
 		// trick the channel into being initialized
@@ -3700,7 +3746,7 @@ describe('message sending flow', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		channel = client.channel('messaging', 'test');
 

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -658,7 +658,7 @@ describe('message update', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		loggerSpy = vi.fn();
 		chatLoggerSystem.configureLoggers({
@@ -1111,7 +1111,7 @@ describe('StreamChat.queryReactions', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		dispatchSpy = vi.spyOn(client, 'dispatchEvent');
 		postStub = vi.spyOn(client, 'queryReactions').mockResolvedValueOnce(postResponse);
@@ -1234,7 +1234,7 @@ describe('message deletion', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		loggerSpy = vi.fn();
 		chatLoggerSystem.configureLoggers({
@@ -1671,7 +1671,7 @@ describe('dispatchEvent: offlineDb.executeQuerySafely', () => {
 	beforeEach(async () => {
 		client = await getClientWithUser({ id: 'user-abc' });
 		const offlineDb = new MockOfflineDB({ client });
-		await offlineDb.init(client.userID);
+		await offlineDb.init(client.userId);
 		client.setOfflineDBApi(offlineDb);
 
 		executeQuerySafelySpy = vi.spyOn(offlineDb, 'executeQuerySafely');

--- a/test/unit/connection.test.js
+++ b/test/unit/connection.test.js
@@ -127,7 +127,7 @@ describe('connection', function () {
 		client._user = user;
 		client.options.enableInsights = true;
 		client.userAgent = 'agent';
-		client.clientID = 'clientID';
+		client.clientId = 'clientID';
 		client.insightMetrics = new InsightMetrics();
 		client.dispatchEvent = () => null;
 		client.recoverState = () => null;

--- a/test/unit/draft.test.js
+++ b/test/unit/draft.test.js
@@ -20,7 +20,7 @@ describe('create draft flow', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		channel = client.channel('messaging', 'test');
 
@@ -96,7 +96,7 @@ describe('delete draft flow', () => {
 		const offlineDb = new MockOfflineDB({ client });
 
 		client.setOfflineDBApi(offlineDb);
-		await client.offlineDb.init(client.userID);
+		await client.offlineDb.init(client.userId);
 
 		channel = client.channel('messaging', 'test');
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -47,7 +47,7 @@ describe('OfflineSupportApi', () => {
       expect(client.offlineDb).toBeDefined();
       const { initialized, userId } = client.offlineDb!.state.getLatestValue() ?? {};
       expect(initialized).toBe(false);
-      expect(userId).toBe(client.userID);
+      expect(userId).toBe(client.userId);
     });
 
     it('should not set client.offlineDb if it has already been set', async () => {
@@ -67,7 +67,7 @@ describe('OfflineSupportApi', () => {
         .spyOn(client.offlineDb!, 'initializeDB')
         .mockResolvedValue(true);
       const initSyncManagerSpy = vi.spyOn(client.offlineDb?.syncManager!, 'init');
-      await client.offlineDb!.init(client.userID as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
 
       expect(initializeDBSpy).toHaveBeenCalledOnce();
       expect(initSyncManagerSpy).toHaveBeenCalledOnce();
@@ -75,7 +75,7 @@ describe('OfflineSupportApi', () => {
       const { initialized, userId } = client.offlineDb?.state.getLatestValue() ?? {};
 
       expect(initialized).toBe(true);
-      expect(userId).toBe(client.userID);
+      expect(userId).toBe(client.userId);
     });
 
     it('should handle offlineDb.initializeDB failing', async () => {
@@ -84,7 +84,7 @@ describe('OfflineSupportApi', () => {
         .spyOn(client.offlineDb!, 'initializeDB')
         .mockResolvedValue(false);
       const initSyncManagerSpy = vi.spyOn(client.offlineDb?.syncManager!, 'init');
-      await client.offlineDb!.init(client.userID as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
 
       expect(initializeDBSpy).toHaveBeenCalledOnce();
       expect(initSyncManagerSpy).not.toHaveBeenCalled();
@@ -92,7 +92,7 @@ describe('OfflineSupportApi', () => {
       const { initialized, userId } = client.offlineDb?.state.getLatestValue() ?? {};
 
       expect(initialized).toBe(false);
-      expect(userId).toBe(client.userID);
+      expect(userId).toBe(client.userId);
     });
 
     it('should gracefully handle the state on exceptions during initialization', async () => {
@@ -103,7 +103,7 @@ describe('OfflineSupportApi', () => {
       const initSyncManagerSpy = vi
         .spyOn(client.offlineDb?.syncManager!, 'init')
         .mockRejectedValue(new Error('Sync manager init failed.'));
-      await client.offlineDb!.init(client.userID as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
 
       expect(initializeDBSpy).toHaveBeenCalledOnce();
       expect(initSyncManagerSpy).toHaveBeenCalledOnce();
@@ -120,9 +120,9 @@ describe('OfflineSupportApi', () => {
         .spyOn(client.offlineDb!, 'initializeDB')
         .mockResolvedValue(true);
       const initSyncManagerSpy = vi.spyOn(client.offlineDb?.syncManager!, 'init');
-      await client.offlineDb!.init(client.userID as unknown as string);
-      await client.offlineDb!.init(client.userID as unknown as string);
-      await client.offlineDb!.init(client.userID as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
 
       expect(initializeDBSpy).toHaveBeenCalledOnce();
       expect(initSyncManagerSpy).toHaveBeenCalledOnce();
@@ -130,7 +130,7 @@ describe('OfflineSupportApi', () => {
       const { initialized, userId } = client.offlineDb?.state.getLatestValue() ?? {};
 
       expect(initialized).toBe(true);
-      expect(userId).toBe(client.userID);
+      expect(userId).toBe(client.userId);
     });
 
     it('should reinitialize if the userId changes', async () => {
@@ -139,7 +139,7 @@ describe('OfflineSupportApi', () => {
         .spyOn(client.offlineDb!, 'initializeDB')
         .mockResolvedValue(true);
       const initSyncManagerSpy = vi.spyOn(client.offlineDb?.syncManager!, 'init');
-      await client.offlineDb!.init(client.userID as unknown as string);
+      await client.offlineDb!.init(client.userId as unknown as string);
       await client.offlineDb!.init('user123');
 
       expect(initializeDBSpy).toHaveBeenCalledTimes(2);
@@ -292,7 +292,7 @@ describe('OfflineSupportApi', () => {
     beforeEach(async () => {
       offlineDb = new MockOfflineDB({ client });
       vi.spyOn(offlineDb!, 'initializeDB').mockResolvedValue(true);
-      await offlineDb.init(client.userID as unknown as string);
+      await offlineDb.init(client.userId as unknown as string);
     });
 
     afterEach(() => {

--- a/test/unit/pagination/UserGroupPaginator.test.ts
+++ b/test/unit/pagination/UserGroupPaginator.test.ts
@@ -24,8 +24,8 @@ describe('UserGroupPaginator', () => {
   it('starts as a forward-only paginator', () => {
     const paginator = new UserGroupPaginator(client);
 
-    expect(paginator.hasNext).toBe(true);
-    expect(paginator.hasPrev).toBe(false);
+    expect(paginator.hasMoreTail).toBe(true);
+    expect(paginator.hasMoreHead).toBe(false);
     expect(paginator.items).toBeUndefined();
     expect(paginator.cursor).toEqual({ tailward: undefined, headward: null });
   });
@@ -59,18 +59,18 @@ describe('UserGroupPaginator', () => {
 
     const paginator = new UserGroupPaginator(client, { pageSize: 2 });
 
-    await paginator.next();
+    await paginator.toTail();
 
     expect(querySpy).toHaveBeenNthCalledWith(1, { limit: 2 });
     expect(paginator.items).toEqual(firstPage);
-    expect(paginator.hasNext).toBe(true);
-    expect(paginator.hasPrev).toBe(false);
+    expect(paginator.hasMoreTail).toBe(true);
+    expect(paginator.hasMoreHead).toBe(false);
     expect(JSON.parse(paginator.cursor?.tailward ?? '{}')).toEqual({
       created_at_gt: firstPage[1].created_at.toISOString(),
       id_gt: firstPage[1].id,
     });
 
-    await paginator.next();
+    await paginator.toTail();
 
     expect(querySpy).toHaveBeenNthCalledWith(2, {
       limit: 2,
@@ -78,8 +78,8 @@ describe('UserGroupPaginator', () => {
       id_gt: firstPage[1].id,
     });
     expect(paginator.items).toEqual([...firstPage, ...secondPage]);
-    expect(paginator.hasNext).toBe(false);
-    expect(paginator.hasPrev).toBe(false);
+    expect(paginator.hasMoreTail).toBe(false);
+    expect(paginator.hasMoreHead).toBe(false);
     // forward-only: headward stays exhausted, tailward exhausted after the short page
     expect(paginator.cursor?.headward).toBeNull();
     expect(paginator.cursor?.tailward == null).toBe(true);
@@ -93,14 +93,14 @@ describe('UserGroupPaginator', () => {
 
     const paginator = new UserGroupPaginator(client, { pageSize: 1 });
 
-    await paginator.next();
+    await paginator.toTail();
 
     paginator.teamId = 'engineering';
 
     expect(paginator.items).toBeUndefined();
     expect(paginator.cursor).toEqual({ tailward: undefined, headward: null });
-    expect(paginator.hasNext).toBe(true);
-    expect(paginator.hasPrev).toBe(false);
+    expect(paginator.hasMoreTail).toBe(true);
+    expect(paginator.hasMoreHead).toBe(false);
   });
 
   it('ignores malformed stored cursors and retries from the first page options', async () => {
@@ -114,7 +114,7 @@ describe('UserGroupPaginator', () => {
       cursor: { tailward: '{not-json', headward: null },
     });
 
-    await paginator.next();
+    await paginator.toTail();
 
     expect(querySpy).toHaveBeenCalledWith({ limit: 1 });
   });
@@ -123,9 +123,9 @@ describe('UserGroupPaginator', () => {
     const querySpy = vi.spyOn(client, 'listUserGroups');
     const paginator = new UserGroupPaginator(client);
 
-    await paginator.prev();
+    await paginator.toHead();
 
     expect(querySpy).not.toHaveBeenCalled();
-    expect(paginator.hasPrev).toBe(false);
+    expect(paginator.hasMoreHead).toBe(false);
   });
 });

--- a/test/unit/pagination/paginators/BasePaginator.test.ts
+++ b/test/unit/pagination/paginators/BasePaginator.test.ts
@@ -3671,6 +3671,93 @@ describe('BasePaginator', () => {
       });
     });
 
+    /**
+     * `offset` addresses a position in the server's result set. An item that leaves the loaded window
+     * because it stopped matching the query is gone from that result set too, so the offset has to
+     * follow it down - otherwise the next page starts too far and skips whatever moved up.
+     */
+    describe('offset over a mutable result set', () => {
+      beforeEach(() => {
+        itemIndex.clear();
+      });
+
+      const loadedPaginator = () => {
+        const paginator = new Paginator({ itemIndex });
+        paginator.sortComparator = makeComparator<TestItem>({
+          sort: [{ field: 'age', direction: -1 }],
+        });
+        paginator.ingestPage({ page: [item3, item2, item1], setActive: true });
+        paginator.state.partialNext({ offset: 3 });
+        return paginator;
+      };
+
+      it('shrinks when a loaded item is removed', () => {
+        const paginator = loadedPaginator();
+
+        paginator.removeItem({ item: item2 });
+
+        expect(paginator.items).toHaveLength(2);
+        expect(paginator.offset).toBe(2);
+      });
+
+      it('is left alone when the removal finds nothing', () => {
+        const paginator = loadedPaginator();
+
+        paginator.removeItem({ id: 'missing' });
+
+        expect(paginator.offset).toBe(3);
+      });
+
+      it('shrinks when an ingested item no longer matches the filter', () => {
+        const paginator = loadedPaginator();
+        // @ts-expect-error accessing protected property
+        paginator.buildMatchFilters = () => ({ name: { $ne: 'renamed' } });
+
+        expect(paginator.ingestItem({ ...item2, name: 'renamed' })).toBe(true);
+
+        expect(paginator.items).toHaveLength(2);
+        expect(paginator.offset).toBe(2);
+      });
+
+      it('is left alone by the remove-and-reinsert of an item that still matches', () => {
+        const paginator = loadedPaginator();
+
+        expect(paginator.ingestItem({ ...item2, name: 'renamed' })).toBe(true);
+
+        expect(paginator.items).toHaveLength(3);
+        expect(paginator.offset).toBe(3);
+      });
+
+      it('does not grow when an item arrives through an event', () => {
+        const paginator = loadedPaginator();
+
+        paginator.ingestItem({ ...item1, id: 'id4', age: 101.5 });
+
+        // an offset that is too small only re-requests an item already held, one that is too large
+        // drops it for good - so insertions are deliberately not mirrored
+        expect(paginator.items).toHaveLength(4);
+        expect(paginator.offset).toBe(3);
+      });
+
+      it('does not go below zero', () => {
+        const paginator = loadedPaginator();
+        paginator.state.partialNext({ offset: 0 });
+
+        paginator.removeItem({ item: item2 });
+
+        expect(paginator.offset).toBe(0);
+      });
+
+      it('is left alone under cursor pagination', () => {
+        const paginator = loadedPaginator();
+        paginator.state.partialNext({ cursor: { tailward: 'next', headward: null } });
+
+        paginator.removeItem({ item: item2 });
+
+        expect(paginator.offset).toBe(3);
+      });
+    });
+
     describe('setItems', () => {
       it('overrides all the items in the state with provided value', () => {
         const paginator = new Paginator();

--- a/test/unit/pagination/paginators/ChannelPaginator.test.ts
+++ b/test/unit/pagination/paginators/ChannelPaginator.test.ts
@@ -841,7 +841,7 @@ describe('ChannelPaginator', () => {
     it('stores the new items in the offlineDB', async () => {
       client.setOfflineDBApi(new MockOfflineDB({ client }));
       (client.offlineDb!.initializeDB as unknown as MockInstance).mockReturnValue(true);
-      await client.offlineDb!.init(client.userID as string);
+      await client.offlineDb!.init(client.userId as string);
       (
         client.offlineDb?.upsertCidsForQuery as unknown as MockInstance
       ).mockImplementation(() => Promise.resolve(true));
@@ -936,7 +936,7 @@ describe('ChannelPaginator', () => {
       offlineDb = new MockOfflineDB({ client });
       client.setOfflineDBApi(offlineDb);
       (client.offlineDb!.initializeDB as unknown as MockInstance).mockReturnValue(true);
-      await client.offlineDb!.init(client.userID as string);
+      await client.offlineDb!.init(client.userId as string);
       client.offlineDb!.syncManager.syncStatus = syncStatus;
       upsertCidsForQuery = client.offlineDb!
         .upsertCidsForQuery as unknown as MockInstance;
@@ -971,7 +971,7 @@ describe('ChannelPaginator', () => {
       await paginator.toTail();
 
       expect(getChannelsForQuery).toHaveBeenCalledWith({
-        userId: client.userID,
+        userId: client.userId,
         options: expect.objectContaining({
           filter_conditions: { type: 'type' },
           sort: [{ field: 'last_message_at', direction: -1 }],
@@ -1646,6 +1646,74 @@ describe('ChannelPaginator', () => {
         'type:plainB',
         'type:plainA',
       ]);
+    });
+  });
+  // Every channel the user reads leaves `has_unread: true` server-side, so the result set shrinks under
+  // the query and the next page has to start that many positions earlier (Zendesk 82913).
+  describe('pagination over a result set that shrinks', () => {
+    const CHANNEL_COUNT = 30;
+    const PAGE_SIZE = 10;
+
+    const buildInbox = () =>
+      Array.from({ length: CHANNEL_COUNT }, (_, index) => {
+        const channel = new Channel(
+          client,
+          'messaging',
+          `channel-${String(index).padStart(2, '0')}`,
+          {},
+        );
+        setLastMessageAt(channel, new Date(CHANNEL_COUNT - index));
+        channel.state.read = {
+          [user.id]: { last_read: new Date(0), unread_messages: 1, user },
+        };
+        return channel;
+      });
+
+    const isUnread = (channel: Channel) =>
+      channel.state.read[user.id].unread_messages > 0;
+
+    it('returns every unread channel while the user reads each page', async () => {
+      const inbox = buildInbox();
+      const offsets: number[] = [];
+      const everReturned = new Set<string>();
+
+      const paginator = new ChannelPaginator({
+        client,
+        filters: { has_unread: true },
+        sort: [{ direction: -1, field: 'last_message_at' }],
+        paginatorOptions: {
+          pageSize: PAGE_SIZE,
+          // stands in for the backend: honours both `has_unread` and `offset`
+          doRequest: async (queryShape) => {
+            const offset = queryShape?.offset ?? 0;
+            const page = inbox
+              .filter(isUnread)
+              .slice(offset, offset + (queryShape?.limit ?? PAGE_SIZE));
+            offsets.push(offset);
+            page.forEach((channel) => everReturned.add(channel.cid));
+            return { items: page };
+          },
+        },
+      });
+
+      await paginator.toTail({ reset: 'yes' });
+
+      let previouslyReturned = -1;
+      while (paginator.hasMoreTail && everReturned.size !== previouslyReturned) {
+        previouslyReturned = everReturned.size;
+        // the user works through every loaded channel
+        (paginator.items ?? []).slice().forEach((channel) => {
+          channel.state.read[user.id].unread_messages = 0;
+          paginator.ingestItem(channel);
+        });
+        await paginator.toTail();
+      }
+
+      // the result set shrank by exactly the page that was read, so every page starts at its head
+      expect(offsets).toEqual([0, 0, 0, 0]);
+      expect(everReturned.size).toBe(CHANNEL_COUNT);
+      expect(paginator.items).toHaveLength(0);
+      expect(paginator.hasMoreTail).toBe(false);
     });
   });
 });

--- a/test/unit/pagination/paginators/MessagePaginator.test.ts
+++ b/test/unit/pagination/paginators/MessagePaginator.test.ts
@@ -1131,7 +1131,7 @@ describe('MessagePaginator', () => {
 
     beforeEach(() => {
       (channel as unknown as { getClient: () => unknown }).getClient = () => ({
-        userID: currentUserId,
+        userId: currentUserId,
         getReplies: channel.getReplies,
       });
     });

--- a/test/unit/pagination/paginators/PinnedMessagePaginator.test.ts
+++ b/test/unit/pagination/paginators/PinnedMessagePaginator.test.ts
@@ -29,7 +29,7 @@ const makeChannel = (getPinnedMessages = vi.fn()) =>
     cid: CID,
     getClient: () => ({
       notifications: { addError: vi.fn() },
-      userID: 'me',
+      userId: 'me',
     }),
     getPinnedMessages,
   }) as unknown as import('../../../../src/channel').Channel;

--- a/test/unit/poll.test.js
+++ b/test/unit/poll.test.js
@@ -618,7 +618,7 @@ describe('Poll', () => {
 				vote_count: originalState.vote_count - 1,
 				vote_counts_by_option,
 			},
-			poll_vote: { ...removedVote, user_id: client.userID },
+			poll_vote: { ...removedVote, user_id: client.userId },
 		});
 
 		expect(poll.data.ownVotesByOptionId).to.eql({
@@ -664,7 +664,7 @@ describe('Poll', () => {
 		poll.handleVoteRemoved({
 			type: 'poll.vote_removed',
 			poll: { ...pollResponse },
-			poll_vote: { ...removedAnswer, user_id: client.userID },
+			poll_vote: { ...removedAnswer, user_id: client.userId },
 		});
 
 		expect(poll.data.ownVotesByOptionId).to.eql(originalState.ownVotesByOptionId);

--- a/test/unit/reactions.optimistic.test.ts
+++ b/test/unit/reactions.optimistic.test.ts
@@ -19,8 +19,8 @@ const CURRENT_USER = { id: 'me' };
 const connect = () => {
   const client = new StreamChat('apiKey');
   client.user = CURRENT_USER;
-  // `userID` is now a read-only getter derived from `client.user`, so setting `client.user` above
-  // is sufficient; assigning `client.userID` directly throws.
+  // `userId` is now a read-only getter derived from `client.user`, so setting `client.user` above
+  // is sufficient; assigning `client.userId` directly throws.
   return client;
 };
 

--- a/test/unit/search/ChannelSearchSource.test.ts
+++ b/test/unit/search/ChannelSearchSource.test.ts
@@ -182,7 +182,7 @@ describe('ChannelSearchSource', () => {
     expect(result).toBe(channels);
   });
 
-  it('works without client.userID', async () => {
+  it('works without client.userId', async () => {
     searchSource.client.user = undefined;
     const spyBuildFilters = vi
       .spyOn(searchSource.filterBuilder, 'buildFilters')

--- a/test/unit/search/MessageSearchSource.test.ts
+++ b/test/unit/search/MessageSearchSource.test.ts
@@ -205,7 +205,7 @@ describe('MessageSearchSource', () => {
     });
   });
 
-  it('returns empty items when client.userID is missing', async () => {
+  it('returns empty items when client.userId is missing', async () => {
     searchSource['client'].user = undefined;
     // @ts-expect-error protected access
     const result = await searchSource.query('test');

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -682,7 +682,7 @@ describe('Threads 2.0', () => {
         });
       });
 
-      describe('markAsRead', () => {
+      describe('markRead', () => {
         let stubbedChannelMarkRead: sinon.SinonStub<
           Parameters<Channel['markRead']>,
           ReturnType<Channel['markRead']>
@@ -696,7 +696,7 @@ describe('Threads 2.0', () => {
           const thread = createTestThread();
           expect(thread.ownUnreadCount).to.equal(0);
 
-          await thread.markAsRead();
+          await thread.markRead();
 
           expect(stubbedChannelMarkRead.notCalled).to.be.true;
         });
@@ -713,6 +713,23 @@ describe('Threads 2.0', () => {
           });
 
           expect(thread.ownUnreadCount).to.equal(42);
+
+          await thread.markRead();
+
+          expect(stubbedChannelMarkRead.calledOnceWith({ thread_id: thread.id })).to.be
+            .true;
+        });
+
+        it('is still reachable through the deprecated markAsRead alias', async () => {
+          const thread = createTestThread({
+            read: [
+              {
+                last_read: new Date().toISOString(),
+                user: { id: TEST_USER_ID },
+                unread_messages: 42,
+              },
+            ],
+          });
 
           await thread.markAsRead();
 


### PR DESCRIPTION
## Description of the changes, What, Why and How?

A `ChannelList` with `filters: { has_unread: true }` skipped roughly half the inbox. A user reading channels and scrolling for more never saw the ones in between, and the list then reported itself exhausted. Reported by a customer (Zendesk 82913) against `stream-chat-react@13.13.4`; the same defect is in `ChannelPaginator`, so v10 did not resolve it.

### The bug

`offset` counted the items the client had *received*, not the items the server's result set still *contains*. Those are the same number only while the result set is stable. It isn't: reading a channel drops it out of `has_unread: true` server-side, so everything behind it moves one position closer and the next page starts too far.

```
100 unread channels, page size 10, the user reads every page before loading the next one

page 1  offset 0   -> unread channels 1-10
page 2  offset 10  -> unread channels 21-30   (11-20 never requested)
page 3  offset 20  -> unread channels 41-50   (31-40 never requested)
page 5  offset 40  -> empty, hasMoreTail becomes false
```

Not specific to `has_unread` — `archived`, `pinned`, `muted` and `hidden` drift the same way.

### Changes

**`BasePaginator.shrinkOffsetAfterRemoval`** — an item that leaves the loaded window because it stopped matching takes one offset position with it. Called from `removeItem()` and from the filter-mismatch branch of `ingestItem()`, not from the transient remove-and-reinsert `ingestItem` does for an item that still matches.

**`Channel._handleChannelEvent` handles `notification.mark_read`** — the only read signal for a channel the user is not watching, since `message.read` reaches watchers only. Without it `state.read` keeps counting the channel as unread. Events naming a `thread_id` are skipped: a thread read says nothing about the channel.

**`ChannelManager.readStateChangedHandler`** — new default handler for `message.read`, `message.read_locally`, `notification.mark_read` and `notification.mark_unread`. Routes the named channel through `ingestChannel`, and only when some registered list actually derives from read state (`has_unread` filter, or `has_unread` / `unread_count` sort). `message.read` fires on every channel the user opens, so a list that does not care about read state now costs one filter check and no list mutation.

**`ChannelManager.dropFromUnmatchedLists`** (new public method) — `_handleClientEvent` zeroes every active channel's unread count when an event reports no unread channels left, whether or not it names one. The client now tells the manager which channels it changed, since the event cannot. Removal-only: the backend rejects `has_unread: false` with a 400, so becoming read can never make a channel belong to a list.

**`PipelineEvent` is derived from the `Event` union** instead of being a hand-written field list, so a field added to a generated event is routable without widening it by hand. Adds internal `KeysOfUnion` / `ValueOfUnion` to `types.utility.ts`. One behaviour note: `user` widens from `UserResponse` to a union including `UserResponseCommonFields` and `UserResponsePrivacyFields`.

**Deprecated symbols removed from the test suite** — `client.userID` → `userId`, `hasNext` / `hasPrev` → `hasMoreTail` / `hasMoreHead`, `paginator.next()` / `prev()` → `toTail()` / `toHead()`, `thread.markAsRead()` → `markRead()`, and others. Tests that exist to cover a deprecated alias keep using it. This caught two places where the SDK called its own deprecated getter: `MessageIntervalPaginator.ts:1403` and `thread.ts:806`.

### Tests

16 new tests. The headline one is `ChannelPaginator.test.ts` → "pagination over a result set that shrinks": 30 unread channels, page size 10, every loaded page read before the next is requested. Asserts all 30 are returned and every page starts at offset 0. Without the fix it requests `[0, 10, 20]` and returns 20 of 30.

Each new test was checked to fail before the fix, not only to pass after it.

### Known gap

`dropFromUnmatchedLists` is called on `client.channelManager` only. A `ChannelManager` an application constructs itself still receives every event but not this call. Closing that means turning the untargeted event into per-channel local events — a new `LocalEvent` member, so a public API decision worth making separately.

## Changelog

- `ChannelList` / `ChannelPaginator` no longer skip channels when paginating a list whose filter is resolved from mutable state, such as an unread inbox (`has_unread: true`).
- `Channel` now applies `notification.mark_read`, so the unread state of a channel the user is not watching stops going stale.
- `ChannelManager` keeps lists filtered or sorted on read state in sync as channels are read and marked unread.
- New: `ChannelManager.dropFromUnmatchedLists(channel)`.
