### PR TITLE
feat: remaining optimistic updates

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,5 +1,6 @@
 import { ChannelState, ChannelWatchStatus } from './channel_state';
 import { CooldownTimer } from './CooldownTimer';
+import { queueOrRun } from './offline-support/queueableOperations';
 import { MessageComposer } from './messageComposer';
 import { MessageReceiptsTracker } from './messageDelivery';
 import type { ReadStoreReconcileMeta } from './messageDelivery';
@@ -42,7 +43,6 @@ import type {
   ChannelStateResponseFields,
   ChannelUpdateOptions,
   Command,
-  CreateDraftResponse,
   DeleteMessageOptions,
   Event,
   EventHandler,
@@ -85,7 +85,6 @@ import type { ChatApi } from './gen/chat/ChatApi';
 import { ChannelApi } from './gen/chat/ChannelApi';
 
 const logger = chatLoggerSystem.getLogger('channel');
-const offlineDbLogger = chatLoggerSystem.getLogger('offline-db');
 
 // todo: move to dedicated file
 export type SendMessageWithStateUpdateParams = {
@@ -678,26 +677,20 @@ export class Channel extends ChannelApi {
    */
   override async sendMessage(...args: Parameters<ChannelApi['sendMessage']>) {
     const [request] = args;
-    try {
-      const offlineDb = this.getClient().offlineDb;
-      const messageId = request.message?.id;
-      if (offlineDb && messageId) {
-        return await offlineDb.queueTask<Awaited<ReturnType<ChatApi['sendMessage']>>>({
-          task: {
-            channelId: this.id as string,
-            channelType: this.type,
-            messageId,
-            payload: args,
-            type: 'send-message',
-          },
-        });
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('sendMessage', this.cid)
-        .error('Sending the message failed.', { error });
-    }
-    return await this._sendMessage(...args);
+    const messageId = request.message?.id;
+
+    return await queueOrRun({
+      client: this.getClient(),
+      // Nothing to key a queue entry on without a message id, so it runs but is not queued.
+      queue: !!messageId,
+      task: {
+        channelId: this.id as string,
+        channelType: this.type,
+        messageId,
+        payload: args,
+        type: 'send-message',
+      },
+    });
   }
 
   /**
@@ -911,28 +904,18 @@ export class Channel extends ChannelApi {
   async sendReaction(...args: Parameters<ChatApi['sendReaction']>) {
     const [{ id: messageId }] = args;
 
-    try {
-      const offlineDb = this.getClient().offlineDb;
-      if (offlineDb) {
-        // The optimistic reaction row is written by the local-update layer
-        // (`applyReactionLocally`); here we only queue the request for replay.
-        return await offlineDb.queueTask<Awaited<ReturnType<ChatApi['sendReaction']>>>({
-          task: {
-            channelId: this.id as string,
-            channelType: this.type,
-            messageId,
-            payload: args,
-            type: 'send-reaction',
-          },
-        });
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('sendReaction', this.cid)
-        .error('Sending the reaction failed.', { error });
-    }
-
-    return this._sendReaction(...args);
+    // The optimistic reaction row is written by the local-update layer (`applyReactionLocally`); here
+    // we only queue the request for replay.
+    return await queueOrRun({
+      client: this.getClient(),
+      task: {
+        channelId: this.id as string,
+        channelType: this.type,
+        messageId,
+        payload: args,
+        type: 'send-reaction',
+      },
+    });
   }
 
   _sendReaction(...args: Parameters<ChatApi['sendReaction']>) {
@@ -943,28 +926,18 @@ export class Channel extends ChannelApi {
     this._checkInitialized();
     const [request] = args;
 
-    try {
-      const offlineDb = this.getClient().offlineDb;
-      if (offlineDb) {
-        // The optimistic reaction-row removal is handled by the local-update layer
-        // (`applyReactionLocally`); here we only queue the request for replay.
-        return await offlineDb.queueTask<Awaited<ReturnType<ChatApi['deleteReaction']>>>({
-          task: {
-            channelId: this.id as string,
-            channelType: this.type,
-            messageId: request.id,
-            payload: args,
-            type: 'delete-reaction',
-          },
-        });
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('deleteReaction', this.cid)
-        .error('Deleting the reaction failed.', { error });
-    }
-
-    return await this._deleteReaction(...args);
+    // The optimistic reaction-row removal is handled by the local-update layer
+    // (`applyReactionLocally`); here we only queue the request for replay.
+    return await queueOrRun({
+      client: this.getClient(),
+      task: {
+        channelId: this.id as string,
+        channelType: this.type,
+        messageId: request.id,
+        payload: args,
+        type: 'delete-reaction',
+      },
+    });
   }
 
   /**
@@ -2303,26 +2276,17 @@ export class Channel extends ChannelApi {
    */
   override async createDraft(...args: Parameters<ChannelApi['createDraft']>) {
     const [request] = args;
-    try {
-      const offlineDb = this.getClient().offlineDb;
-      if (offlineDb) {
-        return (await offlineDb.queueTask<CreateDraftResponse>({
-          task: {
-            channelId: this.id as string,
-            channelType: this.type,
-            threadId: request.message?.parent_id,
-            payload: args,
-            type: 'create-draft',
-          },
-        })) as Awaited<ReturnType<ChannelApi['createDraft']>>;
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('createDraft', this.cid)
-        .error('Creating the draft in the offline database failed.', { error });
-    }
 
-    return this._createDraft(...args);
+    return await queueOrRun({
+      client: this.getClient(),
+      task: {
+        channelId: this.id as string,
+        channelType: this.type,
+        threadId: request.message?.parent_id,
+        payload: args,
+        type: 'create-draft',
+      },
+    });
   }
 
   async _deleteDraft(...args: Parameters<ChannelApi['deleteDraft']>) {
@@ -2335,28 +2299,17 @@ export class Channel extends ChannelApi {
    */
   override async deleteDraft(...args: Parameters<ChannelApi['deleteDraft']>) {
     const [request] = args;
-    try {
-      const offlineDb = this.getClient().offlineDb;
-      if (offlineDb) {
-        return (await offlineDb.queueTask<Awaited<ReturnType<ChannelApi['deleteDraft']>>>(
-          {
-            task: {
-              channelId: this.id as string,
-              channelType: this.type,
-              threadId: request?.parent_id,
-              payload: args,
-              type: 'delete-draft',
-            },
-          },
-        )) as Awaited<ReturnType<ChannelApi['deleteDraft']>>;
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('deleteDraft', this.cid)
-        .error('Deleting the draft from the offline database failed.', { error });
-    }
 
-    return this._deleteDraft(...args);
+    return await queueOrRun({
+      client: this.getClient(),
+      task: {
+        channelId: this.id as string,
+        channelType: this.type,
+        threadId: request?.parent_id,
+        payload: args,
+        type: 'delete-draft',
+      },
+    });
   }
 
   /**

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -402,8 +402,18 @@ export class Channel extends ChannelApi {
       get: (id) =>
         this.messagePaginator.getItem(id) ?? this.getClient().messageStore.get(id),
       remove: (id) => {
+        const parentId =
+          this.messagePaginator.getItem(id)?.parent_id ??
+          this.getClient().messageStore.get(id)?.parent_id;
+
         this.messagePaginator.removeItem({ id });
         this.pinnedMessagesPaginator.removeItem({ id });
+
+        if (parentId) {
+          this.getClient().threads.threadsById[parentId]?.messagePaginator.removeItem({
+            id,
+          });
+        }
       },
       handlers: () => {
         const { requestHandlers } = this.configState.getLatestValue();

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -377,10 +377,7 @@ export class Channel extends ChannelApi {
     this.cooldownTimer.registerSubscriptions();
 
     this.messageOperations = new MessageOperations({
-      ...createMessageOperationsPersistence({
-        getCid: () => this.cid,
-        getClient: () => this.getClient(),
-      }),
+      ...createMessageOperationsPersistence({ channel: this }),
       ingest: (m) => {
         const store = this.getClient().messageStore;
         // The paginator is the entry point whenever it can hold the message — it owns interval
@@ -680,6 +677,7 @@ export class Channel extends ChannelApi {
     const messageId = request.message?.id;
 
     return await queueOrRun({
+      channel: this,
       client: this.getClient(),
       // Nothing to key a queue entry on without a message id, so it runs but is not queued.
       queue: !!messageId,
@@ -907,6 +905,7 @@ export class Channel extends ChannelApi {
     // The optimistic reaction row is written by the local-update layer (`applyReactionLocally`); here
     // we only queue the request for replay.
     return await queueOrRun({
+      channel: this,
       client: this.getClient(),
       task: {
         channelId: this.id as string,
@@ -929,6 +928,7 @@ export class Channel extends ChannelApi {
     // The optimistic reaction-row removal is handled by the local-update layer
     // (`applyReactionLocally`); here we only queue the request for replay.
     return await queueOrRun({
+      channel: this,
       client: this.getClient(),
       task: {
         channelId: this.id as string,
@@ -2278,6 +2278,7 @@ export class Channel extends ChannelApi {
     const [request] = args;
 
     return await queueOrRun({
+      channel: this,
       client: this.getClient(),
       task: {
         channelId: this.id as string,
@@ -2301,6 +2302,7 @@ export class Channel extends ChannelApi {
     const [request] = args;
 
     return await queueOrRun({
+      channel: this,
       client: this.getClient(),
       task: {
         channelId: this.id as string,

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -6,7 +6,10 @@ import { MessageComposer } from './messageComposer';
 import { MessageReceiptsTracker } from './messageDelivery';
 import type { ReadStoreReconcileMeta } from './messageDelivery';
 import { MessagePaginator, PinnedMessagePaginator } from './pagination/paginators';
-import { MessageOperations } from './messageOperations';
+import {
+  createMessageOperationsPersistence,
+  MessageOperations,
+} from './messageOperations';
 import {
   channelHasReadEvents,
   formatMessage,
@@ -375,11 +378,37 @@ export class Channel extends ChannelApi {
     this.cooldownTimer.registerSubscriptions();
 
     this.messageOperations = new MessageOperations({
+      ...createMessageOperationsPersistence({
+        getCid: () => this.cid,
+        getClient: () => this.getClient(),
+      }),
       ingest: (m) => {
-        this.messagePaginator.ingestItem(m);
-        this.getClient().messageStore.flushSubscribers(m.id);
+        const store = this.getClient().messageStore;
+        // The paginator is the entry point whenever it can hold the message — it owns interval
+        // placement, and its "no longer matches the filter" branch correctly evicts a message that
+        // stopped matching. But its filter is `{ cid, parent_id? }`, so an operation aimed at a message
+        // this paginator does not accept (most importantly a THREAD PARENT edited or deleted from
+        // inside the open thread, which the reply paginator rejects for having no `parent_id`) would
+        // otherwise be silently dropped. Falling back to the client-global store reaches the message
+        // wherever it is held and fans out to every collection holding it — the same reason
+        // `applyReactionLocally` addresses purely by id.
+        if (this.messagePaginator.matchesFilter(m)) {
+          this.messagePaginator.ingestItem(m);
+        } else if (store.has(m.id)) {
+          store.upsert(m);
+        }
+        store.flushSubscribers(m.id);
       },
-      get: (id) => this.messagePaginator.getItem(id),
+      // Mirrors `ingest`'s routing: a message this paginator does not hold can still be held by the
+      // client-global store (a thread parent, a message displayed by another collection), and the
+      // policy uses this both for its freshness comparison and to decide whether there is anything to
+      // update optimistically at all. Reading only the paginator would make those two disagree.
+      get: (id) =>
+        this.messagePaginator.getItem(id) ?? this.getClient().messageStore.get(id),
+      remove: (id) => {
+        this.messagePaginator.removeItem({ id });
+        this.pinnedMessagesPaginator.removeItem({ id });
+      },
       handlers: () => {
         const { requestHandlers } = this.configState.getLatestValue();
         const deleteMessageRequest = requestHandlers?.deleteMessageRequest;
@@ -1866,7 +1895,11 @@ export class Channel extends ChannelApi {
    *
    * Preserves failed (unsent) messages: an overlap merge keeps them (the reconcile's provenance guard
    * never prunes a non-server message); only a disjoint rebuild can drop them, so any that actually
-   * fell out are re-ingested below.
+   * fell out are re-ingested below. The offline DB is consulted alongside the in-memory window, because
+   * a failed message can be absent from memory and still be the user's unsent work — a cold boot starts
+   * with an empty paginator, and an eviction can drop it mid-session. v9 got this from a second, lagging
+   * copy of the list (the React SDK's own state); with one reactive source of truth the persisted row is
+   * that buffer.
    */
   async reload() {
     if (this._reloading || (!this.initialized && !this.offlineMode)) return;
@@ -1876,7 +1909,19 @@ export class Channel extends ChannelApi {
       const headItems = paginator.headItems;
       const requestedLimit =
         Math.max(headItems.length, paginator.pageSize ?? 0) || undefined;
-      const failedBefore = headItems.filter((message) => message.status === 'failed');
+      const offlineDb = this.getClient().offlineDb;
+      const failedInMemory = headItems.filter((message) => message.status === 'failed');
+      // Read before the await, so this cannot pick up a message that failed DURING the reload — that
+      // one is already in the paginator and does not need re-ingesting.
+      const failedInDb = offlineDb
+        ? await offlineDb.getFailedMessages({ cid: this.cid })
+        : [];
+      const failedById = new Map<string, LocalMessage>();
+      for (const message of [...failedInDb, ...failedInMemory]) {
+        // In-memory wins on a collision: it is at least as fresh as the row it was mirrored from.
+        failedById.set(message.id, message);
+      }
+      const failedBefore = [...failedById.values()];
 
       await this.watch({ messages: { limit: requestedLimit } });
       this.offlineMode = false;

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,13 +1,13 @@
 import { ChannelState, ChannelWatchStatus } from './channel_state';
 import { CooldownTimer } from './CooldownTimer';
-import { isEphemeral } from './errors';
-import { applyReactionLocally } from './entityStore';
 import { MessageComposer } from './messageComposer';
 import { MessageReceiptsTracker } from './messageDelivery';
 import type { ReadStoreReconcileMeta } from './messageDelivery';
 import { MessagePaginator, PinnedMessagePaginator } from './pagination/paginators';
 import {
+  addReactionOptimistically,
   createMessageOperationsPersistence,
+  deleteReactionOptimistically,
   MessageOperations,
 } from './messageOperations';
 import {
@@ -759,10 +759,7 @@ export class Channel extends ChannelApi {
   }
 
   /**
-   * Adds a reaction with an optimistic local state update: the reaction is applied to the cached
-   * message immediately ({@link applyReactionLocally}), then the request is
-   * fired via {@link Channel.sendReaction} (which owns the offline-DB write + queue). The
-   * server-authoritative counts reconcile on the response; the message is rolled back on failure.
+   * Adds a reaction with an optimistic local state update - see {@link addReactionOptimistically}.
    */
   async addReactionWithLocalUpdate({
     messageId,
@@ -773,31 +770,12 @@ export class Channel extends ChannelApi {
     reaction: ReactionRequest;
     options?: Pick<SendReactionRequest, 'enforce_unique' | 'skip_push'>;
   }) {
-    const client = this.getClient();
-    const undo = applyReactionLocally(client, {
-      enforceUnique: options?.enforce_unique ?? false,
-      messageId,
-      reaction,
-    });
-
-    try {
-      const response = await this.sendReaction({ id: messageId, reaction, ...options });
-      // reconcile the server copy only if we still hold it — a bare upsert of an unheld id would
-      // orphan it (the store's refcount GC only reclaims held ids).
-      if (response?.message && client.messageStore.has(response.message.id)) {
-        client.messageStore.upsert(formatMessage(response.message));
-      }
-    } catch (error) {
-      if (undo && (!client.offlineDb || !isEphemeral(error as Error))) {
-        undo();
-      }
-      throw error;
-    }
+    await addReactionOptimistically({ channel: this, messageId, options, reaction });
   }
 
   /**
-   * Removes the current user's reaction with an optimistic local state update, mirroring
-   * {@link Channel.addReactionWithLocalUpdate}.
+   * Removes the current user's reaction with an optimistic local state update - see
+   * {@link deleteReactionOptimistically}.
    */
   async deleteReactionWithLocalUpdate({
     messageId,
@@ -806,26 +784,7 @@ export class Channel extends ChannelApi {
     messageId: string;
     type: string;
   }) {
-    const client = this.getClient();
-    const undo = applyReactionLocally(client, {
-      messageId,
-      reaction: { type },
-      removed: true,
-    });
-
-    try {
-      const response = await this.deleteReaction({ id: messageId, type });
-      // reconcile the server copy only if we still hold it — a bare upsert of an unheld id would
-      // orphan it (the store's refcount GC only reclaims held ids).
-      if (response?.message && client.messageStore.has(response.message.id)) {
-        client.messageStore.upsert(formatMessage(response.message));
-      }
-    } catch (error) {
-      if (undo && (!client.offlineDb || !isEphemeral(error as Error))) {
-        undo();
-      }
-      throw error;
-    }
+    await deleteReactionOptimistically({ channel: this, messageId, type });
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -2037,14 +2037,6 @@ export class StreamChat extends ChatApi {
     const [request] = args;
     try {
       if (this.offlineDb) {
-        if (request.hard) {
-          await this.offlineDb.hardDeleteMessage({ id: request.id });
-        } else {
-          await this.offlineDb.softDeleteMessage({
-            id: request.id,
-            deleteForMe: request.delete_for_me,
-          });
-        }
         return await this.offlineDb.queueTask<
           Awaited<ReturnType<ChatApi['deleteMessage']>>
         >({

--- a/src/client.ts
+++ b/src/client.ts
@@ -57,6 +57,7 @@ import type {
 } from './types';
 import { InsightMetrics, postInsights } from './insights';
 import { chatLoggerSystem } from './logger';
+import { queueOrRun } from './offline-support/queueableOperations';
 import { Thread } from './thread';
 import { Moderation } from './moderation';
 import { ThreadManager } from './thread_manager';
@@ -2003,26 +2004,16 @@ export class StreamChat extends ChatApi {
     ]
   ) {
     const [request] = args;
-    try {
-      if (this.offlineDb) {
-        return await this.offlineDb.queueTask<
-          Awaited<ReturnType<ChatApi['updateMessage']>>
-        >({
-          task: {
-            ...getPendingTaskChannelData(request.message?.cid),
-            messageId: request.id,
-            payload: args,
-            type: 'update-message',
-          },
-        });
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('updateMessage')
-        .error('Updating the message failed.', { error });
-    }
 
-    return await this._updateMessage(...args);
+    return await queueOrRun({
+      client: this,
+      task: {
+        ...getPendingTaskChannelData(request.message?.cid),
+        messageId: request.id,
+        payload: args,
+        type: 'update-message',
+      },
+    });
   }
 
   async _updateMessage(...args: Parameters<ChatApi['updateMessage']>) {
@@ -2035,25 +2026,15 @@ export class StreamChat extends ChatApi {
    */
   override async deleteMessage(...args: Parameters<ChatApi['deleteMessage']>) {
     const [request] = args;
-    try {
-      if (this.offlineDb) {
-        return await this.offlineDb.queueTask<
-          Awaited<ReturnType<ChatApi['deleteMessage']>>
-        >({
-          task: {
-            messageId: request.id,
-            payload: args,
-            type: 'delete-message',
-          },
-        });
-      }
-    } catch (error) {
-      offlineDbLogger
-        .withExtraTags('deleteMessage')
-        .error('Deleting the message failed.', { error });
-    }
 
-    return this._deleteMessage(...args);
+    return await queueOrRun({
+      client: this,
+      task: {
+        messageId: request.id,
+        payload: args,
+        type: 'delete-message',
+      },
+    });
   }
 
   async _deleteMessage(...args: Parameters<ChatApi['deleteMessage']>) {

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -1,9 +1,35 @@
-import type { LocalMessage, MessageResponse, StreamAPIError } from '../types';
+import type {
+  DeleteMessageOptions,
+  LocalMessage,
+  MessageResponse,
+  StreamAPIError,
+} from '../types';
 import { formatMessage } from '../utils';
+import type { MessageOperationSpec, OperationKind, OperationParams } from './types';
 
 export type MessageOperationStatePolicyContext = {
   ingest: (m: LocalMessage) => void;
   get: (id: string) => LocalMessage | undefined;
+  remove: (id: string) => void;
+  persist: (m: LocalMessage) => void;
+  purge: (id: string) => void;
+  isQueued: (error: unknown) => boolean;
+};
+
+/**
+ * What {@link MessageOperationStatePolicy.optimistic} wrote, handed back to
+ * {@link MessageOperationStatePolicy.failure} so it can decide whether to revert and to what.
+ */
+export type OptimisticOutcome = {
+  /**
+   * The exact object the optimistic step wrote. Used as a concurrency guard rather than a value:
+   * `EntityStore.upsert` REPLACES the canonical copy, so `get(id) === applied` is a sound "nothing
+   * else has written since" check, and anything else means a fresher truth (a WS event, another
+   * operation) landed and must not be clobbered by a revert.
+   */
+  applied?: LocalMessage;
+  /** The copy that was there beforehand, i.e. what a revert restores. */
+  previous?: LocalMessage;
 };
 
 const parseError = (error: unknown): StreamAPIError => {
@@ -14,6 +40,27 @@ const parseError = (error: unknown): StreamAPIError => {
 const isAlreadyExistsError = (error: unknown, parsed: StreamAPIError) =>
   parsed.code === 4 && error instanceof Error && error.message.includes('already exists');
 
+const isHardDelete = (options: unknown) =>
+  !!(options as DeleteMessageOptions | undefined)?.hard;
+
+/**
+ * The local-state half of every message operation: what to show before the request resolves, what to
+ * do with the server's answer, and what to do when it fails.
+ *
+ * Per-operation rather than uniform, because the three kinds want genuinely different things:
+ *
+ * - **send / retry** — optimistically `sending`, `failed` on failure, and a pessimistic write-ahead to
+ *   the offline DB so a process death between compose and server-ack leaves a message that hydrates as
+ *   failed-and-retryable instead of vanishing.
+ * - **update** — optimistically applied and persisted, and **never reverted**: rolling back would
+ *   destroy text the user typed. A definitive rejection surfaces as a failed/error state on the message
+ *   while keeping the edit; a queued (offline) failure surfaces as nothing at all, because the edit is
+ *   pending, not failed.
+ * - **delete** — optimistically marked `deleted` (or removed outright, for a hard delete), and
+ *   **reverted** on a definitive rejection: unlike an edit there is no user input to lose, and leaving a
+ *   "Message deleted" placeholder on a message that still exists server-side is a lie that only
+ *   self-corrects on the next query.
+ */
 export class MessageOperationStatePolicy {
   private ctx: MessageOperationStatePolicyContext;
 
@@ -21,25 +68,103 @@ export class MessageOperationStatePolicy {
     this.ctx = ctx;
   }
 
-  optimistic(localMessage: LocalMessage) {
-    this.ctx.ingest({
+  optimistic<K extends OperationKind>(
+    kind: K,
+    params: OperationParams<K>,
+  ): OptimisticOutcome {
+    const { localMessage } = params;
+    const previous = this.ctx.get(localMessage.id);
+
+    if (kind === 'delete') {
+      if (isHardDelete(params.options)) {
+        this.ctx.remove(localMessage.id);
+        // No `purge` here: `client.deleteMessage` already hard-deletes the row before it queues the
+        // request, so the offline DB is correct even when we never reach the server.
+        return { previous };
+      }
+
+      // Nothing holds this message, so there is nothing to optimistically hide — and ingesting would
+      // insert a phantom "Message deleted" row for something that was never on screen. The server
+      // response still reconciles normally below.
+      if (!previous) return {};
+
+      const applied: LocalMessage = {
+        ...localMessage,
+        deleted_at: new Date(),
+        type: 'deleted',
+        ...((params.options as DeleteMessageOptions | undefined)?.delete_for_me
+          ? { deleted_for_me: true }
+          : {}),
+      };
+      this.ctx.ingest(applied);
+      return { applied, previous };
+    }
+
+    if (kind === 'update') {
+      // Preserve the status: an edit must not turn a received message into `sending`, and an edit of a
+      // message that never left the device has to stay `failed`.
+      const isFailed = localMessage.status === 'failed';
+      const editedAt = new Date();
+      const applied: LocalMessage = {
+        ...localMessage,
+        error: isFailed ? localMessage.error : undefined,
+        updated_at: editedAt,
+        // `message_text_updated_at` is what drives the "edited" indicator, so it has to appear
+        // immediately — but only for a message the server has actually seen. A failed message never
+        // received a server-confirmed text update and must not appear to have had one.
+        ...(isFailed ? {} : { message_text_updated_at: editedAt }),
+      };
+      this.ctx.ingest(applied);
+      this.ctx.persist(applied);
+      return { applied, previous };
+    }
+
+    const applied: LocalMessage = {
       ...localMessage,
       error: undefined,
       status:
         !localMessage.status || localMessage.status === 'failed'
           ? 'sending'
           : localMessage.status,
-    });
+    };
+    this.ctx.ingest(applied);
+    // Write-ahead, pessimistically FAILED. If the app dies between here and the server's ack the
+    // message comes back as failed and retryable rather than disappearing; a success overwrites it
+    // below. The retry payload does not need persisting alongside it — `MessageOperations.retry`
+    // reconstructs it from the message when `failedSendCache` is cold.
+    this.ctx.persist({ ...applied, status: 'failed' });
+    return { applied, previous };
   }
 
-  success({
+  success<K extends OperationKind>({
+    kind,
     messageFromResponse,
     messageId,
+    options,
   }: {
-    messageFromResponse: MessageResponse;
+    kind: K;
+    messageFromResponse: MessageResponse | undefined;
     messageId: string;
+    options?: MessageOperationSpec[K]['options'];
   }) {
+    // Guard before anything else. `formatMessage(undefined)` does not throw — it yields
+    // `{ status: 'received', created_at: <now>, updated_at: <now> }`, an id-less message whose
+    // `updated_at` beats the freshness check below, so without this an empty response ingested junk.
+    if (!messageFromResponse) return;
+
     const formatted = formatMessage({ ...messageFromResponse, status: 'received' });
+
+    if (kind === 'delete') {
+      if (isHardDelete(options)) {
+        this.ctx.remove(messageId);
+        this.ctx.purge(messageId);
+        return;
+      }
+      this.ctx.ingest(formatted);
+      this.ctx.persist(formatted);
+      return;
+    }
+
     const existing = this.ctx.get(messageId);
 
     const serverNewer =
@@ -48,30 +173,110 @@ export class MessageOperationStatePolicy {
       !existing || formatted.updated_at.getTime() >= existing.updated_at.getTime();
     const existingIsOurOptimisticSend = existing?.status === 'sending';
 
-    if (serverNewer || (existingIsOurOptimisticSend && serverSameOrNewer)) {
+    const applyServerCopy =
+      serverNewer || (existingIsOurOptimisticSend && serverSameOrNewer);
+
+    if (applyServerCopy) {
       this.ctx.ingest(formatted);
     }
+
+    if (kind === 'update') {
+      // Persist only what we actually applied, so the row can never disagree with memory.
+      if (applyServerCopy) this.ctx.persist(formatted);
+      return;
+    }
+
+    // Unconditional for send/retry: the optimistic step wrote a pessimistic `failed` row, so skipping
+    // this would leave a delivered message hydrating as failed after a restart.
+    this.ctx.persist(formatted);
   }
 
-  failure({
+  failure<K extends OperationKind>({
     error,
+    kind,
     localMessage,
     messageId,
+    optimistic,
+    options,
   }: {
     error: unknown;
+    kind: K;
     localMessage: LocalMessage;
     messageId: string;
+    optimistic?: OptimisticOutcome;
+    options?: MessageOperationSpec[K]['options'];
   }) {
     const parsed = parseError(error);
 
     if (isAlreadyExistsError(error, parsed)) {
       const existing = this.ctx.get(messageId);
       if (existing?.status === 'sending') {
-        this.ctx.ingest({ ...localMessage, status: 'received' });
+        const received: LocalMessage = { ...localMessage, status: 'received' };
+        this.ctx.ingest(received);
+        this.ctx.persist(received);
       }
       return;
     }
 
-    this.ctx.ingest({ ...localMessage, status: 'failed', error: parsed });
+    // Queued for replay: pending, not failed. Leave the optimistic state exactly as it stands.
+    //
+    // Deliberately scoped to update/delete. A send that never reached the server has to settle as
+    // `failed` even when its task is queued, because the retry affordance is the only way the user can
+    // get that message out — this is the v9 behaviour, and treating a queued send as merely "pending"
+    // would leave it spinning forever.
+    const queued = kind !== 'send' && kind !== 'retry' && this.ctx.isQueued(error);
+
+    if (kind === 'delete') {
+      if (!queued) this.revertDelete({ messageId, optimistic, options });
+      return;
+    }
+
+    if (kind === 'update') {
+      if (queued) return;
+      // The edit itself is kept — only the failure is recorded on top of it. NOTE: this lights up the
+      // retry affordance, which re-SENDS rather than re-edits; that predates this change and is
+      // deliberately left alone.
+      const failed: LocalMessage = {
+        ...(this.ctx.get(messageId) ?? localMessage),
+        error: parsed,
+        status: 'failed',
+      };
+      this.ctx.ingest(failed);
+      this.ctx.persist(failed);
+      return;
+    }
+
+    const failed: LocalMessage = { ...localMessage, error: parsed, status: 'failed' };
+    this.ctx.ingest(failed);
+    this.ctx.persist(failed);
+  }
+
+  private revertDelete<K extends OperationKind>({
+    messageId,
+    optimistic,
+    options,
+  }: {
+    messageId: string;
+    optimistic?: OptimisticOutcome;
+    options?: MessageOperationSpec[K]['options'];
+  }) {
+    const previous = optimistic?.previous;
+    // Nothing was held locally, so the optimistic step changed nothing to put back.
+    if (!previous) return;
+
+    if (isHardDelete(options)) {
+      // A hard delete took the message out of local state, so there is no current copy to compare
+      // against — the snapshot is unambiguously what belongs there.
+      this.ctx.ingest(previous);
+      this.ctx.persist(previous);
+      return;
+    }
+
+    if (optimistic?.applied && this.ctx.get(messageId) !== optimistic.applied) return;
+
+    this.ctx.ingest(previous);
+    // Undoes the row `client.deleteMessage` soft-deleted before queueing: the upsert rewrites `type`
+    // and `deletedAt` from the restored message.
+    this.ctx.persist(previous);
   }
 }

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -13,7 +13,7 @@ export type MessageOperationStatePolicyContext = {
   remove: (id: string) => void;
   persist: (m: LocalMessage) => void;
   purge: (id: string) => void;
-  isQueued: (error: unknown) => boolean;
+  isQueued: (messageId: string) => Promise<boolean>;
 };
 
 /**
@@ -191,7 +191,7 @@ export class MessageOperationStatePolicy {
     this.ctx.persist(formatted);
   }
 
-  failure<K extends OperationKind>({
+  async failure<K extends OperationKind>({
     error,
     kind,
     localMessage,
@@ -224,7 +224,8 @@ export class MessageOperationStatePolicy {
     // `failed` even when its task is queued, because the retry affordance is the only way the user can
     // get that message out — this is the v9 behaviour, and treating a queued send as merely "pending"
     // would leave it spinning forever.
-    const queued = kind !== 'send' && kind !== 'retry' && this.ctx.isQueued(error);
+    const queued =
+      kind !== 'send' && kind !== 'retry' && (await this.ctx.isQueued(messageId));
 
     if (kind === 'delete') {
       if (!queued) this.revertDelete({ messageId, optimistic, options });

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -142,11 +142,13 @@ export class MessageOperationStatePolicy {
     kind,
     messageFromResponse,
     messageId,
+    optimistic,
     options,
   }: {
     kind: K;
     messageFromResponse: MessageResponse | undefined;
     messageId: string;
+    optimistic?: OptimisticOutcome;
     options?: MessageOperationSpec[K]['options'];
   }) {
     // Guard before anything else. `formatMessage(undefined)` does not throw — it yields
@@ -169,6 +171,11 @@ export class MessageOperationStatePolicy {
 
     const existing = this.ctx.get(messageId);
 
+    const nothingWroteSinceOptimisticEdit =
+      kind === 'update' && !!optimistic?.applied && existing === optimistic.applied;
+
+    // Only reached when something else did write and then both copies are server-derived, so
+    // comparing their timestamps is comparing one clock against itself.
     const serverNewer =
       !existing || formatted.updated_at.getTime() > existing.updated_at.getTime();
     const serverSameOrNewer =
@@ -176,7 +183,9 @@ export class MessageOperationStatePolicy {
     const existingIsOurOptimisticSend = existing?.status === 'sending';
 
     const applyServerCopy =
-      serverNewer || (existingIsOurOptimisticSend && serverSameOrNewer);
+      nothingWroteSinceOptimisticEdit ||
+      serverNewer ||
+      (existingIsOurOptimisticSend && serverSameOrNewer);
 
     if (applyServerCopy) {
       this.ctx.ingest(formatted);

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -76,27 +76,29 @@ export class MessageOperationStatePolicy {
     const previous = this.ctx.get(localMessage.id);
 
     if (kind === 'delete') {
+      const deleteForMe = (params.options as DeleteMessageOptions | undefined)
+        ?.delete_for_me;
+
       if (isHardDelete(params.options)) {
         this.ctx.remove(localMessage.id);
-        // No `purge` here: `client.deleteMessage` already hard-deletes the row before it queues the
-        // request, so the offline DB is correct even when we never reach the server.
+        this.ctx.purge(localMessage.id);
         return { previous };
       }
 
       // Nothing holds this message, so there is nothing to optimistically hide — and ingesting would
-      // insert a phantom "Message deleted" row for something that was never on screen. The server
-      // response still reconciles normally below.
+      // insert a phantom "Message deleted" row for something that was never on screen. Nothing is
+      // written to the offline DB either: it mirrors local state, so it must not be told about state
+      // that does not exist. The server response still reconciles normally below.
       if (!previous) return {};
 
       const applied: LocalMessage = {
         ...localMessage,
         deleted_at: new Date(),
         type: 'deleted',
-        ...((params.options as DeleteMessageOptions | undefined)?.delete_for_me
-          ? { deleted_for_me: true }
-          : {}),
+        ...(deleteForMe ? { deleted_for_me: true } : {}),
       };
       this.ctx.ingest(applied);
+      this.ctx.persist(applied);
       return { applied, previous };
     }
 
@@ -276,8 +278,8 @@ export class MessageOperationStatePolicy {
     if (optimistic?.applied && this.ctx.get(messageId) !== optimistic.applied) return;
 
     this.ctx.ingest(previous);
-    // Undoes the row `client.deleteMessage` soft-deleted before queueing: the upsert rewrites `type`
-    // and `deletedAt` from the restored message.
+    // Undoes the row the optimistic step soft-deleted: the upsert rewrites `type` and `deletedAt` from
+    // the restored message.
     this.ctx.persist(previous);
   }
 }

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -165,6 +165,11 @@ export class MessageOperationStatePolicy {
         this.ctx.purge(messageId);
         return;
       }
+      // Mirrors the `!previous` guard in `optimistic`: a message local state does not hold must not be
+      // re-inserted as a "Message deleted" row it never displayed. Read live rather than from the
+      // optimistic snapshot, so a copy that arrived while the request was open is still marked.
+      if (!this.ctx.get(messageId)) return;
+
       this.ctx.ingest(formatted);
       this.ctx.persist(formatted);
       return;
@@ -189,18 +194,12 @@ export class MessageOperationStatePolicy {
       serverNewer ||
       (existingIsOurOptimisticSend && serverSameOrNewer);
 
-    if (applyServerCopy) {
-      this.ctx.ingest(formatted);
-    }
+    if (!applyServerCopy) return;
 
-    if (kind === 'update') {
-      // Persist only what we actually applied, so the row can never disagree with memory.
-      if (applyServerCopy) this.ctx.persist(formatted);
-      return;
-    }
-
-    // Unconditional for send/retry: the optimistic step wrote a pessimistic `failed` row, so skipping
-    // this would leave a delivered message hydrating as failed after a restart.
+    this.ctx.ingest(formatted);
+    // Persist only what was actually applied, so the row can never disagree with memory. For
+    // send/retry this is also what supersedes the pessimistic `failed` write-ahead — and when the copy
+    // is declined it is because a fresher one already landed, whose own path wrote the row.
     this.ctx.persist(formatted);
   }
 

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -172,11 +172,12 @@ export class MessageOperationStatePolicy {
 
     const existing = this.ctx.get(messageId);
 
-    const nothingWroteSinceOptimisticEdit =
-      kind === 'update' && !!optimistic?.applied && existing === optimistic.applied;
+    const nothingWroteSinceOptimistic =
+      !!optimistic?.applied && existing === optimistic.applied;
 
-    // Only reached when something else did write and then both copies are server-derived, so
-    // comparing their timestamps is comparing one clock against itself.
+    // Reached only when something else did write since the optimistic step. For an edit both copies
+    // are then server derived, so comparing their timestamps compares one clock against itself. For a
+    // send the copy that landed is a `message.new` WS event, which is server derived too.
     const serverNewer =
       !existing || formatted.updated_at.getTime() > existing.updated_at.getTime();
     const serverSameOrNewer =
@@ -184,7 +185,7 @@ export class MessageOperationStatePolicy {
     const existingIsOurOptimisticSend = existing?.status === 'sending';
 
     const applyServerCopy =
-      nothingWroteSinceOptimisticEdit ||
+      nothingWroteSinceOptimistic ||
       serverNewer ||
       (existingIsOurOptimisticSend && serverSameOrNewer);
 

--- a/src/messageOperations/MessageOperationStatePolicy.ts
+++ b/src/messageOperations/MessageOperationStatePolicy.ts
@@ -5,6 +5,7 @@ import type {
   StreamAPIError,
 } from '../types';
 import { formatMessage } from '../utils';
+import type { QueueableType } from '../offline-support';
 import type { MessageOperationSpec, OperationKind, OperationParams } from './types';
 
 export type MessageOperationStatePolicyContext = {
@@ -13,7 +14,7 @@ export type MessageOperationStatePolicyContext = {
   remove: (id: string) => void;
   persist: (m: LocalMessage) => void;
   purge: (id: string) => void;
-  isQueued: (messageId: string) => Promise<boolean>;
+  isQueued: (messageId: string, types: readonly QueueableType[]) => Promise<boolean>;
 };
 
 /**
@@ -236,7 +237,11 @@ export class MessageOperationStatePolicy {
     // get that message out — this is the v9 behaviour, and treating a queued send as merely "pending"
     // would leave it spinning forever.
     const queued =
-      kind !== 'send' && kind !== 'retry' && (await this.ctx.isQueued(messageId));
+      kind !== 'send' &&
+      kind !== 'retry' &&
+      (await this.ctx.isQueued(messageId, [
+        kind === 'delete' ? 'delete-message' : 'update-message',
+      ]));
 
     if (kind === 'delete') {
       if (!queued) this.revertDelete({ messageId, optimistic, options });

--- a/src/messageOperations/MessageOperations.ts
+++ b/src/messageOperations/MessageOperations.ts
@@ -166,6 +166,7 @@ export class MessageOperations {
         kind,
         messageFromResponse: response?.message,
         messageId,
+        optimistic,
         options: params.options,
       });
     } catch (e) {

--- a/src/messageOperations/MessageOperations.ts
+++ b/src/messageOperations/MessageOperations.ts
@@ -169,7 +169,7 @@ export class MessageOperations {
         options: params.options,
       });
     } catch (e) {
-      this.policy.failure({
+      await this.policy.failure({
         error: e,
         kind,
         localMessage: params.localMessage,

--- a/src/messageOperations/MessageOperations.ts
+++ b/src/messageOperations/MessageOperations.ts
@@ -1,9 +1,8 @@
-// todo: add tests
 import type { MessageRequest, UpdateMessageOptions } from '../types';
 import { deepFreezeConfig } from '../configuration/utils/deepFreezeConfig';
 import type { StateStore } from '../store';
 import { ConfigController } from '../configuration/ConfigController';
-import { formatMessage, localMessageToNewMessagePayload } from '../utils';
+import { localMessageToNewMessagePayload } from '../utils';
 import { MessageOperationStatePolicy } from './MessageOperationStatePolicy';
 import type {
   MessageOperationsContext,
@@ -48,7 +47,14 @@ export class MessageOperations {
 
   constructor(ctx: MessageOperationsContext) {
     this.ctx = ctx;
-    this.policy = new MessageOperationStatePolicy({ ingest: ctx.ingest, get: ctx.get });
+    this.policy = new MessageOperationStatePolicy({
+      get: ctx.get,
+      ingest: ctx.ingest,
+      isQueued: ctx.isQueued,
+      persist: ctx.persist,
+      purge: ctx.purge,
+      remove: ctx.remove,
+    });
     this.configController = new ConfigController<MessageOperationsConfig>({
       defaults: DEFAULT_MESSAGE_OPERATIONS_CONFIG,
     });
@@ -138,19 +144,39 @@ export class MessageOperations {
     this.failedSendCache.delete(messageId);
   }
 
+  /**
+   * The shared lifecycle: apply the optimistic state, fire the request, then reconcile or record the
+   * failure. `kind` is threaded through because the three operations want materially different state
+   * transitions — see {@link MessageOperationStatePolicy}.
+   */
   private async run<K extends OperationKind>(
+    kind: K,
     params: OperationParams<K>,
     doRequest: OperationRequestFn<K>,
   ): Promise<void> {
     const messageId = params.localMessage.id;
 
-    this.policy.optimistic(params.localMessage);
+    const optimistic = this.policy.optimistic(kind, params);
 
     try {
-      const { message: messageFromResponse } = await doRequest(params);
-      this.policy.success({ messageFromResponse, messageId });
+      // Destructured defensively: a custom request handler is free to resolve with nothing, and the
+      // policy's own guard treats a missing message as "no server copy to apply".
+      const response = await doRequest(params);
+      this.policy.success({
+        kind,
+        messageFromResponse: response?.message,
+        messageId,
+        options: params.options,
+      });
     } catch (e) {
-      this.policy.failure({ error: e, localMessage: params.localMessage, messageId });
+      this.policy.failure({
+        error: e,
+        kind,
+        localMessage: params.localMessage,
+        messageId,
+        optimistic,
+        options: params.options,
+      });
       throw e;
     }
   }
@@ -166,6 +192,7 @@ export class MessageOperations {
 
     try {
       await this.run<'send'>(
+        'send',
         { ...params, message: messageToSend },
         requestFn ??
           handlers.send ??
@@ -204,6 +231,7 @@ export class MessageOperations {
 
     try {
       await this.run<'retry'>(
+        'retry',
         {
           ...params,
           message: messageToSend,
@@ -242,6 +270,7 @@ export class MessageOperations {
     }
 
     return await this.run<'update'>(
+      'update',
       params,
       requestFn ??
         handlers.update ??
@@ -260,7 +289,6 @@ export class MessageOperations {
       (async (p: OperationParams<'delete'>) =>
         await this.ctx.defaults.delete(p.localMessage.id, p.options));
 
-    const { message: messageFromResponse } = await doRequest(params);
-    this.ctx.ingest(formatMessage(messageFromResponse));
+    return await this.run<'delete'>('delete', params, doRequest);
   }
 }

--- a/src/messageOperations/index.ts
+++ b/src/messageOperations/index.ts
@@ -10,8 +10,8 @@ export {
 } from './optimistic';
 export type {
   MessageChange,
-  MessageLocalState,
-  MessageProducer,
+  LocalMessageAccessor,
+  MessageChangeProducer,
   RevertLocalChange,
 } from './optimistic';
 export type { OptimisticOutcome } from './MessageOperationStatePolicy';

--- a/src/messageOperations/index.ts
+++ b/src/messageOperations/index.ts
@@ -1,6 +1,19 @@
 export { MessageOperations } from './MessageOperations';
 export { createMessageOperationsPersistence } from './persistence';
 export { MessageOperationStatePolicy } from './MessageOperationStatePolicy';
+export {
+  addReactionOptimistically,
+  applyMessageChangeLocally,
+  deleteReactionOptimistically,
+  isQueuedForReplay,
+  REMOVE_MESSAGE,
+} from './optimistic';
+export type {
+  MessageChange,
+  MessageLocalState,
+  MessageProducer,
+  RevertLocalChange,
+} from './optimistic';
 export type { OptimisticOutcome } from './MessageOperationStatePolicy';
 export type {
   MessageOperationsContext,

--- a/src/messageOperations/index.ts
+++ b/src/messageOperations/index.ts
@@ -1,5 +1,7 @@
 export { MessageOperations } from './MessageOperations';
+export { createMessageOperationsPersistence } from './persistence';
 export { MessageOperationStatePolicy } from './MessageOperationStatePolicy';
+export type { OptimisticOutcome } from './MessageOperationStatePolicy';
 export type {
   MessageOperationsContext,
   MessageOperationsHandlers,

--- a/src/messageOperations/optimistic.ts
+++ b/src/messageOperations/optimistic.ts
@@ -156,7 +156,7 @@ export const isQueuedForReplay = async (
   // this must not assume a well-formed return.
   const pending = await offlineDb.getPendingTasks({ messageId });
 
-  return pending?.some((task) => types.includes(task.type));
+  return !!pending?.some((task) => types.includes(task.type));
 };
 
 /**

--- a/src/messageOperations/optimistic.ts
+++ b/src/messageOperations/optimistic.ts
@@ -16,10 +16,12 @@ import type {
  * The four message operations `MessageOperations` already owns (send, retry, update, delete) run
  * through {@link MessageOperationStatePolicy}. Anything ELSE — pinning, a poll vote, an integrator's
  * own endpoint — is not a message REQUEST (no `localMessage`, no `sending → received | failed`), so it
- * does not belong in that class. It writes itself, using these two:
+ * does not belong in that class. It writes itself, using these two — from inside `Channel` or
+ * `Thread`, where the accessor is in scope (it is built where `MessageOperations` is constructed and
+ * is not exposed as a field):
  *
  * ```ts
- * const undo = applyMessageChangeLocally(channel.messageState, {
+ * const undo = applyMessageChangeLocally(accessor, {
  *   messageId,
  *   produce: (m) => m && { ...m, pinned: true, pinned_at: new Date() },
  * });
@@ -42,21 +44,22 @@ import type {
  */
 
 /**
- * What a {@link MessageProducer} returns to say "this operation takes the message out of local state"
+ * What a {@link MessageChangeProducer} returns to say "this operation takes the message out of local state"
  * — a hard delete. Distinct from `undefined`, which means "nothing to do".
  */
 export const REMOVE_MESSAGE = Symbol('REMOVE_MESSAGE');
 
 export type MessageChange = LocalMessage | typeof REMOVE_MESSAGE | undefined;
 
-/** An operation's local-state shape: given the copy we hold, what should be there instead. */
-export type MessageProducer = (current: LocalMessage | undefined) => MessageChange;
+/** The change an operation wants made: given the copy currently held, what should be there instead. */
+export type MessageChangeProducer = (current: LocalMessage | undefined) => MessageChange;
 
 /**
- * Where an optimistic operation reads and writes local state. `Channel` and `Thread` each expose one
- * as `messageState`, routed paginator-first with the client-global message store as the fallback.
+ * How an optimistic operation reaches the message it is changing: the read, the write and the removal,
+ * nothing else. `Channel` and `Thread` each build one where they construct their `MessageOperations`,
+ * routed paginator-first with the client-global message store as the fallback.
  */
-export type MessageLocalState = {
+export type LocalMessageAccessor = {
   get: (id: string) => LocalMessage | undefined;
   ingest: (message: LocalMessage) => void;
   remove: (id: string) => void;
@@ -80,16 +83,16 @@ export type RevertLocalChange = () => boolean;
  * the read, the write, the "has anything else written since" guard, working out what the inverse of the
  * write is — is here.
  *
- * Writes go through `state.ingest` / `state.remove` rather than a bare store upsert, so a change that
+ * Writes go through `accessor.ingest` / `accessor.remove` rather than a bare store upsert, so a change that
  * affects COLLECTION MEMBERSHIP works and not just a content change: a store upsert replaces the
  * message wherever it is already held but never consults a collection's filter, so flipping `pinned`
  * could never make it appear in a list it now belongs to.
  */
 export const applyMessageChangeLocally = (
-  state: MessageLocalState,
-  { messageId, produce }: { messageId: string; produce: MessageProducer },
+  accessor: LocalMessageAccessor,
+  { messageId, produce }: { messageId: string; produce: MessageChangeProducer },
 ): RevertLocalChange | undefined => {
-  const previous = state.get(messageId);
+  const previous = accessor.get(messageId);
   const next = produce(previous);
 
   // Nothing to apply — e.g. an optimistic soft delete of a message no collection holds, where
@@ -99,24 +102,24 @@ export const applyMessageChangeLocally = (
   if (next === REMOVE_MESSAGE) {
     if (!previous) return;
 
-    state.remove(messageId);
+    accessor.remove(messageId);
 
     return () => {
       // No identity guard: the message is not in local state, so there is no current copy to compare
       // against and the snapshot is unambiguously what belongs there.
-      state.ingest(previous);
+      accessor.ingest(previous);
       return true;
     };
   }
 
-  state.ingest(next);
+  accessor.ingest(next);
 
   return () => {
     // A fresher truth (a WS event, another operation) landed while the request was in flight.
-    if (state.get(messageId) !== next) return false;
+    if (accessor.get(messageId) !== next) return false;
 
-    if (previous) state.ingest(previous);
-    else state.remove(messageId);
+    if (previous) accessor.ingest(previous);
+    else accessor.remove(messageId);
 
     return true;
   };

--- a/src/messageOperations/optimistic.ts
+++ b/src/messageOperations/optimistic.ts
@@ -3,6 +3,7 @@ import { isEphemeral } from '../errors';
 import { formatMessage } from '../utils';
 import type { Channel } from '../channel';
 import type { StreamChat } from '../client';
+import type { QueueableType } from '../offline-support';
 import type {
   LocalMessage,
   MessageResponse,
@@ -30,7 +31,10 @@ import type {
  *   await client.pinMessage(messageId, expiration);
  * } catch (error) {
  *   // Queued for replay is pending, not failed — there is nothing to roll back.
- *   if (!(await isQueuedForReplay(client, messageId))) undo?.();
+ *   // Naming the operation's OWN task types: every task carries the same `messageId`, so asking
+ *   // "is anything queued for this message" would let an unrelated one answer for you. An operation
+ *   // that is not queueable at all skips this and always rolls back.
+ *   if (!(await isQueuedForReplay(client, messageId, ['pin-message' as QueueableType]))) undo?.();
  *   throw error;
  * }
  * ```
@@ -141,6 +145,7 @@ export const applyMessageChangeLocally = (
 export const isQueuedForReplay = async (
   client: StreamChat,
   messageId: string,
+  types: readonly QueueableType[],
 ): Promise<boolean> => {
   const { offlineDb } = client;
   // No queue at all, so nothing can be pending. `initialized` matters as much as existence: a DB whose
@@ -150,7 +155,8 @@ export const isQueuedForReplay = async (
   // Optional-chained: `getPendingTasks` is part of the `OfflineDBApi` an integrator can implement, so
   // this must not assume a well-formed return.
   const pending = await offlineDb.getPendingTasks({ messageId });
-  return !!pending?.length;
+
+  return pending?.some((task) => types.includes(task.type));
 };
 
 /**
@@ -208,7 +214,7 @@ export const addReactionOptimistically = async ({
     reconcileHeldMessage(channel, response?.message);
   } catch (error) {
     // Queued for replay is pending, not failed — there is nothing to roll back.
-    if (!(await isQueuedForReplay(client, messageId))) undo?.();
+    if (!(await isQueuedForReplay(client, messageId, ['send-reaction']))) undo?.();
     throw error;
   }
 };
@@ -237,7 +243,7 @@ export const deleteReactionOptimistically = async ({
     const response = await channel.deleteReaction({ id: messageId, type });
     reconcileHeldMessage(channel, response?.message);
   } catch (error) {
-    if (!(await isQueuedForReplay(client, messageId))) undo?.();
+    if (!(await isQueuedForReplay(client, messageId, ['delete-reaction']))) undo?.();
     throw error;
   }
 };

--- a/src/messageOperations/optimistic.ts
+++ b/src/messageOperations/optimistic.ts
@@ -1,0 +1,240 @@
+import { applyReactionLocally } from '../entityStore';
+import { isEphemeral } from '../errors';
+import { formatMessage } from '../utils';
+import type { Channel } from '../channel';
+import type { StreamChat } from '../client';
+import type {
+  LocalMessage,
+  MessageResponse,
+  ReactionRequest,
+  SendReactionRequest,
+} from '../types';
+
+/**
+ * ADDING A NEW OPTIMISTIC OPERATION
+ *
+ * The four message operations `MessageOperations` already owns (send, retry, update, delete) run
+ * through {@link MessageOperationStatePolicy}. Anything ELSE — pinning, a poll vote, an integrator's
+ * own endpoint — is not a message REQUEST (no `localMessage`, no `sending → received | failed`), so it
+ * does not belong in that class. It writes itself, using these two:
+ *
+ * ```ts
+ * const undo = applyMessageChangeLocally(channel.messageState, {
+ *   messageId,
+ *   produce: (m) => m && { ...m, pinned: true, pinned_at: new Date() },
+ * });
+ *
+ * try {
+ *   await client.pinMessage(messageId, expiration);
+ * } catch (error) {
+ *   // Queued for replay is pending, not failed — there is nothing to roll back.
+ *   if (!(await isQueuedForReplay(client, messageId))) undo?.();
+ *   throw error;
+ * }
+ * ```
+ *
+ * An operation that also changes which COLLECTION holds the message (pinning does) names that
+ * collection itself — `channel.pinnedMessagesPaginator.ingestItem(...)` after the write,
+ * `removeItem(...)` in the undo — because the call site always knows which list it is about.
+ *
+ * Reactions apply their change with {@link applyReactionLocally} instead: their local update is delta
+ * math over current state rather than a replacement, so their undo is inverse-deltas.
+ */
+
+/**
+ * What a {@link MessageProducer} returns to say "this operation takes the message out of local state"
+ * — a hard delete. Distinct from `undefined`, which means "nothing to do".
+ */
+export const REMOVE_MESSAGE = Symbol('REMOVE_MESSAGE');
+
+export type MessageChange = LocalMessage | typeof REMOVE_MESSAGE | undefined;
+
+/** An operation's local-state shape: given the copy we hold, what should be there instead. */
+export type MessageProducer = (current: LocalMessage | undefined) => MessageChange;
+
+/**
+ * Where an optimistic operation reads and writes local state. `Channel` and `Thread` each expose one
+ * as `messageState`, routed paginator-first with the client-global message store as the fallback.
+ */
+export type MessageLocalState = {
+  get: (id: string) => LocalMessage | undefined;
+  ingest: (message: LocalMessage) => void;
+  remove: (id: string) => void;
+};
+
+/**
+ * Reverts an optimistic write, unless something fresher landed in the meantime.
+ *
+ * Returns whether it actually reverted. `false` means "a newer truth won, leave it alone" — not that
+ * anything went wrong. An operation that also has to un-write something else (restore an offline-DB
+ * row, drop the message from a collection it added it to) reads that, so it does not undo a half of
+ * something that never happened.
+ */
+export type RevertLocalChange = () => boolean;
+
+/**
+ * Reads the copy currently held, hands it to the operation's `produce`, writes the result back, and
+ * returns a reference-equality-guarded undo.
+ *
+ * Everything operation-specific is in `produce`. Everything an operation would otherwise hand-roll —
+ * the read, the write, the "has anything else written since" guard, working out what the inverse of the
+ * write is — is here.
+ *
+ * Writes go through `state.ingest` / `state.remove` rather than a bare store upsert, so a change that
+ * affects COLLECTION MEMBERSHIP works and not just a content change: a store upsert replaces the
+ * message wherever it is already held but never consults a collection's filter, so flipping `pinned`
+ * could never make it appear in a list it now belongs to.
+ */
+export const applyMessageChangeLocally = (
+  state: MessageLocalState,
+  { messageId, produce }: { messageId: string; produce: MessageProducer },
+): RevertLocalChange | undefined => {
+  const previous = state.get(messageId);
+  const next = produce(previous);
+
+  // Nothing to apply — e.g. an optimistic soft delete of a message no collection holds, where
+  // ingesting would insert a phantom "Message deleted" row for something never on screen.
+  if (next === undefined) return;
+
+  if (next === REMOVE_MESSAGE) {
+    if (!previous) return;
+
+    state.remove(messageId);
+
+    return () => {
+      // No identity guard: the message is not in local state, so there is no current copy to compare
+      // against and the snapshot is unambiguously what belongs there.
+      state.ingest(previous);
+      return true;
+    };
+  }
+
+  state.ingest(next);
+
+  return () => {
+    // A fresher truth (a WS event, another operation) landed while the request was in flight.
+    if (state.get(messageId) !== next) return false;
+
+    if (previous) state.ingest(previous);
+    else state.remove(messageId);
+
+    return true;
+  };
+};
+
+/**
+ * Whether this message's mutation is sitting in the offline queue waiting to be replayed. A queued
+ * mutation is pending, not failed: nothing to roll back and nothing to mark.
+ *
+ * Reads the queue. Inferring it from the error's shape ("an initialized offline DB plus an
+ * {@link isEphemeral} error, so it must have been queued") over-reports, because the queue declines
+ * tasks no error shape can predict — an `update-message` whose payload still points at a local
+ * attachment URL is refused by `isMessageUpdateReplayable`, and the edit would then be suppressed as
+ * "pending" with nothing to replay it. A row in the pending-tasks table is the actual fact.
+ *
+ * Ordering is safe: `queueTask` awaits `handleAddPendingTask` before it rethrows, so the row exists by
+ * the time an operation's `catch` runs.
+ */
+export const isQueuedForReplay = async (
+  client: StreamChat,
+  messageId: string,
+): Promise<boolean> => {
+  const { offlineDb } = client;
+  // No queue at all, so nothing can be pending. `initialized` matters as much as existence: a DB whose
+  // `init()` never succeeded cannot hold a pending task.
+  if (!offlineDb?.state.getLatestValue().initialized) return false;
+
+  // Optional-chained: `getPendingTasks` is part of the `OfflineDBApi` an integrator can implement, so
+  // this must not assume a well-formed return.
+  const pending = await offlineDb.getPendingTasks({ messageId });
+  return !!pending?.length;
+};
+
+/**
+ * Reactions do not go through {@link MessageOperations}, and shouldn't: that class models a message
+ * REQUEST — it takes a `localMessage`, returns `{ message }`, and moves it `sending → received |
+ * failed`. A reaction has no status, nothing renders a pending or failed reaction, and the subject of
+ * the request is not the message.
+ *
+ * One implementation each, shared by `Channel` and `Thread`, which had a copy apiece differing only in
+ * `this` vs `this.channel`. The request is channel-level either way, and the local write is addressed
+ * by message id ({@link applyReactionLocally}) rather than through any paginator — which is what lets
+ * it reach a pure thread reply, or a thread parent, that no single collection holds.
+ */
+
+/**
+ * Reconciles the server-authoritative copy, but only if we still hold it — a bare upsert of an unheld
+ * id would orphan it (the store's refcount GC only reclaims held ids).
+ */
+const reconcileHeldMessage = (
+  channel: Channel,
+  message: MessageResponse | undefined | null,
+) => {
+  if (!message) return;
+  const { messageStore } = channel.getClient();
+  if (!messageStore.has(message.id)) return;
+  messageStore.upsert(formatMessage(message));
+};
+
+/**
+ * Adds a reaction with an optimistic local state update: the reaction is applied to the cached message
+ * immediately, then the request is fired via {@link Channel.sendReaction} (which owns the offline-DB
+ * write + queue). The server-authoritative counts reconcile on the response; the reaction is rolled
+ * back on a definitive failure, and left alone when the request was queued for replay.
+ */
+export const addReactionOptimistically = async ({
+  channel,
+  messageId,
+  options,
+  reaction,
+}: {
+  channel: Channel;
+  messageId: string;
+  reaction: ReactionRequest;
+  options?: Pick<SendReactionRequest, 'enforce_unique' | 'skip_push'>;
+}) => {
+  const client = channel.getClient();
+  const undo = applyReactionLocally(client, {
+    enforceUnique: options?.enforce_unique ?? false,
+    messageId,
+    reaction,
+  });
+
+  try {
+    const response = await channel.sendReaction({ id: messageId, reaction, ...options });
+    reconcileHeldMessage(channel, response?.message);
+  } catch (error) {
+    // Queued for replay is pending, not failed — there is nothing to roll back.
+    if (!(await isQueuedForReplay(client, messageId))) undo?.();
+    throw error;
+  }
+};
+
+/**
+ * Removes the current user's reaction with an optimistic local state update, mirroring
+ * {@link addReactionOptimistically}.
+ */
+export const deleteReactionOptimistically = async ({
+  channel,
+  messageId,
+  type,
+}: {
+  channel: Channel;
+  messageId: string;
+  type: string;
+}) => {
+  const client = channel.getClient();
+  const undo = applyReactionLocally(client, {
+    messageId,
+    reaction: { type },
+    removed: true,
+  });
+
+  try {
+    const response = await channel.deleteReaction({ id: messageId, type });
+    reconcileHeldMessage(channel, response?.message);
+  } catch (error) {
+    if (!(await isQueuedForReplay(client, messageId))) undo?.();
+    throw error;
+  }
+};

--- a/src/messageOperations/persistence.ts
+++ b/src/messageOperations/persistence.ts
@@ -1,5 +1,5 @@
 import { isQueuedForReplay } from './optimistic';
-import type { StreamChat } from '../client';
+import type { Channel } from '../channel';
 import type { LocalMessage } from '../types';
 
 /**
@@ -10,27 +10,29 @@ import type { LocalMessage } from '../types';
  * detaches the query rather than awaiting it: local state is the source of truth, so an operation must
  * never fail — or be delayed — because a mirror write did. Same shape `applyReactionLocally` uses.
  *
- * `getCid` is read lazily rather than captured: these hooks are built in the `Channel` constructor,
- * and a channel created before its server data arrives gets its `cid` later.
+ * @param params.channel - The channel these writes belong to. A `Thread` passes its parent channel,
+ *   since a reply's row is stored against the channel like any other message.
  */
 export const createMessageOperationsPersistence = ({
-  getCid,
-  getClient,
+  channel,
 }: {
-  getCid: () => string;
-  getClient: () => StreamChat;
+  channel: Channel;
 }) => ({
   persist: (message: LocalMessage) => {
-    const cid = getCid();
-    getClient().offlineDb?.executeQuerySafely(
-      (db) => db.upsertMessageWithChannelGuard({ message: { ...message, cid } }),
-      { method: 'messageOperations:persist' },
-    );
+    channel
+      .getClient()
+      .offlineDb?.executeQuerySafely(
+        (db) =>
+          db.upsertMessageWithChannelGuard({ message: { ...message, cid: channel.cid } }),
+        { method: 'messageOperations:persist' },
+      );
   },
   purge: (id: string) => {
-    getClient().offlineDb?.executeQuerySafely((db) => db.hardDeleteMessage({ id }), {
-      method: 'messageOperations:purge',
-    });
+    channel
+      .getClient()
+      .offlineDb?.executeQuerySafely((db) => db.hardDeleteMessage({ id }), {
+        method: 'messageOperations:purge',
+      });
   },
-  isQueued: (messageId: string) => isQueuedForReplay(getClient(), messageId),
+  isQueued: (messageId: string) => isQueuedForReplay(channel.getClient(), messageId),
 });

--- a/src/messageOperations/persistence.ts
+++ b/src/messageOperations/persistence.ts
@@ -1,4 +1,4 @@
-import { isEphemeral } from '../errors';
+import { isQueuedForReplay } from './optimistic';
 import type { StreamChat } from '../client';
 import type { LocalMessage } from '../types';
 
@@ -32,13 +32,5 @@ export const createMessageOperationsPersistence = ({
       method: 'messageOperations:purge',
     });
   },
-  isQueued: (error: unknown) => {
-    const { offlineDb } = getClient();
-    // Without an offline DB there is no queue, so nothing was deferred and every failure is final.
-    // `initialized` matters as much as existence: an offline DB whose `init()` never succeeded cannot
-    // persist a pending task, so reporting its failures as "queued" would suppress the failed state for
-    // a mutation that is actually lost.
-    if (!offlineDb?.state.getLatestValue().initialized) return false;
-    return isEphemeral(error as Error);
-  },
+  isQueued: (messageId: string) => isQueuedForReplay(getClient(), messageId),
 });

--- a/src/messageOperations/persistence.ts
+++ b/src/messageOperations/persistence.ts
@@ -1,0 +1,44 @@
+import { isEphemeral } from '../errors';
+import type { StreamChat } from '../client';
+import type { LocalMessage } from '../types';
+
+/**
+ * The offline-DB half of {@link MessageOperationsContext}, built once and shared by `Channel` and
+ * `Thread` so the two cannot drift.
+ *
+ * Every write goes through `executeQuerySafely`, which is a no-op until the DB has initialized and
+ * detaches the query rather than awaiting it: local state is the source of truth, so an operation must
+ * never fail — or be delayed — because a mirror write did. Same shape `applyReactionLocally` uses.
+ *
+ * `getCid` is read lazily rather than captured: these hooks are built in the `Channel` constructor,
+ * and a channel created before its server data arrives gets its `cid` later.
+ */
+export const createMessageOperationsPersistence = ({
+  getCid,
+  getClient,
+}: {
+  getCid: () => string;
+  getClient: () => StreamChat;
+}) => ({
+  persist: (message: LocalMessage) => {
+    const cid = getCid();
+    getClient().offlineDb?.executeQuerySafely(
+      (db) => db.upsertMessageWithChannelGuard({ message: { ...message, cid } }),
+      { method: 'messageOperations:persist' },
+    );
+  },
+  purge: (id: string) => {
+    getClient().offlineDb?.executeQuerySafely((db) => db.hardDeleteMessage({ id }), {
+      method: 'messageOperations:purge',
+    });
+  },
+  isQueued: (error: unknown) => {
+    const { offlineDb } = getClient();
+    // Without an offline DB there is no queue, so nothing was deferred and every failure is final.
+    // `initialized` matters as much as existence: an offline DB whose `init()` never succeeded cannot
+    // persist a pending task, so reporting its failures as "queued" would suppress the failed state for
+    // a mutation that is actually lost.
+    if (!offlineDb?.state.getLatestValue().initialized) return false;
+    return isEphemeral(error as Error);
+  },
+});

--- a/src/messageOperations/persistence.ts
+++ b/src/messageOperations/persistence.ts
@@ -1,6 +1,7 @@
 import { isQueuedForReplay } from './optimistic';
 import type { Channel } from '../channel';
 import type { LocalMessage } from '../types';
+import type { QueueableType } from '../offline-support';
 
 /**
  * The offline-DB half of {@link MessageOperationsContext}, built once and shared by `Channel` and
@@ -34,5 +35,6 @@ export const createMessageOperationsPersistence = ({
         method: 'messageOperations:purge',
       });
   },
-  isQueued: (messageId: string) => isQueuedForReplay(channel.getClient(), messageId),
+  isQueued: (messageId: string, types: readonly QueueableType[]) =>
+    isQueuedForReplay(channel.getClient(), messageId, types),
 });

--- a/src/messageOperations/types.ts
+++ b/src/messageOperations/types.ts
@@ -51,6 +51,26 @@ export type MessageOperationsHandlers = {
 export type MessageOperationsContext = {
   ingest: (m: LocalMessage) => void;
   get: (id: string) => LocalMessage | undefined;
+  /**
+   * Drops the message from local state entirely. Needed by the delete lifecycle: a hard delete removes
+   * the message rather than marking it `deleted` (mirroring the `message.deleted` WS handler, which
+   * branches on `event.hard_delete` the same way).
+   */
+  remove: (id: string) => void;
+  /**
+   * Mirrors a message into the offline DB. Fire-and-forget: local state is the source of truth, so a
+   * failed DB write must never fail the operation.
+   */
+  persist: (m: LocalMessage) => void;
+  /** Removes a message's offline-DB row (the hard-delete counterpart of {@link persist}). */
+  purge: (id: string) => void;
+  /**
+   * Whether a failed request was QUEUED for replay rather than definitively rejected — i.e. there is an
+   * offline DB and the error is {@link isEphemeral}. A queued mutation is pending, not failed, so the
+   * optimistic state stays exactly as it is: no `failed` status, no error, no revert. This is the same
+   * predicate `Channel.addReactionWithLocalUpdate` uses to decide not to undo.
+   */
+  isQueued: (error: unknown) => boolean;
 
   normalizeOutgoingMessage?: (m: MessageRequest) => MessageRequest;
 

--- a/src/messageOperations/types.ts
+++ b/src/messageOperations/types.ts
@@ -8,6 +8,7 @@ import type {
   UpdateMessageAPIResponse,
   UpdateMessageOptions,
 } from '../types';
+import type { QueueableType } from '../offline-support/types';
 
 export type OperationKind = 'send' | 'retry' | 'update' | 'delete';
 
@@ -70,7 +71,7 @@ export type MessageOperationsContext = {
    * not failed, so the optimistic state stays exactly as it is: no `failed` status, no error, no revert.
    * Reactions run the same predicate, which is what keeps the two from drifting.
    */
-  isQueued: (messageId: string) => Promise<boolean>;
+  isQueued: (messageId: string, types: readonly QueueableType[]) => Promise<boolean>;
 
   normalizeOutgoingMessage?: (m: MessageRequest) => MessageRequest;
 

--- a/src/messageOperations/types.ts
+++ b/src/messageOperations/types.ts
@@ -65,12 +65,12 @@ export type MessageOperationsContext = {
   /** Removes a message's offline-DB row (the hard-delete counterpart of {@link persist}). */
   purge: (id: string) => void;
   /**
-   * Whether a failed request was QUEUED for replay rather than definitively rejected — i.e. there is an
-   * offline DB and the error is {@link isEphemeral}. A queued mutation is pending, not failed, so the
-   * optimistic state stays exactly as it is: no `failed` status, no error, no revert. This is the same
-   * predicate `Channel.addReactionWithLocalUpdate` uses to decide not to undo.
+   * Whether this message's mutation is sitting in the offline queue waiting to be replayed — read from
+   * the queue, not inferred from the error ({@link isQueuedForReplay}). A queued mutation is pending,
+   * not failed, so the optimistic state stays exactly as it is: no `failed` status, no error, no revert.
+   * Reactions run the same predicate, which is what keeps the two from drifting.
    */
-  isQueued: (error: unknown) => boolean;
+  isQueued: (messageId: string) => Promise<boolean>;
 
   normalizeOutgoingMessage?: (m: MessageRequest) => MessageRequest;
 

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -11,6 +11,7 @@ import type {
 } from '../types';
 
 import type {
+  ExecuteBatchDBQueriesType,
   OfflineDBApi,
   OfflineDBState,
   PendingTask,
@@ -567,62 +568,110 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
   ) => {
     const channelFromEvent = (event as Extract<WSEvent, { channel?: any }>).channel;
     const cid = (event as Extract<WSEvent, { cid?: any }>).cid || channelFromEvent?.cid;
-    const type = event.type;
 
     if (!cid) {
       return await createQueries(execute);
     }
-    // We want to upsert the channel data if we either:
-    // - Have forceUpdate set to true
-    // - The channel does not yet exist in the DB
-    // If a channel is not present in the db, we first fetch the channel data from the channel object.
-    // This can happen for example when a message.new event is received for a channel that is not in the db due to a channel being hidden.
-    const shouldUpsertChannelData = forceUpdate || !(await this.channelExists({ cid }));
-    if (shouldUpsertChannelData) {
-      const event_ = event as Extract<WSEvent, { channel_type?: any }>;
 
-      let channelData = channelFromEvent;
-      if (!channelData && event_.channel_type && event_.channel_id) {
-        const channelFromState = this.client.channel(
-          event_.channel_type,
-          event_.channel_id,
-        );
-        if (channelFromState.initialized && !channelFromState.pendingDisposal) {
-          channelData = channelFromState.data as unknown as ChannelResponse;
-        }
+    // Fast path: assume the channel row is there — which it is for all but a handful of situations
+    // (an event arriving before the first query persisted the channel, or after a `resetDB`) — and pay
+    // for the guard only when the write actually fails. Every statement these callbacks build is an
+    // upsert, so re-running them behind the guard is idempotent.
+    //
+    // Worth the inversion because this runs on EVERY live WS event: the probe it replaces is a native
+    // round-trip, which on device costs about as much as the write it was protecting.
+    //
+    // Only available when we are the ones executing. An `execute: false` caller is collecting queries
+    // for someone else's batch, so there is no failure here for us to catch and the channel row has to
+    // be secured up front. `forceUpdate` skips it too — that caller wants the channel data written
+    // regardless of whether a row already exists.
+    if (execute && !forceUpdate) {
+      try {
+        return await createQueries(true);
+      } catch (error) {
+        // A missing channel row is the only failure this guard can repair; anything else is a genuine
+        // error and must not be retried.
+        if (await this.channelExists({ cid })) throw error;
       }
-      if (channelData) {
-        const channelQuery = await this.upsertChannelData({
-          channel: channelData,
-          execute: false,
-        });
-        if (channelQuery) {
-          const createdQueries = await createQueries(false);
-          const newQueries = [...channelQuery, ...createdQueries];
-          if (execute) {
-            await this.executeSqlBatch(newQueries);
-          }
-          return newQueries;
-        } else {
-          logger
-            .withExtraTags('queriesWithChannelGuard')
-            .warn(
-              `Could not create channel queries on a "${type}" event for an initialized channel that is not in the database. Skipping the event.`,
-              { event },
-            );
-          return [];
-        }
-      } else {
-        logger
-          .withExtraTags('queriesWithChannelGuard')
-          .warn(
-            `Received a "${type}" event for a non-initialized channel that is not in the database. Skipping the event.`,
-            { event },
-          );
-        return [];
+      return await this.queriesBehindChannelGuard({
+        createQueries,
+        event,
+        execute: true,
+      });
+    }
+
+    if (!forceUpdate && (await this.channelExists({ cid }))) {
+      return await createQueries(execute);
+    }
+
+    return await this.queriesBehindChannelGuard({ createQueries, event, execute });
+  };
+
+  /**
+   * Prepends the channel row to `createQueries`' output so the queries cannot fail on the `cid`
+   * foreign key, sourcing the channel from the event and falling back to the in-memory channel.
+   *
+   * Skips the write entirely when neither can supply it: without a channel row the queries would fail
+   * anyway, and dropping the event is what the caller expects.
+   */
+  private queriesBehindChannelGuard = async ({
+    createQueries,
+    event,
+    execute,
+  }: {
+    createQueries: (executeOverride?: boolean) => Promise<PrepareBatchDBQueries[]>;
+    event: Extract<
+      Event,
+      { channel?: any; cid?: any; channel_type?: any; channel_id?: any }
+    >;
+    execute: boolean;
+  }) => {
+    const type = event.type;
+    const channelFromEvent = (event as Extract<WSEvent, { channel?: any }>).channel;
+    const event_ = event as Extract<WSEvent, { channel_type?: any }>;
+
+    let channelData = channelFromEvent;
+    if (!channelData && event_.channel_type && event_.channel_id) {
+      const channelFromState = this.client.channel(
+        event_.channel_type,
+        event_.channel_id,
+      );
+      if (channelFromState.initialized && !channelFromState.pendingDisposal) {
+        channelData = channelFromState.data as unknown as ChannelResponse;
       }
     }
-    return await createQueries(execute);
+
+    if (!channelData) {
+      logger
+        .withExtraTags('queriesWithChannelGuard')
+        .warn(
+          `Received a "${type}" event for a non-initialized channel that is not in the database. Skipping the event.`,
+          { event },
+        );
+      return [];
+    }
+
+    const channelQuery = await this.upsertChannelData({
+      channel: channelData,
+      execute: false,
+    });
+
+    if (!channelQuery) {
+      logger
+        .withExtraTags('queriesWithChannelGuard')
+        .warn(
+          `Could not create channel queries on a "${type}" event for an initialized channel that is not in the database. Skipping the event.`,
+          { event },
+        );
+      return [];
+    }
+
+    const createdQueries = await createQueries(false);
+    const newQueries = [...channelQuery, ...createdQueries];
+    if (execute) {
+      await this.executeSqlBatch(newQueries);
+    }
+    return newQueries;
   };
 
   /**
@@ -791,6 +840,120 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
     }
 
     return queries;
+  };
+
+  /**
+   * Upsert a single message, first making sure its channel row exists so the insert cannot fail on the
+   * foreign key.
+   *
+   * Concrete on purpose — it composes {@link channelExists}, {@link upsertChannelData} and
+   * {@link upsertMessages}, so every implementation inherits it and no custom offline DB has to
+   * implement anything new (same reasoning as {@link hardDeleteMessages}).
+   *
+   * The guard matters because the message-operations engine writes optimistically, and the very first
+   * message in a freshly created channel can reach here before that channel has ever been persisted.
+   * `upsertMessages` alone is used rather than `updateMessage` because `updateMessage` is an
+   * UPDATE — it no-ops when the row does not exist yet, which is exactly the write-ahead case.
+   *
+   * @param payload.message - The message to persist. Its `cid` decides which channel row is guarded.
+   * @param payload.execute - Whether to immediately execute the operation (optional, defaults to `true`).
+   */
+  public upsertMessageWithChannelGuard = async ({
+    message,
+    execute = true,
+  }: {
+    message: LocalMessage;
+    execute?: boolean;
+  }): Promise<ExecuteBatchDBQueriesType> => {
+    const { cid } = message;
+    if (!cid) return [];
+
+    const messages = [message] as unknown as MessageResponse[];
+
+    // Same inversion as `queriesWithChannelGuard`: attempt the write, and only reach for the channel
+    // row when it actually fails. This runs on every optimistic message write, and the probe it
+    // replaces is a native round-trip costing a meaningful fraction of the write itself.
+    if (execute) {
+      try {
+        return await this.upsertMessages({ messages, execute: true });
+      } catch (error) {
+        if (await this.channelExists({ cid })) throw error;
+      }
+      return await this.upsertMessageBehindChannelGuard({ cid, messages, execute: true });
+    }
+
+    if (await this.channelExists({ cid })) {
+      return await this.upsertMessages({ messages, execute: false });
+    }
+
+    return await this.upsertMessageBehindChannelGuard({ cid, messages, execute });
+  };
+
+  /**
+   * Writes the channel row ahead of the messages so the insert cannot fail on the `cid` foreign key.
+   * Skips the write when there is nothing to build a channel row from — the message stays correct in
+   * memory either way, and an insert that cannot resolve its foreign key is not worth attempting.
+   */
+  private upsertMessageBehindChannelGuard = async ({
+    cid,
+    execute,
+    messages,
+  }: {
+    cid: string;
+    execute: boolean;
+    messages: MessageResponse[];
+  }): Promise<ExecuteBatchDBQueriesType> => {
+    const channel = this.client.activeChannels[cid];
+    if (!channel?.initialized || channel.pendingDisposal) {
+      logger
+        .withExtraTags('upsertMessageWithChannelGuard', cid)
+        .warn('Skipping message persistence: the channel is not in the database.');
+      return [];
+    }
+
+    const queries: ExecuteBatchDBQueriesType = [
+      ...(await this.upsertChannelData({
+        channel: channel.data as ChannelResponse,
+        execute: false,
+      })),
+      ...(await this.upsertMessages({ messages, execute: false })),
+    ];
+
+    if (execute) {
+      await this.executeSqlBatch(queries);
+    }
+
+    return queries;
+  };
+
+  /**
+   * The messages of a channel that are still in a local `failed` state, i.e. composed by this user but
+   * never accepted by the server.
+   *
+   * Concrete, composed from the existing {@link getChannels} primitive, so it adds nothing to
+   * {@link OfflineDBApi} that a custom offline DB would have to implement.
+   *
+   * This is the buffer that lets a failed message survive. v9 recovered such messages by diffing a
+   * second, lagging copy of the message list (the React SDK state) against `channel.state`; with a
+   * single reactive source of truth the persisted row is the only place that memory can be
+   * re-populated from — see `Channel.reload`.
+   *
+   * @param payload.cid - The channel whose failed messages to read.
+   */
+  public getFailedMessages = async ({
+    cid,
+  }: {
+    cid: string;
+  }): Promise<LocalMessage[]> => {
+    const { initialized, userId } = this.state.getLatestValue();
+    if (!initialized || !userId) return [];
+
+    const channels = await this.getChannels({ cids: [cid], userId });
+    const messages = channels?.[0]?.messages ?? [];
+
+    return messages
+      .map((message) => formatMessage(message))
+      .filter((message) => message.status === 'failed');
   };
 
   /**

--- a/src/offline-support/offline_support_api.ts
+++ b/src/offline-support/offline_support_api.ts
@@ -15,7 +15,9 @@ import type {
   OfflineDBApi,
   OfflineDBState,
   PendingTask,
+  PendingTaskOf,
   PrepareBatchDBQueries,
+  QueueableType,
 } from './types';
 import { OfflineError } from './types';
 import { isEphemeral } from '../errors';
@@ -32,6 +34,8 @@ import {
   runDetached,
 } from '../utils';
 import { isMessageUpdateReplayable } from './util';
+import { QUEUEABLE_OPERATIONS, runQueueableOperation } from './queueableOperations';
+import type { QueueableOperation } from './queueableOperations';
 
 const logger = chatLoggerSystem.getLogger('offline-db');
 import type { WSEvent } from '../gen/models';
@@ -1552,58 +1556,28 @@ export abstract class AbstractOfflineDB implements OfflineDBApi {
    * @param isPendingTask - a control value telling us if it's an actual pending task being executed
    * or delayed execution
    */
-  private executeTask = async (
-    { task }: { task: PendingTask },
+  /**
+   * Replays one queued operation, through the {@link QUEUEABLE_OPERATIONS} registry rather than a
+   * per-type branch here — the same registry a first attempt resolves through, so the two cannot
+   * describe different requests.
+   *
+   * @param task - the task to run.
+   * @param isPendingTask - whether this is a replay rather than a first attempt. A first attempt has an
+   *   optimistic layer above it that settles local state; a replay does not, so some operations have to
+   *   settle it themselves (see `onReplay`).
+   */
+  private executeTask = async <T extends QueueableType>(
+    { task }: { task: PendingTaskOf<T> },
     isPendingTask = false,
   ) => {
-    if (task.type === 'update-message') {
-      return await this.client._updateMessage(...task.payload);
+    const result = await runQueueableOperation({ client: this.client, task });
+
+    if (isPendingTask) {
+      const operation = QUEUEABLE_OPERATIONS[task.type] as QueueableOperation<T>;
+      operation.onReplay?.({ client: this.client, result, task });
     }
 
-    if (task.type === 'delete-message') {
-      return await this.client._deleteMessage(...task.payload);
-    }
-
-    const { channelType, channelId } = task;
-
-    if (channelType && channelId) {
-      const channel = this.client.channel(channelType, channelId);
-
-      if (task.type === 'send-reaction') {
-        return await channel._sendReaction(...task.payload);
-      }
-
-      if (task.type === 'delete-reaction') {
-        return await channel._deleteReaction(...task.payload);
-      }
-
-      if (task.type === 'create-draft') {
-        return await channel._createDraft(...task.payload);
-      }
-
-      if (task.type === 'delete-draft') {
-        return await channel._deleteDraft(...task.payload);
-      }
-
-      if (task.type === 'send-message') {
-        const newMessageResponse = await channel._sendMessage(...task.payload);
-        const newMessage = newMessageResponse?.message;
-        if (isPendingTask && newMessage) {
-          if (newMessage?.parent_id) {
-            this.client.threads.threadsById[newMessage.parent_id]?.upsertReplyLocally({
-              message: newMessage,
-              timestampChanged: true,
-            });
-          }
-          channel.messagePaginator.trackLastMessage(formatMessage(newMessage));
-        }
-        return newMessageResponse;
-      }
-    }
-
-    throw new Error(
-      `Tried to execute invalid pending task type (${task.type}) while synchronizing the database.`,
-    );
+    return result;
   };
 
   /**

--- a/src/offline-support/offline_sync_manager.ts
+++ b/src/offline-support/offline_sync_manager.ts
@@ -4,6 +4,8 @@ import type { AbstractOfflineDB } from './offline_support_api';
 import type { AxiosError } from 'axios';
 import { isAxiosError } from 'axios';
 import { chatLoggerSystem } from '../logger';
+import { decodeWSEvent } from '../gen/model-decoders/event-decoder-mapping';
+import type { WSEvent } from '../gen/models';
 import type { APIError } from '../types';
 
 const logger = chatLoggerSystem.getLogger('offline-db');
@@ -194,6 +196,14 @@ export class OfflineDBSyncManager {
             channel_cids: cids,
             last_sync_at: lastSyncedAtDate,
           });
+
+          // Left out decoding is needed here because the timestamps arrive as nanosecond integers,
+          // `new Date(1786219962651957000)` overflows the Date range and persisting one threw
+          // `RangeError: Date value out of bounds`, which the catch below reads as the "too many
+          // events" API error and answers by resetting the whole database. This was introduced with
+          // the OpenAPI refactor and should be addressed there.
+          // TODO: Remove this when the upstream decoders properly handle the sync API.
+          result.events = result.events?.map((event) => decodeWSEvent(event) as WSEvent);
 
           // Opt-in positive cap owned by this manager; undefined/non-positive = no limit.
           const { syncMaxEventCount } = this;

--- a/src/offline-support/queueableOperations.ts
+++ b/src/offline-support/queueableOperations.ts
@@ -1,0 +1,191 @@
+import { chatLoggerSystem } from '../logger';
+import { formatMessage } from '../utils';
+import type { Channel } from '../channel';
+import type { StreamChat } from '../client';
+import type { PendingTask, PendingTaskOf, QueueableResult, QueueableType } from './types';
+
+/**
+ * How one queued operation is replayed, and what a replay does beyond the request itself.
+ *
+ * `run` is typed from {@link QueueableOperationSignatures}, so an entry cannot resolve to the wrong
+ * method or spread the wrong payload into it.
+ *
+ * @internal
+ */
+const logger = chatLoggerSystem.getLogger('offline-db');
+
+export type QueueableOperation<T extends QueueableType> = {
+  /**
+   * How a failed QUEUEING attempt is logged. Declared per operation rather than passed in per call,
+   * because the wording is a property of the operation, not of the caller — and the caller is then left
+   * saying only which operation it wants.
+   */
+  logFailureAs: { message: string; method: string };
+  /** Performs the request. Used both for a first attempt and for a replay. */
+  run: (params: {
+    client: StreamChat;
+    task: PendingTaskOf<T>;
+  }) => Promise<QueueableResult<T>>;
+  /**
+   * Local state to settle AFTER a replay, and only after a replay — a first attempt has an optimistic
+   * layer above it that already owns this. Declared per operation rather than hidden in a branch,
+   * because "a replay does more than a first attempt" is the kind of asymmetry that goes unnoticed.
+   */
+  onReplay?: (params: {
+    client: StreamChat;
+    result: QueueableResult<T>;
+    task: PendingTaskOf<T>;
+  }) => void;
+};
+
+/**
+ * A task's channel. Every channel-scoped operation carries `channelType`/`channelId`, and a task that
+ * somehow reached the queue without them cannot be replayed at all.
+ */
+const channelOf = (client: StreamChat, task: PendingTask): Channel => {
+  const { channelId, channelType } = task;
+  if (!channelType || !channelId) {
+    throw new Error(
+      `Cannot replay a "${task.type}" task without a channel type and id (message: ${task.messageId}).`,
+    );
+  }
+  return client.channel(channelType, channelId);
+};
+
+/**
+ * The registry: one entry per queueable operation, and the mapped type means a missing entry does not
+ * compile.
+ *
+ * @internal
+ */
+export const QUEUEABLE_OPERATIONS: {
+  [T in QueueableType]: QueueableOperation<T>;
+} = {
+  'create-draft': {
+    logFailureAs: {
+      message: 'Creating the draft in the offline database failed.',
+      method: 'createDraft',
+    },
+    run: ({ client, task }) => channelOf(client, task)._createDraft(...task.payload),
+  },
+  'delete-draft': {
+    logFailureAs: {
+      message: 'Deleting the draft from the offline database failed.',
+      method: 'deleteDraft',
+    },
+    run: ({ client, task }) => channelOf(client, task)._deleteDraft(...task.payload),
+  },
+  'delete-message': {
+    logFailureAs: { message: 'Deleting the message failed.', method: 'deleteMessage' },
+    run: ({ client, task }) => client._deleteMessage(...task.payload),
+  },
+  'delete-reaction': {
+    logFailureAs: { message: 'Deleting the reaction failed.', method: 'deleteReaction' },
+    run: ({ client, task }) => channelOf(client, task)._deleteReaction(...task.payload),
+  },
+  'send-message': {
+    logFailureAs: { message: 'Sending the message failed.', method: 'sendMessage' },
+    /**
+     * A replayed send is the first time local state learns the message exists server-side: the
+     * optimistic layer that would normally reconcile it belongs to a `MessageOperations` call that
+     * finished (and failed) long ago.
+     */
+    onReplay: ({ client, result, task }) => {
+      const message = result?.message;
+      if (!message) return;
+
+      if (message.parent_id) {
+        client.threads.threadsById[message.parent_id]?.upsertReplyLocally({
+          message,
+          timestampChanged: true,
+        });
+      }
+      channelOf(client, task).messagePaginator.trackLastMessage(formatMessage(message));
+    },
+    run: ({ client, task }) => channelOf(client, task)._sendMessage(...task.payload),
+  },
+  'send-reaction': {
+    logFailureAs: { message: 'Sending the reaction failed.', method: 'sendReaction' },
+    run: ({ client, task }) => channelOf(client, task)._sendReaction(...task.payload),
+  },
+  'update-message': {
+    logFailureAs: { message: 'Updating the message failed.', method: 'updateMessage' },
+    run: ({ client, task }) => client._updateMessage(...task.payload),
+  },
+};
+
+/**
+ * The shape every offline-aware request shares: try it through the pending-task queue so it can be
+ * replayed on reconnect, and otherwise — no offline DB, queueing not possible, or the queued attempt
+ * rejected — run it directly.
+ *
+ * Both paths resolve through {@link QUEUEABLE_OPERATIONS}, so "what this task actually runs" is defined
+ * once. Before, the caller passed its own direct call alongside the task, which meant the first attempt
+ * and the replay were two independent statements of the same thing.
+ *
+ * Note the direct call is BOTH the no-offline-DB path — its actual purpose — and, on a queue failure, a
+ * second attempt at a request that may already have reached the server. That predates this helper and
+ * is unchanged by it; having one place to fix it is a reason this exists.
+ *
+ * A failed queueing attempt is logged, not rethrown: falling back to running the request directly is
+ * the point. What it is logged as comes off the operation's own `logFailureAs`, so a caller says which
+ * operation it wants and nothing about how to describe it.
+ *
+ * @internal
+ *
+ * @param params.client - Resolves the operation, and carries the offline DB when one is registered.
+ * @param params.queue - Whether this task can be queued at all. `false` for a send with no message id,
+ *   which there is nothing to key a queue entry on — it still runs, just not through the queue.
+ * @param params.task - Which operation to run, and the arguments to run it with.
+ */
+export const queueOrRun = async <T extends QueueableType>({
+  client,
+  queue = true,
+  task,
+}: {
+  client: StreamChat;
+  queue?: boolean;
+  task: PendingTaskOf<T>;
+}): Promise<QueueableResult<T>> => {
+  const { offlineDb } = client;
+
+  if (offlineDb && queue) {
+    try {
+      return await offlineDb.queueTask<QueueableResult<T>>({ task });
+    } catch (error) {
+      const { message, method } = QUEUEABLE_OPERATIONS[task.type].logFailureAs;
+      // The cid comes from the task when it carries a channel, so a channel-scoped failure is logged
+      // against its channel without the caller having to say so.
+      const cid =
+        task.channelType && task.channelId
+          ? [`${task.channelType}:${task.channelId}`]
+          : [];
+      logger.withExtraTags(method, ...cid).error(message, { error });
+    }
+  }
+
+  return await runQueueableOperation({ client, task });
+};
+
+/**
+ * Resolves a task to its operation and runs it. Shared by a first attempt and by a replay.
+ *
+ * @internal
+ */
+export const runQueueableOperation = async <T extends QueueableType>({
+  client,
+  task,
+}: {
+  client: StreamChat;
+  task: PendingTaskOf<T>;
+}): Promise<QueueableResult<T>> => {
+  const operation = QUEUEABLE_OPERATIONS[task.type] as QueueableOperation<T> | undefined;
+
+  if (!operation) {
+    throw new Error(
+      `Tried to execute invalid pending task type (${task.type}) while synchronizing the database.`,
+    );
+  }
+
+  return await operation.run({ client, task });
+};

--- a/src/offline-support/queueableOperations.ts
+++ b/src/offline-support/queueableOperations.ts
@@ -21,8 +21,14 @@ export type QueueableOperation<T extends QueueableType> = {
    * saying only which operation it wants.
    */
   logFailureAs: { message: string; method: string };
-  /** Performs the request. Used both for a first attempt and for a replay. */
+  /**
+   * Performs the request. Used both for a first attempt and for a replay.
+   *
+   * `channel` is the instance the CALLER already holds, when there is one. A first attempt comes from a
+   * `Channel` method and must run on that exact object; only a replay has to look one up.
+   */
   run: (params: {
+    channel?: Channel;
     client: StreamChat;
     task: PendingTaskOf<T>;
   }) => Promise<QueueableResult<T>>;
@@ -39,10 +45,20 @@ export type QueueableOperation<T extends QueueableType> = {
 };
 
 /**
- * A task's channel. Every channel-scoped operation carries `channelType`/`channelId`, and a task that
- * somehow reached the queue without them cannot be replayed at all.
+ * The channel an operation runs on: the caller's own instance when it has one, and otherwise resolved
+ * from the task.
+ *
+ * Preferring the caller's instance is not an optimisation. `client.channel()` returns the cached
+ * instance only while it is in `activeChannels` and not `pendingDisposal` — otherwise it CONSTRUCTS a
+ * new `Channel`, which builds paginators and a composer and registers subscriptions. A first attempt
+ * always has the real instance in hand, so it should never risk that.
+ *
+ * A replay has no instance, so it resolves from the task. Every channel-scoped operation carries
+ * `channelType`/`channelId`; a task that reached the queue without them cannot be replayed at all.
  */
-const channelOf = (client: StreamChat, task: PendingTask): Channel => {
+const channelOf = (client: StreamChat, task: PendingTask, channel?: Channel): Channel => {
+  if (channel) return channel;
+
   const { channelId, channelType } = task;
   if (!channelType || !channelId) {
     throw new Error(
@@ -66,14 +82,16 @@ export const QUEUEABLE_OPERATIONS: {
       message: 'Creating the draft in the offline database failed.',
       method: 'createDraft',
     },
-    run: ({ client, task }) => channelOf(client, task)._createDraft(...task.payload),
+    run: ({ channel, client, task }) =>
+      channelOf(client, task, channel)._createDraft(...task.payload),
   },
   'delete-draft': {
     logFailureAs: {
       message: 'Deleting the draft from the offline database failed.',
       method: 'deleteDraft',
     },
-    run: ({ client, task }) => channelOf(client, task)._deleteDraft(...task.payload),
+    run: ({ channel, client, task }) =>
+      channelOf(client, task, channel)._deleteDraft(...task.payload),
   },
   'delete-message': {
     logFailureAs: { message: 'Deleting the message failed.', method: 'deleteMessage' },
@@ -81,7 +99,8 @@ export const QUEUEABLE_OPERATIONS: {
   },
   'delete-reaction': {
     logFailureAs: { message: 'Deleting the reaction failed.', method: 'deleteReaction' },
-    run: ({ client, task }) => channelOf(client, task)._deleteReaction(...task.payload),
+    run: ({ channel, client, task }) =>
+      channelOf(client, task, channel)._deleteReaction(...task.payload),
   },
   'send-message': {
     logFailureAs: { message: 'Sending the message failed.', method: 'sendMessage' },
@@ -102,11 +121,13 @@ export const QUEUEABLE_OPERATIONS: {
       }
       channelOf(client, task).messagePaginator.trackLastMessage(formatMessage(message));
     },
-    run: ({ client, task }) => channelOf(client, task)._sendMessage(...task.payload),
+    run: ({ channel, client, task }) =>
+      channelOf(client, task, channel)._sendMessage(...task.payload),
   },
   'send-reaction': {
     logFailureAs: { message: 'Sending the reaction failed.', method: 'sendReaction' },
-    run: ({ client, task }) => channelOf(client, task)._sendReaction(...task.payload),
+    run: ({ channel, client, task }) =>
+      channelOf(client, task, channel)._sendReaction(...task.payload),
   },
   'update-message': {
     logFailureAs: { message: 'Updating the message failed.', method: 'updateMessage' },
@@ -133,16 +154,20 @@ export const QUEUEABLE_OPERATIONS: {
  *
  * @internal
  *
+ * @param params.channel - The channel instance the caller already holds, so a first attempt runs on
+ *   that exact object rather than one `client.channel()` might reconstruct.
  * @param params.client - Resolves the operation, and carries the offline DB when one is registered.
  * @param params.queue - Whether this task can be queued at all. `false` for a send with no message id,
  *   which there is nothing to key a queue entry on — it still runs, just not through the queue.
  * @param params.task - Which operation to run, and the arguments to run it with.
  */
 export const queueOrRun = async <T extends QueueableType>({
+  channel,
   client,
   queue = true,
   task,
 }: {
+  channel?: Channel;
   client: StreamChat;
   queue?: boolean;
   task: PendingTaskOf<T>;
@@ -164,7 +189,7 @@ export const queueOrRun = async <T extends QueueableType>({
     }
   }
 
-  return await runQueueableOperation({ client, task });
+  return await runQueueableOperation({ channel, client, task });
 };
 
 /**
@@ -173,9 +198,11 @@ export const queueOrRun = async <T extends QueueableType>({
  * @internal
  */
 export const runQueueableOperation = async <T extends QueueableType>({
+  channel,
   client,
   task,
 }: {
+  channel?: Channel;
   client: StreamChat;
   task: PendingTaskOf<T>;
 }): Promise<QueueableResult<T>> => {
@@ -187,5 +214,5 @@ export const runQueueableOperation = async <T extends QueueableType>({
     );
   }
 
-  return await operation.run({ client, task });
+  return await operation.run({ channel, client, task });
 };

--- a/src/offline-support/types.ts
+++ b/src/offline-support/types.ts
@@ -420,43 +420,69 @@ export type PendingTaskTypes = {
   deleteDraft: 'delete-draft';
 };
 
-// TODO: Please rethink the definition of PendingTasks as it seems awkward
+/**
+ * Every operation the offline queue can replay, declared as the method that performs it.
+ *
+ * This map is the single definition of what a queueable operation IS. `PendingTask`'s payload union is
+ * derived from it, and `QUEUEABLE_OPERATIONS` has to supply a resolver for each key — so a new task
+ * type is a compile error until both its signature and its resolver exist, rather than a runtime
+ * "Tried to execute invalid pending task type" the first time somebody queues one.
+ *
+ * The `_`-prefixed forms deliberately: the public `sendMessage` / `updateMessage` / … queue, so
+ * resolving to those would make a replay queue itself again instead of hitting the server.
+ *
+ * @internal
+ */
+export type QueueableOperationSignatures = {
+  'create-draft': Channel['_createDraft'];
+  'delete-draft': Channel['_deleteDraft'];
+  'delete-message': StreamChat['_deleteMessage'];
+  'delete-reaction': Channel['_deleteReaction'];
+  'send-message': Channel['_sendMessage'];
+  'send-reaction': Channel['_sendReaction'];
+  'update-message': StreamChat['_updateMessage'];
+};
+
+export type QueueableType = keyof QueueableOperationSignatures;
+
+/**
+ * The argument list of a queueable operation — what a task carries as its `payload`.
+ *
+ * @internal
+ */
+export type QueueablePayload<T extends QueueableType> = Parameters<
+  QueueableOperationSignatures[T]
+>;
+
+/**
+ * What a queueable operation resolves with.
+ *
+ * @internal
+ */
+export type QueueableResult<T extends QueueableType> = Awaited<
+  ReturnType<QueueableOperationSignatures[T]>
+>;
+
+/**
+ * A queued request: which operation, and the arguments to replay it with. The payload is the argument
+ * list of the method named in {@link QueueableOperationSignatures}, so the two cannot drift.
+ */
 export type PendingTask = {
   channelId?: string;
   channelType?: string;
   messageId?: string;
   id?: number;
   threadId?: string;
-} & (
-  | {
-      payload: Parameters<Channel['sendReaction']>;
-      type: PendingTaskTypes['sendReaction'];
-    }
-  | {
-      payload: Parameters<StreamChat['updateMessage']>;
-      type: PendingTaskTypes['updateMessage'];
-    }
-  | {
-      payload: Parameters<StreamChat['deleteMessage']>;
-      type: PendingTaskTypes['deleteMessage'];
-    }
-  | {
-      payload: Parameters<Channel['deleteReaction']>;
-      type: PendingTaskTypes['deleteReaction'];
-    }
-  | {
-      payload: Parameters<Channel['sendMessage']>;
-      type: PendingTaskTypes['sendMessage'];
-    }
-  | {
-      payload: Parameters<Channel['createDraft']>;
-      type: PendingTaskTypes['createDraft'];
-    }
-  | {
-      payload: Parameters<Channel['deleteDraft']>;
-      type: PendingTaskTypes['deleteDraft'];
-    }
-);
+} & {
+  [T in QueueableType]: { payload: QueueablePayload<T>; type: T };
+}[QueueableType];
+
+/**
+ * A task narrowed to one operation.
+ *
+ * @internal
+ */
+export type PendingTaskOf<T extends QueueableType> = Extract<PendingTask, { type: T }>;
 
 export type OfflineErrorType = 'connection:lost';
 

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -272,10 +272,7 @@ export class Thread extends WithSubscriptions {
     });
 
     this.messageOperations = new MessageOperations({
-      ...createMessageOperationsPersistence({
-        getCid: () => this.channel.cid,
-        getClient: () => this.channel.getClient(),
-      }),
+      ...createMessageOperationsPersistence({ channel: this.channel }),
       ingest: (m) => {
         const store = this.channel.getClient().messageStore;
         // See the matching comment in `Channel`: the reply paginator's filter demands

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -30,7 +30,10 @@ import type {
 import type { StreamChat } from './client';
 import type { CustomThreadData } from './custom_types';
 import { MessageComposer } from './messageComposer';
-import { MessageOperations } from './messageOperations';
+import {
+  createMessageOperationsPersistence,
+  MessageOperations,
+} from './messageOperations';
 import { WithSubscriptions } from './utils/WithSubscriptions';
 import { MessagePaginator } from './pagination';
 import type { MergeNewestPageOptions } from './pagination';
@@ -268,11 +271,40 @@ export class Thread extends WithSubscriptions {
     });
 
     this.messageOperations = new MessageOperations({
+      ...createMessageOperationsPersistence({
+        getCid: () => this.channel.cid,
+        getClient: () => this.channel.getClient(),
+      }),
       ingest: (m) => {
-        this.messagePaginator.ingestItem(m);
-        this.channel.getClient().messageStore.flushSubscribers(m.id);
+        const store = this.channel.getClient().messageStore;
+        // See the matching comment in `Channel`: the reply paginator's filter demands
+        // `parent_id === this.id`, so an operation on this thread's PARENT message — edited or deleted
+        // from inside the open thread, which is how the UI SDKs route it — is not something the reply
+        // paginator can hold. The store reaches it (a subscribed thread seeds its parent there) and
+        // fans the change out to the channel list too.
+        if (this.messagePaginator.matchesFilter(m)) {
+          this.messagePaginator.ingestItem(m);
+        } else if (store.has(m.id)) {
+          store.upsert(m);
+        }
+        store.flushSubscribers(m.id);
       },
-      get: (id) => this.messagePaginator.getItem(id),
+      // Mirrors `ingest`'s routing: a message this paginator does not hold can still be held by the
+      // client-global store (a thread parent, a message displayed by another collection), and the
+      // policy uses this both for its freshness comparison and to decide whether there is anything to
+      // update optimistically at all. Reading only the paginator would make those two disagree.
+      get: (id) =>
+        this.messagePaginator.getItem(id) ??
+        this.channel.getClient().messageStore.get(id),
+      remove: (id) => {
+        this.messagePaginator.removeItem({ id });
+        // A reply with `show_in_channel` is held by the channel list as well, so removing it from the
+        // reply paginator alone leaves a ghost there until the `message.deleted` event arrives. Both
+        // calls are no-ops when the paginator does not hold the id, which is the same reason the SDK's
+        // own `removeMessage` removes from the channel unconditionally.
+        this.channel.messagePaginator.removeItem({ id });
+        this.channel.pinnedMessagesPaginator.removeItem({ id });
+      },
       normalizeOutgoingMessage: (m) => ({
         ...m,
         parent_id: this.id,

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -4,7 +4,6 @@ import {
   formatMessage,
   localMessageToNewMessagePayload,
 } from './utils';
-import { applyReactionLocally } from './entityStore';
 import type {
   DraftResponse,
   EventType,
@@ -20,7 +19,7 @@ import type {
   ThreadStateResponse,
   UserResponse,
 } from './types';
-import { isDoesNotExistError, isEphemeral } from './errors';
+import { isDoesNotExistError } from './errors';
 import type {
   Channel,
   DeleteMessageWithStateUpdateParams,
@@ -31,7 +30,9 @@ import type { StreamChat } from './client';
 import type { CustomThreadData } from './custom_types';
 import { MessageComposer } from './messageComposer';
 import {
+  addReactionOptimistically,
   createMessageOperationsPersistence,
+  deleteReactionOptimistically,
   MessageOperations,
 } from './messageOperations';
 import { WithSubscriptions } from './utils/WithSubscriptions';
@@ -1095,10 +1096,10 @@ export class Thread extends WithSubscriptions {
   }
 
   /**
-   * Adds a reaction to a reply with an optimistic local state update, mirroring
-   * {@link Channel.addReactionWithLocalUpdate}. The optimistic message is applied to THIS thread's
-   * paginator (so pure replies get optimism the channel paginator can't give); the request routes
-   * through the parent channel since reactions are channel-level.
+   * Adds a reaction to a reply with an optimistic local state update — see
+   * {@link addReactionOptimistically}, which `Channel` shares. The request routes through the parent
+   * channel because reactions are channel-level, while the local write is addressed by message id and
+   * so reaches a pure reply no channel collection holds.
    */
   async addReactionWithLocalUpdate({
     messageId,
@@ -1109,35 +1110,17 @@ export class Thread extends WithSubscriptions {
     reaction: ReactionRequest;
     options?: Pick<SendReactionRequest, 'enforce_unique' | 'skip_push'>;
   }) {
-    const client = this.channel.getClient();
-    const undo = applyReactionLocally(client, {
-      enforceUnique: options?.enforce_unique ?? false,
+    await addReactionOptimistically({
+      channel: this.channel,
       messageId,
+      options,
       reaction,
     });
-
-    try {
-      const response = await this.channel.sendReaction({
-        id: messageId,
-        reaction,
-        ...options,
-      });
-      // reconcile the server copy only if we still hold it — a bare upsert of an unheld id would
-      // orphan it (the store's refcount GC only reclaims held ids).
-      if (response?.message && client.messageStore.has(response.message.id)) {
-        client.messageStore.upsert(formatMessage(response.message));
-      }
-    } catch (error) {
-      if (undo && (!client.offlineDb || !isEphemeral(error as Error))) {
-        undo();
-      }
-      throw error;
-    }
   }
 
   /**
-   * Removes the current user's reaction from a reply with an optimistic local state update,
-   * mirroring {@link Thread.addReactionWithLocalUpdate}.
+   * Removes the current user's reaction from a reply with an optimistic local state update — see
+   * {@link deleteReactionOptimistically}, which `Channel` shares.
    */
   async deleteReactionWithLocalUpdate({
     messageId,
@@ -1146,26 +1129,7 @@ export class Thread extends WithSubscriptions {
     messageId: string;
     type: string;
   }) {
-    const client = this.channel.getClient();
-    const undo = applyReactionLocally(client, {
-      messageId,
-      reaction: { type },
-      removed: true,
-    });
-
-    try {
-      const response = await this.channel.deleteReaction({ id: messageId, type });
-      // reconcile the server copy only if we still hold it — a bare upsert of an unheld id would
-      // orphan it (the store's refcount GC only reclaims held ids).
-      if (response?.message && client.messageStore.has(response.message.id)) {
-        client.messageStore.upsert(formatMessage(response.message));
-      }
-    } catch (error) {
-      if (undo && (!client.offlineDb || !isEphemeral(error as Error))) {
-        undo();
-      }
-      throw error;
-    }
+    await deleteReactionOptimistically({ channel: this.channel, messageId, type });
   }
 
   public markRead = async ({ force = false }: { force?: boolean } = {}) => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -1623,6 +1623,8 @@ describe('MessageComposer', () => {
         messageComposer.textComposer.setText('Hello');
         const composed = await messageComposer.compose();
         const serverMessage = generateMsg({
+          // The echo carries the channel, like a real response — the paginator matches on `{ cid }`.
+          cid: mockChannel.cid,
           id: composed!.localMessage.id,
           updated_at: new Date(
             composed!.localMessage.updated_at.getTime() + 100,
@@ -1730,6 +1732,7 @@ describe('MessageComposer', () => {
           options: composed!.sendOptions,
           sendMessageRequestFn: async () => ({
             message: generateMsg({
+              cid: mockChannel.cid,
               id: messageId,
               updated_at: serverUpdatedAt.toISOString(),
             }),

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -1655,13 +1655,21 @@ describe('MessageComposer', () => {
           localMessage: composed!.localMessage,
           message: composed!.message,
           options: composed!.sendOptions,
-          sendMessageRequestFn: async () => ({ message: serverMessage }),
+          sendMessageRequestFn: async () => {
+            // The echo their names describe, actually landing — mid-flight, as it would in practice.
+            mockChannel.messagePaginator.ingestItem({
+              ...composed!.localMessage,
+              status: 'received',
+              text: 'from the websocket echo',
+              updated_at: new Date(composedUpdatedAt + 5000),
+            });
+            return { message: serverMessage };
+          },
         });
         const after = mockChannel.messagePaginator.getItem(messageId);
-        expect(after?.status).toBe('sending');
-        expect(after?.updated_at.getTime()).toBeGreaterThanOrEqual(
-          composedUpdatedAt - 100,
-        );
+        // The echo is newer, so the slower response must not overwrite it.
+        expect(after?.text).toBe('from the websocket echo');
+        expect(after?.status).toBe('received');
       });
 
       it('does not update the message in state if it already exists on the server and in the local state as not delivered', async () => {
@@ -1675,18 +1683,26 @@ describe('MessageComposer', () => {
           localMessage: composed!.localMessage,
           message: composed!.message,
           options: composed!.sendOptions,
-          sendMessageRequestFn: async () => ({
-            message: generateMsg({
-              id: messageId,
-              updated_at: olderServerTime.toISOString(),
-            }),
-          }),
+          sendMessageRequestFn: async () => {
+            // The pre-existing copy these names describe, actually landing mid-flight.
+            mockChannel.messagePaginator.ingestItem({
+              ...composed!.localMessage,
+              status: 'received',
+              text: 'from the websocket echo',
+              updated_at: new Date(composedUpdatedAt + 5000),
+            });
+            return {
+              message: generateMsg({
+                id: messageId,
+                updated_at: olderServerTime.toISOString(),
+              }),
+            };
+          },
         });
         const after = mockChannel.messagePaginator.getItem(messageId);
-        expect(after?.status).toBe('sending');
-        expect(after?.updated_at.getTime()).toBeGreaterThanOrEqual(
-          composedUpdatedAt - 100,
-        );
+        // Newer than the response, so the slower response must not overwrite it.
+        expect(after?.text).toBe('from the websocket echo');
+        expect(after?.status).toBe('received');
       });
 
       it('does not update the message in state if it already exists on the server and in the local state as not failed', async () => {
@@ -1700,16 +1716,26 @@ describe('MessageComposer', () => {
           localMessage: composed!.localMessage,
           message: composed!.message,
           options: composed!.sendOptions,
-          sendMessageRequestFn: async () => ({
-            message: generateMsg({
-              id: messageId,
-              updated_at: olderServerTime.toISOString(),
-            }),
-          }),
+          sendMessageRequestFn: async () => {
+            // The pre-existing copy these names describe, actually landing mid-flight.
+            mockChannel.messagePaginator.ingestItem({
+              ...composed!.localMessage,
+              status: 'received',
+              text: 'from the websocket echo',
+              updated_at: new Date(composedUpdatedAt + 5000),
+            });
+            return {
+              message: generateMsg({
+                id: messageId,
+                updated_at: olderServerTime.toISOString(),
+              }),
+            };
+          },
         });
         const after = mockChannel.messagePaginator.getItem(messageId);
-        expect(after?.status).toBe('sending');
-        expect(after?.updated_at.getTime()).toBe(composedUpdatedAt);
+        // Newer than the response, so the slower response must not overwrite it.
+        expect(after?.text).toBe('from the websocket echo');
+        expect(after?.status).toBe('received');
       });
 
       it('updates the message in state if it already exists on the server and in the local state with status sending', async () => {

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -4107,6 +4107,62 @@ describe('Channel.reload', () => {
 		expect(channel.messagePaginator.items.map((m) => m.id)).toContain('failed');
 	});
 
+	it('recovers a failed message from the offline DB when memory no longer holds it', async () => {
+		// The cold-boot / evicted case. The in-memory window is the only place `failedBefore` used to look,
+		// so a failed message the paginator had already lost was unrecoverable — v9 got away with reading
+		// its own lagging React copy, which a single reactive source of truth does not have.
+		seedLatestWindow(channel, [msg('m1', 1), msg('m2', 2)]);
+		const unsent = formatMessage(msg('unsent', 10, { status: 'failed' }));
+		client.setOfflineDBApi(new MockOfflineDB({ client }));
+		client.offlineDb.state.partialNext({ initialized: true, userId: 'user' });
+		// `query()` persists its result through `executeQuerySafely`, which hands the returned promise to
+		// `runDetached` — a bare `vi.fn()` returns undefined and blows up there.
+		client.offlineDb.upsertChannels.mockResolvedValue([]);
+		vi.spyOn(client.offlineDb, 'getFailedMessages').mockResolvedValue([unsent]);
+		vi.spyOn(channel, 'getOrCreate').mockImplementation(async () =>
+			generateChannel({
+				channel: { id: channel.id, type: channel.type },
+				messages: [msg('m1', 1), msg('m2', 2)],
+			}),
+		);
+
+		await channel.reload();
+
+		expect(client.offlineDb.getFailedMessages).toHaveBeenCalledWith({ cid: channel.cid });
+		expect(channel.messagePaginator.items.map((m) => m.id)).toContain('unsent');
+	});
+
+	it('does not duplicate a failed message held both in memory and in the offline DB', async () => {
+		const unsent = msg('unsent', 10, { status: 'failed' });
+		seedLatestWindow(channel, [msg('m1', 1), unsent]);
+		client.setOfflineDBApi(new MockOfflineDB({ client }));
+		client.offlineDb.state.partialNext({ initialized: true, userId: 'user' });
+		client.offlineDb.upsertChannels.mockResolvedValue([]);
+		vi.spyOn(client.offlineDb, 'getFailedMessages').mockResolvedValue([
+			formatMessage(unsent),
+		]);
+		vi.spyOn(channel, 'getOrCreate').mockImplementation(async () =>
+			generateChannel({
+				channel: { id: channel.id, type: channel.type },
+				messages: [msg('m1', 1)],
+			}),
+		);
+
+		await channel.reload();
+
+		expect(channel.messagePaginator.items.filter((m) => m.id === 'unsent')).toHaveLength(
+			1,
+		);
+	});
+
+	it('reloads without consulting the DB when offline support is disabled', async () => {
+		seedLatestWindow(channel, [msg('m1', 1)]);
+		vi.spyOn(channel, 'watch').mockResolvedValue({ messages: [msg('m1', 1)] });
+
+		// Guards the `offlineDb ? ... : []` branch: no offline DB must not mean a crash or a stray await.
+		await expect(channel.reload()).resolves.toBeUndefined();
+	});
+
 	it('merges the fetched page into a channel whose only message was ingested live', async () => {
 		// The thread defect from the channel side: a brand-new channel has an EMPTY first page, so the
 		// sent message lands in a LOGICAL head and `reload()` used to discard the server's page whole.

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -753,6 +753,10 @@ describe('message update', () => {
 			expect(queueTaskSpy).toHaveBeenCalledTimes(1);
 			expect(queueTaskSpy).toHaveBeenCalledWith({
 				task: {
+					// Derived from the message's `cid` by `getPendingTaskChannelData`, so a queued task
+					// always carries the channel it belongs to.
+					channelId: 'general',
+					channelType: 'messaging',
 					messageId: 'msg-123',
 					payload: [request],
 					type: 'update-message',
@@ -779,6 +783,10 @@ describe('message update', () => {
 			expect(queueTaskSpy).toHaveBeenCalledTimes(1);
 			expect(queueTaskSpy).toHaveBeenCalledWith({
 				task: {
+					// Derived from the message's `cid` by `getPendingTaskChannelData`, so a queued task
+					// always carries the channel it belongs to.
+					channelId: 'general',
+					channelType: 'messaging',
 					messageId: 'msg-123',
 					payload: [request],
 					type: 'update-message',

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -1267,15 +1267,15 @@ describe('message deletion', () => {
 			vi.resetAllMocks();
 		});
 
-		it('routes soft delete through offlineDb.softDeleteMessage and queues the task', async () => {
+		// The offline-DB row is NOT written here: the optimistic layer owns it
+		// (`MessageOperationStatePolicy`), so this method only queues the request. Writing it here ran
+		// ahead of the state it mirrors, and a custom `deleteMessageRequest` skipped it entirely.
+		it('queues a soft delete without touching the offline-DB row', async () => {
 			const request = { id: messageId };
 
 			await client.deleteMessage(request);
 
-			expect(client.offlineDb.softDeleteMessage).toHaveBeenCalledTimes(1);
-			expect(client.offlineDb.softDeleteMessage).toHaveBeenCalledWith({
-				id: messageId,
-			});
+			expect(client.offlineDb.softDeleteMessage).not.toHaveBeenCalled();
 			expect(client.offlineDb.hardDeleteMessage).not.toHaveBeenCalled();
 
 			expect(queueTaskSpy).toHaveBeenCalledTimes(1);
@@ -1289,15 +1289,12 @@ describe('message deletion', () => {
 			expect(_deleteMessageSpy).not.toHaveBeenCalled();
 		});
 
-		it('routes hard delete through offlineDb.hardDeleteMessage and queues the task', async () => {
+		it('queues a hard delete without touching the offline-DB row', async () => {
 			const request = { id: messageId, hard: true };
 
 			await client.deleteMessage(request);
 
-			expect(client.offlineDb.hardDeleteMessage).toHaveBeenCalledTimes(1);
-			expect(client.offlineDb.hardDeleteMessage).toHaveBeenCalledWith({
-				id: messageId,
-			});
+			expect(client.offlineDb.hardDeleteMessage).not.toHaveBeenCalled();
 			expect(client.offlineDb.softDeleteMessage).not.toHaveBeenCalled();
 
 			expect(queueTaskSpy).toHaveBeenCalledTimes(1);
@@ -1311,19 +1308,6 @@ describe('message deletion', () => {
 			expect(_deleteMessageSpy).not.toHaveBeenCalled();
 		});
 
-		it('forwards delete_for_me to offlineDb.softDeleteMessage', async () => {
-			const request = { id: messageId, delete_for_me: true };
-
-			await client.deleteMessage(request);
-
-			expect(client.offlineDb.softDeleteMessage).toHaveBeenCalledTimes(1);
-			expect(client.offlineDb.softDeleteMessage).toHaveBeenCalledWith({
-				id: messageId,
-				deleteForMe: true,
-			});
-			expect(client.offlineDb.hardDeleteMessage).not.toHaveBeenCalled();
-		});
-
 		it('falls back to _deleteMessage if offlineDb is not set', async () => {
 			client.offlineDb = undefined;
 			const request = { id: messageId };
@@ -1334,14 +1318,13 @@ describe('message deletion', () => {
 			expect(_deleteMessageSpy).toHaveBeenCalledWith(request);
 		});
 
-		it('logs and falls back to _deleteMessage if offline delete throws', async () => {
-			client.offlineDb.softDeleteMessage.mockRejectedValue(new Error('Offline failure'));
+		it('logs and falls back to _deleteMessage if offline queueing throws', async () => {
+			queueTaskSpy.mockRejectedValue(new Error('Offline failure'));
 			const request = { id: messageId };
 
 			await client.deleteMessage(request);
 
 			expect(loggerSpy).toHaveBeenCalledTimes(1);
-			expect(queueTaskSpy).not.toHaveBeenCalled();
 			expect(_deleteMessageSpy).toHaveBeenCalledTimes(1);
 			expect(_deleteMessageSpy).toHaveBeenCalledWith(request);
 		});

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -533,6 +533,54 @@ describe('MessageOperations — optimistic lifecycle', () => {
       expect(lastPersisted()?.text).toBe('after');
     });
 
+    // The optimistic write stamps `updated_at` from the CLIENT clock, so comparing the server's
+    // `updated_at` against it compares two different clocks. A device running even slightly ahead of
+    // the server would lose the whole server copy — the enriched `html`, URL/attachment enrichment,
+    // translations, the server's own `message_text_updated_at` — and the DB row with it.
+    it('applies the server copy even when the client clock runs ahead of the server', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { lastPersisted, ops, store } = harness({ seed });
+
+      // A server timestamp a minute BEHIND the optimistic stamp: the device's clock is fast.
+      const serverUpdatedAt = new Date(Date.now() - 60_000).toISOString();
+
+      await ops.update({ localMessage: { ...seed, text: 'after' } }, async () => ({
+        message: makeMessageResponse({
+          html: '<p>after</p>',
+          id: 'm1',
+          text: 'after',
+          updated_at: serverUpdatedAt,
+        }),
+      }));
+
+      expect(store.get('m1')?.html).toBe('<p>after</p>');
+      expect(lastPersisted()?.html).toBe('<p>after</p>');
+    });
+
+    // The other half of the guard above: relaxing it must not let a slow response overwrite something
+    // that genuinely landed after it. Once another writer has replaced the copy, identity no longer
+    // matches and the decision falls back to timestamps — and both copies are server-derived by then,
+    // so that comparison is one clock against itself.
+    it('does not overwrite a fresher copy that landed while the request was in flight', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { ops, store } = harness({ seed });
+
+      const fresher = makeLocalMessage({
+        id: 'm1',
+        status: 'received',
+        text: 'from a websocket event',
+        updated_at: new Date(Date.now() + 60_000),
+      });
+
+      await ops.update({ localMessage: { ...seed, text: 'after' } }, async () => {
+        // Lands while the request is open, exactly as a `message.updated` echo would.
+        store.set('m1', fresher);
+        return { message: makeMessageResponse({ id: 'm1', text: 'after' }) };
+      });
+
+      expect(store.get('m1')?.text).toBe('from a websocket event');
+    });
+
     it('stamps message_text_updated_at so the "edited" indicator shows immediately', async () => {
       const seed = makeLocalMessage({ id: 'm1', status: 'received' });
       const { ops, persisted } = harness({ seed });

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -516,12 +516,20 @@ describe('MessageOperations — optimistic lifecycle', () => {
   describe('update', () => {
     it('applies and persists the edit, preserving the existing status', async () => {
       const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
-      const { lastPersisted, ops, store } = harness({ seed });
+      const { lastPersisted, ops, persisted, store } = harness({ seed });
 
-      await ops.update({ localMessage: { ...seed, text: 'after' } });
+      // The echo has to carry the edited text. The harness default does not, so whether the edit
+      // survived came down to the optimistic write and the mocked response landing in the same
+      // millisecond — a real server echoes what it stored.
+      await ops.update({ localMessage: { ...seed, text: 'after' } }, async () => ({
+        message: makeMessageResponse({ id: 'm1', text: 'after' }),
+      }));
 
+      // Status preservation is asserted on the optimistic write specifically: the server echo supplies
+      // `received` of its own, so reading the final state could pass without preservation happening.
+      expect(persisted[0].text).toBe('after');
+      expect(persisted[0].status).toBe('received');
       expect(store.get('m1')?.text).toBe('after');
-      expect(store.get('m1')?.status).toBe('received');
       expect(lastPersisted()?.text).toBe('after');
     });
 

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -654,6 +654,72 @@ describe('MessageOperations — optimistic lifecycle', () => {
       expect(purged).toContain('m1');
     });
 
+    /**
+     * The offline-DB row is the optimistic layer's to write, not `client.deleteMessage`'s. It used to be
+     * deleted by the request method before the task was even queued — which put a second uncoordinated
+     * writer on the DB, ran ahead of the state the DB mirrors, and was skipped entirely whenever a
+     * custom `deleteMessageRequest` replaced `client.deleteMessage`.
+     */
+    it('mirrors the deleted message into the offline DB from the optimistic step', async () => {
+      // Asserted on the write that happened BEFORE the response, which is the whole point: the row
+      // used to be written by `client.deleteMessage` ahead of the state it mirrors.
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, persisted } = harness({ seed });
+      let duringRequest: LocalMessage | undefined;
+
+      await ops.delete({ localMessage: seed }, async () => {
+        duringRequest = persisted[0];
+        return { message: makeMessageResponse({ id: 'm1' }) };
+      });
+
+      expect(duringRequest?.type).toBe('deleted');
+      expect(duringRequest?.deleted_at).toBeInstanceOf(Date);
+    });
+
+    it('carries delete_for_me into the mirrored row', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, persisted } = harness({ seed });
+
+      await ops.delete({ localMessage: seed, options: { delete_for_me: true } });
+
+      expect(persisted[0].deleted_for_me).toBe(true);
+    });
+
+    it('purges the offline-DB row for a hard delete rather than mirroring it', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, purged } = harness({ seed });
+
+      await ops.delete({ localMessage: seed, options: { hard: true } });
+
+      expect(purged).toContain('m1');
+    });
+
+    it('still writes the row when a custom request handler replaces client.deleteMessage', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, persisted } = harness({ seed });
+
+      await ops.delete({ localMessage: seed }, async () => ({
+        message: makeMessageResponse({ id: 'm1', type: 'deleted' }),
+      }));
+
+      expect(persisted[0].type).toBe('deleted');
+    });
+
+    it('writes nothing to the offline DB for a message local state does not hold', async () => {
+      // The DB mirrors local state, so it must not be told about state that does not exist — and a
+      // definitive failure would have nothing to restore that row from. Sampled DURING the request,
+      // since the success path legitimately persists the server's copy afterwards.
+      const { ops, persisted } = harness();
+      let duringRequest: number | undefined;
+
+      await ops.delete({ localMessage: makeLocalMessage({ id: 'm1' }) }, async () => {
+        duringRequest = persisted.length;
+        return { message: makeMessageResponse({ id: 'm1' }) };
+      });
+
+      expect(duringRequest).toBe(0);
+    });
+
     it('reverts the delete when the request fails definitively', async () => {
       const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'still here' });
       const { lastPersisted, ops, store } = harness({ seed });

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -30,6 +30,20 @@ const makeMessageResponse = (overrides?: Partial<MessageResponse>): MessageRespo
     ...overrides,
   }) as MessageResponse;
 
+/**
+ * The local-state hooks the engine needs but most of these tests do not assert on.
+ *
+ * `isQueued: () => false` preserves the semantics these tests were written against: with no offline
+ * queue behind it, every failure is a definitive rejection. The tests that care about the queued case
+ * override it.
+ */
+const stateHooks = (store: Store) => ({
+  isQueued: () => false,
+  persist: () => {},
+  purge: () => {},
+  remove: (id: string) => store.delete(id),
+});
+
 const defaultDelete = async () => ({ message: makeMessageResponse({ id: 'm1' }) });
 
 describe('MessageOperations', () => {
@@ -37,6 +51,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -57,6 +72,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -80,6 +96,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -102,6 +119,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -125,6 +143,7 @@ describe('MessageOperations', () => {
     const sendCalls: Array<{ message: Message; options: unknown }> = [];
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -170,6 +189,7 @@ describe('MessageOperations', () => {
       const sendCalls: Array<{ message: Message; options: unknown }> = [];
 
       const ops = new MessageOperations({
+        ...stateHooks(store),
         ingest: (m) => store.set(m.id, m),
         get: (id) => store.get(id),
         handlers: () => ({}),
@@ -218,6 +238,7 @@ describe('MessageOperations', () => {
     const sendCalls: Array<{ message: Message; options: unknown }> = [];
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -265,6 +286,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       normalizeOutgoingMessage: (m) => ({ ...m, parent_id: 't1' }),
@@ -294,6 +316,7 @@ describe('MessageOperations', () => {
     let seenOptions: unknown = 'unset';
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -332,6 +355,7 @@ describe('MessageOperations', () => {
     let seenOptions: unknown = 'unset';
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -358,6 +382,7 @@ describe('MessageOperations', () => {
     }));
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -379,6 +404,7 @@ describe('MessageOperations', () => {
     const store: Store = new Map();
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({}),
@@ -414,6 +440,7 @@ describe('MessageOperations', () => {
     }));
 
     const ops = new MessageOperations({
+      ...stateHooks(store),
       ingest: (m) => store.set(m.id, m),
       get: (id) => store.get(id),
       handlers: () => ({ delete: configuredDelete }),
@@ -431,6 +458,309 @@ describe('MessageOperations', () => {
       localMessage,
       options: { hard: true },
     });
-    expect(store.get('m1')?.text).toBe('deleted via configured handler');
+    // A hard delete REMOVES the message rather than re-ingesting the response copy — the same branch
+    // the `message.deleted` WS handler takes on `event.hard_delete`. Ingesting it (which is what this
+    // used to assert) put a message the server had just destroyed back into the list.
+    expect(store.has('m1')).toBe(false);
+  });
+});
+
+describe('MessageOperations — optimistic lifecycle', () => {
+  /**
+   * A harness that records every hook the engine drives, so a test can assert on what was applied to
+   * state, what was mirrored to the DB, and what was removed — without hand-building a context.
+   */
+  const harness = ({
+    isQueued = false,
+    seed,
+  }: { isQueued?: boolean; seed?: LocalMessage } = {}) => {
+    const store: Store = new Map();
+    if (seed) store.set(seed.id, seed);
+    const persisted: LocalMessage[] = [];
+    const purged: string[] = [];
+    const removed: string[] = [];
+
+    const context = {
+      defaults: {
+        delete: defaultDelete,
+        send: async () => ({ message: makeMessageResponse({ id: 'm1' }) }),
+        update: async () => ({ message: makeMessageResponse({ id: 'm1' }) }),
+      },
+      get: (id: string) => store.get(id),
+      handlers: () => ({}),
+      ingest: (m: LocalMessage) => store.set(m.id, m),
+      isQueued: () => isQueued,
+      persist: (m: LocalMessage) => persisted.push(m),
+      purge: (id: string) => purged.push(id),
+      remove: (id: string) => {
+        removed.push(id);
+        store.delete(id);
+      },
+    };
+
+    return {
+      context,
+      lastPersisted: () => persisted[persisted.length - 1],
+      ops: new MessageOperations(context),
+      persisted,
+      purged,
+      removed,
+      store,
+    };
+  };
+
+  const rejects = async (promise: Promise<unknown>) => {
+    await expect(promise).rejects.toBeDefined();
+  };
+
+  describe('update', () => {
+    it('applies and persists the edit, preserving the existing status', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { lastPersisted, ops, store } = harness({ seed });
+
+      await ops.update({ localMessage: { ...seed, text: 'after' } });
+
+      expect(store.get('m1')?.text).toBe('after');
+      expect(store.get('m1')?.status).toBe('received');
+      expect(lastPersisted()?.text).toBe('after');
+    });
+
+    it('stamps message_text_updated_at so the "edited" indicator shows immediately', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, persisted } = harness({ seed });
+
+      await ops.update({ localMessage: { ...seed, text: 'after' } });
+
+      // Asserted on the optimistic write specifically: the server echo would supply its own value, so
+      // reading the final state could pass without the optimistic stamp ever existing.
+      expect(persisted[0].message_text_updated_at).toBeInstanceOf(Date);
+    });
+
+    it('does not stamp message_text_updated_at when editing a failed message', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'failed' });
+      const { ops, persisted } = harness({ seed });
+
+      await rejects(
+        ops.update({ localMessage: { ...seed, text: 'after' } }, async () => {
+          throw new Error('nope');
+        }),
+      );
+
+      // A message that never reached the server has no server-confirmed text update to advertise.
+      expect(persisted[0].message_text_updated_at).toBeUndefined();
+      expect(persisted[0].status).toBe('failed');
+    });
+
+    it('keeps the edit and does NOT mark it failed when the request was queued', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { ops, store } = harness({ isQueued: true, seed });
+
+      await rejects(
+        ops.update({ localMessage: { ...seed, text: 'after' } }, async () => {
+          throw new Error('offline');
+        }),
+      );
+
+      expect(store.get('m1')?.text).toBe('after');
+      expect(store.get('m1')?.status).not.toBe('failed');
+      expect(store.get('m1')?.error).toBeUndefined();
+    });
+
+    it('keeps the edit and records the failure when the request was NOT queued', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { lastPersisted, ops, store } = harness({ seed });
+
+      await rejects(
+        ops.update({ localMessage: { ...seed, text: 'after' } }, async () => {
+          throw new Error('validation');
+        }),
+      );
+
+      // The edit is never rolled back — that would destroy text the user typed.
+      expect(store.get('m1')?.text).toBe('after');
+      expect(store.get('m1')?.status).toBe('failed');
+      expect(lastPersisted()?.text).toBe('after');
+      expect(lastPersisted()?.status).toBe('failed');
+    });
+
+    it('ignores a response that carries no message', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { ops, store } = harness({ seed });
+
+      await ops.update(
+        { localMessage: { ...seed, text: 'after' } },
+        async () => ({}) as never,
+      );
+
+      // `formatMessage(undefined)` yields an id-less message stamped with the current time, which used
+      // to beat the freshness check and get ingested over the optimistic copy.
+      expect(store.get('m1')?.text).toBe('after');
+      expect(store.size).toBe(1);
+    });
+  });
+
+  describe('delete', () => {
+    it('optimistically marks the message deleted before the request resolves', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, store } = harness({ seed });
+      let duringRequest: LocalMessage | undefined;
+
+      await ops.delete({ localMessage: seed }, async () => {
+        duringRequest = store.get('m1');
+        return {
+          message: makeMessageResponse({
+            id: 'm1',
+            deleted_at: new Date().toISOString(),
+          }),
+        };
+      });
+
+      expect(duringRequest?.type).toBe('deleted');
+      expect(duringRequest?.deleted_at).toBeInstanceOf(Date);
+    });
+
+    it('sets deleted_for_me for a delete_for_me delete', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, store } = harness({ seed });
+      let duringRequest: LocalMessage | undefined;
+
+      await ops.delete(
+        { localMessage: seed, options: { delete_for_me: true } },
+        async () => {
+          duringRequest = store.get('m1');
+          return { message: makeMessageResponse({ id: 'm1' }) };
+        },
+      );
+
+      expect(duringRequest?.deleted_for_me).toBe(true);
+    });
+
+    it('optimistically removes the message for a hard delete, and purges it on success', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, purged, removed, store } = harness({ seed });
+
+      await ops.delete({ localMessage: seed, options: { hard: true } });
+
+      expect(removed).toContain('m1');
+      expect(store.has('m1')).toBe(false);
+      expect(purged).toContain('m1');
+    });
+
+    it('reverts the delete when the request fails definitively', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'still here' });
+      const { lastPersisted, ops, store } = harness({ seed });
+
+      await rejects(
+        ops.delete({ localMessage: seed }, async () => {
+          throw new Error('not allowed');
+        }),
+      );
+
+      // Leaving a "Message deleted" placeholder on a message that still exists server-side is a lie
+      // that only self-corrects on the next query.
+      expect(store.get('m1')?.type).toBe('regular');
+      expect(store.get('m1')?.deleted_at).toBeNull();
+      expect(store.get('m1')?.text).toBe('still here');
+      expect(lastPersisted()?.type).toBe('regular');
+    });
+
+    it('reverts a failed hard delete by putting the message back', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'still here' });
+      const { ops, store } = harness({ seed });
+
+      await rejects(
+        ops.delete({ localMessage: seed, options: { hard: true } }, async () => {
+          throw new Error('not allowed');
+        }),
+      );
+
+      expect(store.get('m1')?.text).toBe('still here');
+    });
+
+    it('keeps the optimistic delete when the request was queued', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { ops, store } = harness({ isQueued: true, seed });
+
+      await rejects(
+        ops.delete({ localMessage: seed }, async () => {
+          throw new Error('offline');
+        }),
+      );
+
+      expect(store.get('m1')?.type).toBe('deleted');
+    });
+
+    it('does not revert over a fresher copy that landed while the request was in flight', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received', text: 'before' });
+      const { ops, store } = harness({ seed });
+
+      await rejects(
+        ops.delete({ localMessage: seed }, async () => {
+          // Stand in for a WS event replacing the canonical copy mid-request.
+          store.set(
+            'm1',
+            makeLocalMessage({ id: 'm1', status: 'received', text: 'from websocket' }),
+          );
+          throw new Error('not allowed');
+        }),
+      );
+
+      expect(store.get('m1')?.text).toBe('from websocket');
+    });
+
+    it('is a no-op revert when the message was not held locally', async () => {
+      const { ops, store } = harness();
+      const localMessage = makeLocalMessage({ id: 'm1', status: 'received' });
+
+      await rejects(
+        ops.delete({ localMessage }, async () => {
+          throw new Error('not allowed');
+        }),
+      );
+
+      expect(store.has('m1')).toBe(false);
+    });
+  });
+
+  describe('send', () => {
+    it('writes the message ahead as failed, then supersedes it with the received copy', async () => {
+      const { ops, persisted } = harness();
+      const localMessage = makeLocalMessage({ id: 'm1', status: undefined as never });
+
+      await ops.send({ localMessage });
+
+      // The write-ahead is what makes a message survive a process death between compose and ack.
+      expect(persisted[0].status).toBe('failed');
+      expect(persisted[persisted.length - 1].status).toBe('received');
+    });
+
+    it('persists the failed state when the send fails', async () => {
+      const { lastPersisted, ops, store } = harness();
+      const localMessage = makeLocalMessage({ id: 'm1' });
+
+      await rejects(
+        ops.send({ localMessage }, async () => {
+          throw new Error('boom');
+        }),
+      );
+
+      expect(store.get('m1')?.status).toBe('failed');
+      expect(lastPersisted()?.status).toBe('failed');
+    });
+
+    it('still marks a send failed when it was queued — an unsent message is not pending forever', async () => {
+      const { ops, store } = harness({ isQueued: true });
+      const localMessage = makeLocalMessage({ id: 'm1' });
+
+      await rejects(
+        ops.send({ localMessage }, async () => {
+          throw new Error('offline');
+        }),
+      );
+
+      // Deliberately unlike update/delete: v9 showed an offline send as failed-and-retryable, and the
+      // retry affordance is the only way the user gets that message out.
+      expect(store.get('m1')?.status).toBe('failed');
+    });
   });
 });

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -856,6 +856,27 @@ describe('MessageOperations — optimistic lifecycle', () => {
       expect(persisted[persisted.length - 1].status).toBe('received');
     });
 
+    // The send twin of the edit case above. The optimistic step does not stamp `updated_at`, but it
+    // spreads the composed message, and the composer stamped it from the CLIENT clock. So the
+    // timestamp comparison here is also cross-clock: a device running fast would drop the server copy
+    // and leave the message `sending`, while the unconditional persist below wrote `received` — memory
+    // and the offline-DB row disagreeing about the same message.
+    it('applies the server copy on a send even when the client clock runs ahead', async () => {
+      const { lastPersisted, ops, store } = harness();
+      const localMessage = makeLocalMessage({
+        id: 'm1',
+        status: 'sending',
+        updated_at: new Date(Date.now() + 60_000),
+      });
+
+      await ops.send({ localMessage }, async () => ({
+        message: makeMessageResponse({ id: 'm1', updated_at: new Date().toISOString() }),
+      }));
+
+      expect(store.get('m1')?.status).toBe('received');
+      expect(lastPersisted()?.status).toBe('received');
+    });
+
     it('persists the failed state when the send fails', async () => {
       const { lastPersisted, ops, store } = harness();
       const localMessage = makeLocalMessage({ id: 'm1' });

--- a/test/unit/messageOperations/MessageOperations.test.ts
+++ b/test/unit/messageOperations/MessageOperations.test.ts
@@ -394,6 +394,10 @@ describe('MessageOperations', () => {
     });
 
     const localMessage = makeLocalMessage({ id: 'm1', status: 'received' });
+    // Only a message local state holds can be deleted; an empty store would exercise the phantom-row
+    // path `success` deliberately refuses.
+    store.set(localMessage.id, localMessage);
+
     await ops.delete({ localMessage });
 
     expect(defaultsDelete).toHaveBeenCalledWith('m1', undefined);
@@ -416,6 +420,7 @@ describe('MessageOperations', () => {
     });
 
     const localMessage = makeLocalMessage({ id: 'm1', status: 'received' });
+    store.set(localMessage.id, localMessage);
 
     await ops.delete({ localMessage }, async () => ({
       message: makeMessageResponse({
@@ -844,6 +849,35 @@ describe('MessageOperations — optimistic lifecycle', () => {
     });
   });
 
+  describe('delete', () => {
+    // `optimistic` deliberately writes nothing when local state holds no copy — ingesting would insert
+    // a "Message deleted" row for something that was never on screen. `success` then ingested the
+    // server's copy unconditionally, putting the phantom row back. The guard only appeared to hold
+    // offline, where the request fails and `success` never runs.
+    it('does not insert a deleted row for a message nothing was displaying', async () => {
+      const { ops, persisted, store } = harness();
+
+      await ops.delete({ localMessage: makeLocalMessage({ id: 'm1' }) }, async () => ({
+        message: makeMessageResponse({ id: 'm1', type: 'deleted' }),
+      }));
+
+      expect(store.has('m1')).toBe(false);
+      expect(persisted).toHaveLength(0);
+    });
+
+    it('still applies the server copy for a message it does hold', async () => {
+      const seed = makeLocalMessage({ id: 'm1', status: 'received' });
+      const { lastPersisted, ops, store } = harness({ seed });
+
+      await ops.delete({ localMessage: seed }, async () => ({
+        message: makeMessageResponse({ id: 'm1', type: 'deleted' }),
+      }));
+
+      expect(store.get('m1')?.type).toBe('deleted');
+      expect(lastPersisted()?.type).toBe('deleted');
+    });
+  });
+
   describe('send', () => {
     it('writes the message ahead as failed, then supersedes it with the received copy', async () => {
       const { ops, persisted } = harness();
@@ -875,6 +909,40 @@ describe('MessageOperations — optimistic lifecycle', () => {
 
       expect(store.get('m1')?.status).toBe('received');
       expect(lastPersisted()?.status).toBe('received');
+    });
+
+    // The DB mirrors memory. When a fresher copy (a `message.new` echo) has already landed, the
+    // response is too stale to apply — and equally too stale to write to the row.
+    it('does not persist a server copy it declined to apply', async () => {
+      const { ops, persisted, store } = harness();
+      const localMessage = makeLocalMessage({
+        id: 'm1',
+        status: 'sending',
+        updated_at: new Date(Date.now() + 60_000),
+      });
+
+      await ops.send({ localMessage }, async () => {
+        // The echo lands while the request is open, and is newer than the response.
+        store.set(
+          'm1',
+          makeLocalMessage({
+            id: 'm1',
+            status: 'received',
+            text: 'from the echo',
+            updated_at: new Date(Date.now() + 120_000),
+          }),
+        );
+        return {
+          message: makeMessageResponse({
+            id: 'm1',
+            updated_at: new Date().toISOString(),
+          }),
+        };
+      });
+
+      expect(store.get('m1')?.text).toBe('from the echo');
+      // Only the pessimistic write-ahead should have been written; the declined copy must not follow it.
+      expect(persisted.map((m) => m.status)).toEqual(['failed']);
     });
 
     it('persists the failed state when the send fails', async () => {

--- a/test/unit/messageOperations/optimistic.test.ts
+++ b/test/unit/messageOperations/optimistic.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  applyMessageChangeLocally,
+  isQueuedForReplay,
+  REMOVE_MESSAGE,
+} from '../../../src/messageOperations/optimistic';
+import type { StreamChat } from '../../../src/client';
+import type {
+  LocalMessageChange,
+  MessageLocalState,
+} from '../../../src/messageOperations/optimistic';
+import type { LocalMessage } from '../../../src/types';
+
+const message = (overrides?: Partial<LocalMessage>): LocalMessage =>
+  ({
+    created_at: new Date(),
+    id: 'm1',
+    text: 'hi',
+    type: 'regular',
+    updated_at: new Date(),
+    ...overrides,
+  }) as LocalMessage;
+
+const makeState = (seed?: LocalMessage) => {
+  const store = new Map<string, LocalMessage>();
+  if (seed) store.set(seed.id, seed);
+
+  const state: MessageLocalState = {
+    get: (id) => store.get(id),
+    ingest: (m) => {
+      store.set(m.id, m);
+    },
+    remove: (id) => {
+      store.delete(id);
+    },
+  };
+
+  return { state, store };
+};
+
+describe('applyMessageChangeLocally', () => {
+  it('writes what produce returns, and hands back an undo', () => {
+    const { state, store } = makeState(message({ text: 'before' }));
+
+    const undo = applyMessageChangeLocally(state, {
+      messageId: 'm1',
+      produce: (current) => ({ ...current!, text: 'after' }),
+    });
+
+    expect(store.get('m1')?.text).toBe('after');
+    expect(typeof undo).toBe('function');
+  });
+
+  it('hands produce the copy currently held', () => {
+    const existing = message();
+    const { state } = makeState(existing);
+    const produce = vi.fn(() => undefined);
+
+    applyMessageChangeLocally(state, { messageId: 'm1', produce });
+
+    expect(produce).toHaveBeenCalledWith(existing);
+  });
+
+  it('does nothing when produce declines the change', () => {
+    const { state, store } = makeState();
+    const change = applyMessageChangeLocally(state, {
+      messageId: 'm1',
+      produce: () => undefined,
+    });
+
+    expect(change).toBeUndefined();
+    expect(store.size).toBe(0);
+  });
+
+  describe('undo', () => {
+    it('restores the previous copy and reports that it reverted', () => {
+      const existing = message({ text: 'before' });
+      const { state, store } = makeState(existing);
+
+      const undo = applyMessageChangeLocally(state, {
+        messageId: 'm1',
+        produce: (current) => ({ ...current!, text: 'after' }),
+      });
+
+      expect(undo?.()).toBe(true);
+      expect(store.get('m1')).toBe(existing);
+    });
+
+    it('does not clobber a fresher copy that landed while the request was in flight', () => {
+      const { state, store } = makeState(message({ text: 'before' }));
+
+      const undo = applyMessageChangeLocally(state, {
+        messageId: 'm1',
+        produce: (current) => ({ ...current!, text: 'after' }),
+      });
+
+      const fromWebsocket = message({ text: 'from WS' });
+      state.ingest(fromWebsocket);
+
+      expect(undo?.()).toBe(false);
+      expect(store.get('m1')).toBe(fromWebsocket);
+    });
+
+    it('removes a message it added, when there was nothing to restore', () => {
+      const { state, store } = makeState();
+
+      const undo = applyMessageChangeLocally(state, {
+        messageId: 'm1',
+        produce: () => message({ text: 'optimistic' }),
+      });
+
+      expect(store.has('m1')).toBe(true);
+      expect(undo?.()).toBe(true);
+      expect(store.has('m1')).toBe(false);
+    });
+  });
+
+  describe('REMOVE_MESSAGE', () => {
+    it('removes the message and puts it back on undo', () => {
+      const existing = message();
+      const { state, store } = makeState(existing);
+
+      const undo = applyMessageChangeLocally(state, {
+        messageId: 'm1',
+        produce: () => REMOVE_MESSAGE,
+      });
+
+      expect(store.has('m1')).toBe(false);
+      expect(undo?.()).toBe(true);
+      expect(store.get('m1')).toBe(existing);
+    });
+
+    it('is a no-op when nothing was held', () => {
+      const { state } = makeState();
+      const remove = vi.spyOn(state, 'remove');
+
+      expect(
+        applyMessageChangeLocally(state, {
+          messageId: 'm1',
+          produce: () => REMOVE_MESSAGE,
+        }),
+      ).toBeUndefined();
+      expect(remove).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('isQueuedForReplay', () => {
+  const clientWith = (pending: unknown, initialized = true) =>
+    ({
+      offlineDb: {
+        getPendingTasks: vi.fn(async () => pending),
+        state: { getLatestValue: () => ({ initialized }) },
+      },
+    }) as unknown as StreamChat;
+
+  it('is queued when the pending-tasks table holds something for the message', async () => {
+    const client = clientWith([{ id: 1 }]);
+
+    await expect(isQueuedForReplay(client, 'm1')).resolves.toBe(true);
+    expect(client.offlineDb?.getPendingTasks).toHaveBeenCalledWith({ messageId: 'm1' });
+  });
+
+  it('is NOT queued when the table holds nothing — regardless of how retryable the error looked', async () => {
+    // The case the old inference got wrong: the queue declined the task (an `update-message` still
+    // pointing at a local attachment URL), so the edit must settle as a genuine failure.
+    await expect(isQueuedForReplay(clientWith([]), 'm1')).resolves.toBe(false);
+  });
+
+  it('reports not-queued when there is no initialized offline DB to queue into', async () => {
+    await expect(isQueuedForReplay({} as StreamChat, 'm1')).resolves.toBe(false);
+    await expect(isQueuedForReplay(clientWith([{ id: 1 }], false), 'm1')).resolves.toBe(
+      false,
+    );
+  });
+
+  it('tolerates an implementation that returns nothing', async () => {
+    await expect(isQueuedForReplay(clientWith(undefined), 'm1')).resolves.toBe(false);
+  });
+});

--- a/test/unit/messageOperations/optimistic.test.ts
+++ b/test/unit/messageOperations/optimistic.test.ts
@@ -7,7 +7,7 @@ import {
 import type { StreamChat } from '../../../src/client';
 import type {
   LocalMessageChange,
-  MessageLocalState,
+  LocalMessageAccessor,
 } from '../../../src/messageOperations/optimistic';
 import type { LocalMessage } from '../../../src/types';
 
@@ -25,7 +25,7 @@ const makeState = (seed?: LocalMessage) => {
   const store = new Map<string, LocalMessage>();
   if (seed) store.set(seed.id, seed);
 
-  const state: MessageLocalState = {
+  const state: LocalMessageAccessor = {
     get: (id) => store.get(id),
     ingest: (m) => {
       store.set(m.id, m);

--- a/test/unit/messageOperations/optimistic.test.ts
+++ b/test/unit/messageOperations/optimistic.test.ts
@@ -154,27 +154,58 @@ describe('isQueuedForReplay', () => {
       },
     }) as unknown as StreamChat;
 
-  it('is queued when the pending-tasks table holds something for the message', async () => {
-    const client = clientWith([{ id: 1 }]);
+  it('is queued when the table holds a task of one of the given types', async () => {
+    const client = clientWith([{ id: 1, type: 'update-message' }]);
 
-    await expect(isQueuedForReplay(client, 'm1')).resolves.toBe(true);
+    await expect(isQueuedForReplay(client, 'm1', ['update-message'])).resolves.toBe(true);
     expect(client.offlineDb?.getPendingTasks).toHaveBeenCalledWith({ messageId: 'm1' });
+  });
+
+  // Every task type shares the `messageId` column, so the table answering "yes, something" says
+  // nothing about whether THIS operation was queued. A reaction the user made moments earlier would
+  // otherwise report a refused edit as pending — and nothing would ever replay it.
+  it('is NOT queued when the only task for the message belongs to another operation', async () => {
+    const client = clientWith([{ id: 1, type: 'send-reaction' }]);
+
+    await expect(isQueuedForReplay(client, 'm1', ['update-message'])).resolves.toBe(
+      false,
+    );
+  });
+
+  it('picks its own task out of a mixed queue', async () => {
+    const client = clientWith([
+      { id: 1, type: 'send-reaction' },
+      { id: 2, type: 'delete-message' },
+    ]);
+
+    await expect(isQueuedForReplay(client, 'm1', ['delete-message'])).resolves.toBe(true);
+    await expect(isQueuedForReplay(client, 'm1', ['update-message'])).resolves.toBe(
+      false,
+    );
   });
 
   it('is NOT queued when the table holds nothing — regardless of how retryable the error looked', async () => {
     // The case the old inference got wrong: the queue declined the task (an `update-message` still
     // pointing at a local attachment URL), so the edit must settle as a genuine failure.
-    await expect(isQueuedForReplay(clientWith([]), 'm1')).resolves.toBe(false);
+    await expect(
+      isQueuedForReplay(clientWith([]), 'm1', ['update-message']),
+    ).resolves.toBe(false);
   });
 
   it('reports not-queued when there is no initialized offline DB to queue into', async () => {
-    await expect(isQueuedForReplay({} as StreamChat, 'm1')).resolves.toBe(false);
-    await expect(isQueuedForReplay(clientWith([{ id: 1 }], false), 'm1')).resolves.toBe(
-      false,
-    );
+    await expect(
+      isQueuedForReplay({} as StreamChat, 'm1', ['update-message']),
+    ).resolves.toBe(false);
+    await expect(
+      isQueuedForReplay(clientWith([{ id: 1, type: 'update-message' }], false), 'm1', [
+        'update-message',
+      ]),
+    ).resolves.toBe(false);
   });
 
   it('tolerates an implementation that returns nothing', async () => {
-    await expect(isQueuedForReplay(clientWith(undefined), 'm1')).resolves.toBe(false);
+    await expect(
+      isQueuedForReplay(clientWith(undefined), 'm1', ['update-message']),
+    ).resolves.toBeFalsy();
   });
 });

--- a/test/unit/messageOperations/optimistic.test.ts
+++ b/test/unit/messageOperations/optimistic.test.ts
@@ -206,6 +206,6 @@ describe('isQueuedForReplay', () => {
   it('tolerates an implementation that returns nothing', async () => {
     await expect(
       isQueuedForReplay(clientWith(undefined), 'm1', ['update-message']),
-    ).resolves.toBeFalsy();
+    ).resolves.toBe(false);
   });
 });

--- a/test/unit/messageOperations/optimisticRouting.test.ts
+++ b/test/unit/messageOperations/optimisticRouting.test.ts
@@ -82,6 +82,92 @@ describe('optimistic edit/delete routing', () => {
   const parentProjection = (thread: Thread) =>
     thread.state.getLatestValue().parentMessage;
 
+  /**
+   * A `show_in_channel` reply is held by BOTH lists — the channel paginator's filter is just `{ cid }`
+   * — so a hard delete has to clear both. `Thread`'s own `remove` already reaches into the channel;
+   * this is the mirror, for a reply deleted from the channel list while its thread is loaded.
+   */
+  describe('show_in_channel reply hard-deleted from the channel', () => {
+    const setupSharedReply = () => {
+      const parentId = uuidv4();
+      const parentMessage = generateMsg({
+        cid: channel.cid,
+        id: parentId,
+      }) as MessageResponse;
+      const thread = new Thread({ client, channel, parentMessage });
+      thread.registerSubscriptions();
+
+      const reply = generateMsg({
+        cid: channel.cid,
+        parent_id: parentId,
+        show_in_channel: true,
+        text: 'shown in both',
+      }) as MessageResponse;
+
+      // Held by both lists, which is what `show_in_channel` means.
+      seedChannel(channel, reply);
+      thread.messagePaginator.ingestPage({
+        isHead: true,
+        isTail: true,
+        page: [formatMessage(reply)],
+        setActive: true,
+      });
+
+      // Only threads the manager knows about are reachable from `Channel`.
+      client.threads.state.partialNext({ threads: [thread] });
+
+      return { reply, thread };
+    };
+
+    it('clears it from the thread reply list as well as the channel', async () => {
+      const { reply, thread } = setupSharedReply();
+      vi.spyOn(client, 'deleteMessage').mockResolvedValue({} as never);
+
+      expect(channel.messagePaginator.getItem(reply.id)).toBeDefined();
+      expect(thread.messagePaginator.getItem(reply.id)).toBeDefined();
+
+      await channel.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(reply) as LocalMessage,
+        options: { hard: true },
+      });
+
+      expect(channel.messagePaginator.getItem(reply.id)).toBeUndefined();
+      // Without the mirror this stayed behind until the `message.deleted` event arrived — and for a
+      // hard delete queued offline, not until the next reconnect.
+      expect(thread.messagePaginator.getItem(reply.id)).toBeUndefined();
+    });
+
+    it('leaves threads belonging to other channels alone', async () => {
+      const { reply } = setupSharedReply();
+      const otherChannel = createChannel(client);
+      const otherParent = generateMsg({ cid: otherChannel.cid }) as MessageResponse;
+      const otherThread = new Thread({
+        channel: otherChannel,
+        client,
+        parentMessage: otherParent,
+      });
+      otherThread.registerSubscriptions();
+      // Same id in another channel's thread: only the deleting channel's threads may be touched.
+      otherThread.messagePaginator.ingestPage({
+        isHead: true,
+        isTail: true,
+        page: [formatMessage({ ...reply, cid: otherChannel.cid })],
+        setActive: true,
+      });
+      client.threads.state.partialNext({
+        threads: [...client.threads.state.getLatestValue().threads, otherThread],
+      });
+      vi.spyOn(client, 'deleteMessage').mockResolvedValue({} as never);
+
+      await channel.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(reply) as LocalMessage,
+        options: { hard: true },
+      });
+
+      expect(otherThread.messagePaginator.getItem(reply.id)).toBeDefined();
+    });
+  });
+
   describe('thread parent edited from inside the thread', () => {
     it('reflects the optimistic edit on the parent projection', async () => {
       const { parentId, parentMessage, thread } = setupThread();

--- a/test/unit/messageOperations/optimisticRouting.test.ts
+++ b/test/unit/messageOperations/optimisticRouting.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { formatMessage, StreamChat, Thread } from '../../../src';
+import type { Channel, LocalMessage, MessageResponse } from '../../../src';
+import { generateUUIDv4 as uuidv4 } from '../../../src/utils';
+import { generateChannel } from '../test-utils/generateChannel';
+import { generateMsg } from '../test-utils/generateMessage';
+
+/**
+ * Where an optimistic edit/delete LANDS, as opposed to what it does once it gets there
+ * (`MessageOperations.test.ts`).
+ *
+ * The interesting case is a thread's PARENT message edited or deleted from inside the open thread,
+ * which is how the UI SDKs route it while a thread is on screen. The reply paginator's local filter is
+ * `{ cid, parent_id: thread.id }` and a parent has no `parent_id`, so it cannot hold the parent — the
+ * write has to reach the client-global message store instead, the same way `applyReactionLocally` does.
+ */
+const CURRENT_USER = { id: 'me' };
+
+const connect = () => {
+  const client = new StreamChat('apiKey');
+  client.user = CURRENT_USER;
+  return client;
+};
+
+const createChannel = (client: StreamChat) => {
+  const { channel: channelResponse } = generateChannel();
+  const channel = client.channel(channelResponse.type, channelResponse.id);
+  channel.initialized = true;
+  return channel;
+};
+
+const seedChannel = (channel: Channel, message: MessageResponse) =>
+  channel.messagePaginator.ingestPage({
+    isHead: true,
+    isTail: true,
+    page: [formatMessage(message)],
+    setActive: true,
+  });
+
+describe('optimistic edit/delete routing', () => {
+  let client: StreamChat;
+  let channel: Channel;
+
+  beforeEach(() => {
+    client = connect();
+    channel = createChannel(client);
+  });
+
+  /**
+   * A thread whose parent is registered in the message store (which `registerSubscriptions` does), so
+   * `state.parentMessage` is a projection of the canonical copy.
+   */
+  const setupThread = ({ seedParentInChannel = false } = {}) => {
+    const parentId = uuidv4();
+    const parentMessage = generateMsg({
+      cid: channel.cid,
+      id: parentId,
+      text: 'parent before',
+    }) as MessageResponse;
+    if (seedParentInChannel) seedChannel(channel, parentMessage);
+
+    const thread = new Thread({ client, channel, parentMessage });
+    thread.registerSubscriptions();
+
+    const reply = generateMsg({
+      cid: channel.cid,
+      parent_id: parentId,
+      text: 'reply before',
+    }) as MessageResponse;
+    thread.messagePaginator.ingestPage({
+      isHead: true,
+      isTail: true,
+      page: [formatMessage(reply)],
+      setActive: true,
+    });
+
+    return { parentId, parentMessage, reply, thread };
+  };
+
+  const parentProjection = (thread: Thread) =>
+    thread.state.getLatestValue().parentMessage;
+
+  describe('thread parent edited from inside the thread', () => {
+    it('reflects the optimistic edit on the parent projection', async () => {
+      const { parentId, parentMessage, thread } = setupThread();
+      // Never resolves during the assertion window: the optimistic state is what is under test, not
+      // the reconcile.
+      vi.spyOn(client, 'updateMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.updateMessageWithLocalUpdate({
+        localMessage: {
+          ...formatMessage(parentMessage),
+          text: 'parent after',
+        } as LocalMessage,
+      });
+
+      // Before the routing fix this went to the reply paginator, whose filter rejected it for having no
+      // `parent_id`, and the edit was silently dropped.
+      expect(parentProjection(thread)?.text).toBe('parent after');
+    });
+
+    it('reflects it on the channel copy too when the channel holds the parent', async () => {
+      const { parentId, parentMessage, thread } = setupThread({
+        seedParentInChannel: true,
+      });
+      vi.spyOn(client, 'updateMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.updateMessageWithLocalUpdate({
+        localMessage: {
+          ...formatMessage(parentMessage),
+          text: 'parent after',
+        } as LocalMessage,
+      });
+
+      expect(channel.messagePaginator.getItem(parentId)?.text).toBe('parent after');
+      expect(parentProjection(thread)?.text).toBe('parent after');
+    });
+
+    it('does not add the parent to the reply list', async () => {
+      const { parentId, parentMessage, thread } = setupThread();
+      vi.spyOn(client, 'updateMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.updateMessageWithLocalUpdate({
+        localMessage: {
+          ...formatMessage(parentMessage),
+          text: 'parent after',
+        } as LocalMessage,
+      });
+
+      expect(
+        thread.messagePaginator.items?.some((message) => message.id === parentId),
+      ).toBe(false);
+    });
+
+    it('reflects an optimistic delete of the parent', async () => {
+      const { parentMessage, thread } = setupThread({ seedParentInChannel: true });
+      vi.spyOn(client, 'deleteMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(parentMessage) as LocalMessage,
+      });
+
+      expect(parentProjection(thread)?.type).toBe('deleted');
+      expect(parentProjection(thread)?.deleted_at).toBeInstanceOf(Date);
+      // `deletedAt` sits on the thread state root, derived from the parent by the store projection —
+      // so this also proves the write went through the store rather than the reply paginator.
+      expect(thread.state.getLatestValue().deletedAt).toBeTruthy();
+    });
+  });
+
+  describe('thread reply', () => {
+    it('removes a show_in_channel reply from the channel list too on a hard delete', async () => {
+      const { parentId, thread } = setupThread();
+      // A reply the author chose to also post to the channel is held by BOTH paginators, so removing it
+      // from the reply list alone leaves a ghost in the main list.
+      const shown = generateMsg({
+        cid: channel.cid,
+        parent_id: parentId,
+        show_in_channel: true,
+      }) as MessageResponse;
+      seedChannel(channel, shown);
+      thread.messagePaginator.ingestItem(formatMessage(shown));
+      expect(channel.messagePaginator.getItem(shown.id)).toBeDefined();
+      vi.spyOn(client, 'deleteMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(shown) as LocalMessage,
+        options: { hard: true },
+      });
+
+      expect(thread.messagePaginator.getItem(shown.id)).toBeUndefined();
+      expect(channel.messagePaginator.getItem(shown.id)).toBeUndefined();
+    });
+
+    it('still routes an optimistic edit into the reply paginator', async () => {
+      const { reply, thread } = setupThread();
+      vi.spyOn(client, 'updateMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      thread.updateMessageWithLocalUpdate({
+        localMessage: { ...formatMessage(reply), text: 'reply after' } as LocalMessage,
+      });
+
+      expect(thread.messagePaginator.getItem(reply.id)?.text).toBe('reply after');
+    });
+  });
+
+  describe('channel message', () => {
+    it('routes an optimistic edit into the channel paginator', async () => {
+      const message = generateMsg({
+        cid: channel.cid,
+        text: 'before',
+      }) as MessageResponse;
+      seedChannel(channel, message);
+      vi.spyOn(client, 'updateMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      channel.updateMessageWithLocalUpdate({
+        localMessage: { ...formatMessage(message), text: 'after' } as LocalMessage,
+      });
+
+      expect(channel.messagePaginator.getItem(message.id)?.text).toBe('after');
+    });
+
+    it('marks an optimistic soft delete as deleted in the channel paginator', async () => {
+      const message = generateMsg({ cid: channel.cid }) as MessageResponse;
+      seedChannel(channel, message);
+      vi.spyOn(client, 'deleteMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      channel.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(message) as LocalMessage,
+      });
+
+      expect(channel.messagePaginator.getItem(message.id)?.type).toBe('deleted');
+      expect(channel.messagePaginator.getItem(message.id)?.deleted_at).toBeInstanceOf(
+        Date,
+      );
+    });
+
+    it('removes the message from the channel paginator for an optimistic hard delete', async () => {
+      const message = generateMsg({ cid: channel.cid }) as MessageResponse;
+      seedChannel(channel, message);
+      vi.spyOn(client, 'deleteMessage').mockReturnValue(new Promise(() => {}) as never);
+
+      channel.deleteMessageWithLocalUpdate({
+        localMessage: formatMessage(message) as LocalMessage,
+        options: { hard: true },
+      });
+
+      expect(channel.messagePaginator.getItem(message.id)).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/messageOperations/optimisticRouting.test.ts
+++ b/test/unit/messageOperations/optimisticRouting.test.ts
@@ -4,6 +4,8 @@ import type { Channel, LocalMessage, MessageResponse } from '../../../src';
 import { generateUUIDv4 as uuidv4 } from '../../../src/utils';
 import { generateChannel } from '../test-utils/generateChannel';
 import { generateMsg } from '../test-utils/generateMessage';
+import { MockOfflineDB } from '../offline-support/MockOfflineDB';
+import type { PendingTask, StableWSConnection } from '../../../src';
 
 /**
  * Where an optimistic edit/delete LANDS, as opposed to what it does once it gets there
@@ -226,6 +228,93 @@ describe('optimistic edit/delete routing', () => {
       });
 
       expect(channel.messagePaginator.getItem(message.id)).toBeUndefined();
+    });
+  });
+
+  /**
+   * Whether a failed mutation settles as `failed` or is left pending, driven end to end rather than by an
+   * injected `isQueued` (which is what `MessageOperations.test.ts` does).
+   *
+   * The distinction only exists because the OFFLINE QUEUE can refuse a task the error's shape says is
+   * perfectly retryable: `handleAddPendingTask` drops an `update-message` whose payload still points at a
+   * local attachment URL, because nothing could ever replay it. Inferring "retryable error + offline DB ⇒
+   * queued" therefore left such an edit looking pending forever, with nothing coming to finish it.
+   */
+  describe('a failed edit, queued or not', () => {
+    /**
+     * A `MockOfflineDB` with a real in-memory pending-task table: the SQL layer is faked, the queue
+     * semantics are not. `queueTask` and `handleAddPendingTask` are inherited, so the decision under test
+     * is the production one.
+     */
+    const enableOfflineDb = () => {
+      const db = new MockOfflineDB({ client });
+      client.setOfflineDBApi(db);
+      db.state.partialNext({ initialized: true, userId: CURRENT_USER.id });
+
+      const pendingTasks: PendingTask[] = [];
+      db.addPendingTask.mockImplementation(async (task: PendingTask) => {
+        pendingTasks.push(task);
+        return [];
+      });
+      db.getPendingTasks.mockImplementation(async (conditions?: { messageId?: string }) =>
+        pendingTasks.filter(
+          (task) => !conditions?.messageId || task.messageId === conditions.messageId,
+        ),
+      );
+      db.channelExists.mockResolvedValue(true);
+      db.upsertMessages.mockResolvedValue([]);
+      db.updateMessage.mockResolvedValue([]);
+
+      // Offline: `queueTask` short-circuits before any HTTP, and the direct attempt that
+      // `client.updateMessage` falls through to fails too.
+      client.wsConnection = { isHealthy: false } as StableWSConnection;
+      vi.spyOn(client, '_updateMessage').mockRejectedValue(
+        Object.assign(new Error('network down'), { code: 9 }),
+      );
+
+      return { db, pendingTasks };
+    };
+
+    const editMessageWithAttachment = async (asset_url: string) => {
+      const message = generateMsg({
+        attachments: [{ asset_url, type: 'file' }],
+        cid: channel.cid,
+        id: uuidv4(),
+        text: 'before',
+      }) as MessageResponse;
+      seedChannel(channel, message);
+
+      await expect(
+        channel.updateMessageWithLocalUpdate({
+          localMessage: { ...formatMessage(message), text: 'after' } as LocalMessage,
+        }),
+      ).rejects.toThrow();
+
+      return channel.messagePaginator.getItem(message.id);
+    };
+
+    it('settles FAILED when the queue refused the task, however retryable the error looked', async () => {
+      const { pendingTasks } = enableOfflineDb();
+
+      // A local URI is exactly what `isMessageUpdateReplayable` refuses.
+      const edited = await editMessageWithAttachment('file:///tmp/local.pdf');
+
+      expect(pendingTasks).toHaveLength(0);
+      expect(edited?.status).toBe('failed');
+      expect(edited?.error).toBeDefined();
+      // The edit itself survives — reverting would destroy text the user typed.
+      expect(edited?.text).toBe('after');
+    });
+
+    it('stays pending when the task WAS queued, with no failed state on the message', async () => {
+      const { pendingTasks } = enableOfflineDb();
+
+      const edited = await editMessageWithAttachment('https://example.com/remote.pdf');
+
+      expect(pendingTasks.map((task) => task.type)).toEqual(['update-message']);
+      expect(edited?.status).not.toBe('failed');
+      expect(edited?.error).toBeUndefined();
+      expect(edited?.text).toBe('after');
     });
   });
 });

--- a/test/unit/messageOperations/optimisticRouting.test.ts
+++ b/test/unit/messageOperations/optimisticRouting.test.ts
@@ -392,6 +392,37 @@ describe('optimistic edit/delete routing', () => {
       expect(edited?.text).toBe('after');
     });
 
+    // Every task type shares the `messageId` column, so "is anything queued for this message" is not
+    // the same question as "is THIS operation queued". A reaction the user made moments earlier must
+    // not disguise a refused edit as pending.
+    it('is not fooled by an unrelated task queued against the same message', async () => {
+      const { pendingTasks } = enableOfflineDb();
+      const messageId = uuidv4();
+      const message = generateMsg({
+        attachments: [{ asset_url: 'file:///tmp/local.pdf', type: 'file' }],
+        cid: channel.cid,
+        id: messageId,
+        text: 'before',
+      }) as MessageResponse;
+      seedChannel(channel, message);
+
+      pendingTasks.push({
+        messageId,
+        payload: [{ id: messageId, reaction: { type: 'love' } }],
+        type: 'send-reaction',
+      } as unknown as PendingTask);
+
+      await expect(
+        channel.updateMessageWithLocalUpdate({
+          localMessage: { ...formatMessage(message), text: 'after' } as LocalMessage,
+        }),
+      ).rejects.toThrow();
+
+      // The local attachment URI means the queue refused the edit, so nothing will ever replay it.
+      expect(pendingTasks.map((task) => task.type)).toEqual(['send-reaction']);
+      expect(channel.messagePaginator.getItem(messageId)?.status).toBe('failed');
+    });
+
     it('stays pending when the task WAS queued, with no failed state on the message', async () => {
       const { pendingTasks } = enableOfflineDb();
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -9,6 +9,7 @@ import {
   ChannelMemberResponse,
   ChannelResponse,
   ChannelStateResponseFields,
+  LocalMessage,
   MessageResponse,
   OfflineDBSyncManager,
   OfflineError,
@@ -331,6 +332,18 @@ describe('OfflineSupportApi', () => {
         createQueries = vi.fn(async () => [{ sql: 'MOCK_QUERY', args: [] }]);
       });
 
+      /**
+       * The guard is LAZY: it attempts the write first and only repairs the channel row when that
+       * attempt fails. So a `createQueries` that fails when asked to EXECUTE and succeeds when only
+       * building queries is what a foreign-key violation looks like from the guard's point of view,
+       * and it is what makes the guard engage at all.
+       */
+      const failsOnExecute = () =>
+        vi.fn(async (shouldExecute?: boolean) => {
+          if (shouldExecute) throw new Error('FOREIGN KEY constraint failed');
+          return [{ sql: 'MOCK_QUERY', args: [] }];
+        });
+
       it('returns createQueries result when no cid is present', async () => {
         const event: Event = { type: 'message.new' };
         const result = await offlineDb.queriesWithChannelGuard({ event }, createQueries);
@@ -346,6 +359,7 @@ describe('OfflineSupportApi', () => {
           channel: { id: '123', type: 'messaging' } as any,
         };
 
+        createQueries = failsOnExecute();
         offlineDb.channelExists.mockResolvedValue(false);
         offlineDb.upsertChannelData.mockResolvedValue([{ sql: 'UPSERT', args: [] }]);
         const clientChannelSpy = vi.spyOn(client, 'channel');
@@ -387,6 +401,7 @@ describe('OfflineSupportApi', () => {
           channel_id: '123',
         };
 
+        createQueries = failsOnExecute();
         offlineDb.channelExists.mockResolvedValue(false);
         offlineDb.upsertChannelData.mockResolvedValue([{ sql: 'UPSERT', args: [] }]);
 
@@ -415,6 +430,7 @@ describe('OfflineSupportApi', () => {
           channel_id: '123',
         };
 
+        createQueries = failsOnExecute();
         offlineDb.channelExists.mockResolvedValue(false);
 
         const sinkSpy = vi.fn();
@@ -446,9 +462,30 @@ describe('OfflineSupportApi', () => {
 
         const result = await offlineDb.queriesWithChannelGuard({ event }, createQueries);
 
-        expect(offlineDb.channelExists).toHaveBeenCalledWith({ cid: 'channel:123' });
+        // The point of the lazy guard: on the overwhelmingly common path the existence probe — a
+        // native round-trip costing a meaningful fraction of the write itself — is never issued.
+        expect(offlineDb.channelExists).not.toHaveBeenCalled();
         expect(createQueries).toHaveBeenCalledWith(true);
         expect(result).toEqual([{ sql: 'MOCK_QUERY', args: [] }]);
+      });
+
+      it('rethrows a write failure that is not a missing channel row, without retrying', async () => {
+        const event: Event = {
+          type: 'message.new',
+          cid: 'channel:123',
+          channel: { id: '123', type: 'messaging' } as any,
+        };
+
+        createQueries = failsOnExecute();
+        // The channel row is there, so the failure is genuine and repairing nothing would help.
+        offlineDb.channelExists.mockResolvedValue(true);
+
+        await expect(
+          offlineDb.queriesWithChannelGuard({ event }, createQueries),
+        ).rejects.toThrow('FOREIGN KEY constraint failed');
+        expect(offlineDb.upsertChannelData).not.toHaveBeenCalled();
+        // Exactly one attempt: a broken statement must not be run twice.
+        expect(createQueries).toHaveBeenCalledTimes(1);
       });
 
       it('does not execute queries when execute is false', async () => {
@@ -474,6 +511,7 @@ describe('OfflineSupportApi', () => {
       });
 
       it('should reject if channelExists throws', async () => {
+        createQueries = failsOnExecute();
         offlineDb.channelExists.mockRejectedValue(new Error('DB failure'));
         const event: Event = {
           type: 'message.new',
@@ -488,6 +526,7 @@ describe('OfflineSupportApi', () => {
       });
 
       it('should reject if upsertChannelData throws when channelExists returns false', async () => {
+        createQueries = failsOnExecute();
         offlineDb.channelExists.mockResolvedValue(false);
         offlineDb.upsertChannelData.mockRejectedValue(new Error('Upsert failed'));
 
@@ -969,6 +1008,179 @@ describe('OfflineSupportApi', () => {
           expect(offlineDb.hardDeleteMessage).not.toHaveBeenCalled();
           expect(offlineDb.executeSqlBatch).not.toHaveBeenCalled();
           expect(result).toEqual([]);
+        });
+      });
+
+      describe('upsertMessageWithChannelGuard', () => {
+        beforeEach(() => {
+          offlineDb.upsertMessages.mockResolvedValue([['UPSERT message']]);
+          offlineDb.upsertChannelData.mockResolvedValue([['UPSERT channel']]);
+          offlineDb.executeSqlBatch.mockResolvedValue(undefined);
+        });
+
+        afterEach(() => {
+          vi.resetAllMocks();
+        });
+
+        const message = {
+          cid: 'messaging:c1',
+          id: 'm1',
+          status: 'failed',
+        } as LocalMessage;
+
+        /** What a foreign-key violation looks like: the direct write fails, building queries does not. */
+        const failWriteSucceedBuild = () => {
+          offlineDb.upsertMessages.mockImplementation(
+            async ({ execute }: { execute?: boolean }) => {
+              if (execute) throw new Error('FOREIGN KEY constraint failed');
+              return [['UPSERT message']];
+            },
+          );
+        };
+
+        it('writes the message directly, without probing for the channel row', async () => {
+          const result = await offlineDb.upsertMessageWithChannelGuard({ message });
+
+          // The lazy guard's whole point: no existence probe on the common path.
+          expect(offlineDb.channelExists).not.toHaveBeenCalled();
+          expect(offlineDb.upsertChannelData).not.toHaveBeenCalled();
+          expect(offlineDb.upsertMessages).toHaveBeenCalledWith({
+            messages: [message],
+            execute: true,
+          });
+          expect(result).toEqual([['UPSERT message']]);
+        });
+
+        it('creates the missing channel row and retries, in one batch', async () => {
+          failWriteSucceedBuild();
+          offlineDb.channelExists.mockResolvedValue(false);
+          client.activeChannels['messaging:c1'] = {
+            data: { cid: 'messaging:c1' },
+            initialized: true,
+            pendingDisposal: false,
+          } as never;
+
+          const result = await offlineDb.upsertMessageWithChannelGuard({ message });
+
+          // Ordering matters: the message insert would otherwise violate the foreign key again.
+          expect(result).toEqual([['UPSERT channel'], ['UPSERT message']]);
+          expect(offlineDb.executeSqlBatch).toHaveBeenCalledTimes(1);
+        });
+
+        it('rethrows a failure that is not a missing channel row, without retrying', async () => {
+          failWriteSucceedBuild();
+          offlineDb.channelExists.mockResolvedValue(true);
+
+          await expect(
+            offlineDb.upsertMessageWithChannelGuard({ message }),
+          ).rejects.toThrow('FOREIGN KEY constraint failed');
+          // A write that fails for some other reason must not be run a second time.
+          expect(offlineDb.upsertChannelData).not.toHaveBeenCalled();
+        });
+
+        it('skips the write when there is no channel row and nothing to build one from', async () => {
+          failWriteSucceedBuild();
+          offlineDb.channelExists.mockResolvedValue(false);
+          delete client.activeChannels['messaging:c1'];
+
+          const result = await offlineDb.upsertMessageWithChannelGuard({ message });
+
+          expect(offlineDb.upsertChannelData).not.toHaveBeenCalled();
+          expect(offlineDb.executeSqlBatch).not.toHaveBeenCalled();
+          expect(result).toEqual([]);
+        });
+
+        it('probes up front when execute is false, since there is no failure to catch', async () => {
+          offlineDb.channelExists.mockResolvedValue(true);
+
+          const result = await offlineDb.upsertMessageWithChannelGuard({
+            message,
+            execute: false,
+          });
+
+          expect(offlineDb.executeSqlBatch).not.toHaveBeenCalled();
+          expect(result).toEqual([['UPSERT message']]);
+        });
+
+        it('skips a message with no cid rather than guessing a channel', async () => {
+          const result = await offlineDb.upsertMessageWithChannelGuard({
+            message: { id: 'm1', status: 'failed' } as LocalMessage,
+          });
+
+          expect(offlineDb.channelExists).not.toHaveBeenCalled();
+          expect(offlineDb.upsertMessages).not.toHaveBeenCalled();
+          expect(result).toEqual([]);
+        });
+      });
+
+      describe('getFailedMessages', () => {
+        afterEach(() => {
+          vi.resetAllMocks();
+        });
+
+        it('returns only the locally failed messages of the channel', async () => {
+          offlineDb.state.partialNext({ initialized: true, userId: 'user-1' });
+          offlineDb.getChannels.mockResolvedValue([
+            {
+              messages: [
+                { id: 'sent', status: 'received', updated_at: new Date().toISOString() },
+                { id: 'unsent', status: 'failed', updated_at: new Date().toISOString() },
+                // No status at all — a plain server message, which must not be mistaken for unsent.
+                { id: 'plain', updated_at: new Date().toISOString() },
+              ],
+            },
+          ]);
+
+          const result = await offlineDb.getFailedMessages({ cid: 'messaging:c1' });
+
+          expect(offlineDb.getChannels).toHaveBeenCalledWith({
+            cids: ['messaging:c1'],
+            userId: 'user-1',
+          });
+          expect(result.map((message) => message.id)).toEqual(['unsent']);
+        });
+
+        it('formats the rows it returns', async () => {
+          offlineDb.state.partialNext({ initialized: true, userId: 'user-1' });
+          offlineDb.getChannels.mockResolvedValue([
+            {
+              messages: [
+                {
+                  created_at: '2024-01-01T00:00:00.000Z',
+                  id: 'unsent',
+                  status: 'failed',
+                  updated_at: '2024-01-01T00:00:00.000Z',
+                },
+              ],
+            },
+          ]);
+
+          const [failed] = await offlineDb.getFailedMessages({ cid: 'messaging:c1' });
+
+          // The paginator compares `updated_at` as a Date, so a raw storable row cannot be re-ingested.
+          expect(failed.created_at).toBeInstanceOf(Date);
+          expect(failed.updated_at).toBeInstanceOf(Date);
+        });
+
+        it('returns nothing when the channel is not in the database', async () => {
+          offlineDb.state.partialNext({ initialized: true, userId: 'user-1' });
+          offlineDb.getChannels.mockResolvedValue([]);
+
+          expect(await offlineDb.getFailedMessages({ cid: 'messaging:c1' })).toEqual([]);
+        });
+
+        it('does not query before the database is initialized', async () => {
+          offlineDb.state.partialNext({ initialized: false, userId: 'user-1' });
+
+          expect(await offlineDb.getFailedMessages({ cid: 'messaging:c1' })).toEqual([]);
+          expect(offlineDb.getChannels).not.toHaveBeenCalled();
+        });
+
+        it('does not query without a user', async () => {
+          offlineDb.state.partialNext({ initialized: true, userId: undefined });
+
+          expect(await offlineDb.getFailedMessages({ cid: 'messaging:c1' })).toEqual([]);
+          expect(offlineDb.getChannels).not.toHaveBeenCalled();
         });
       });
 

--- a/test/unit/offline-support/offline_support_api.test.ts
+++ b/test/unit/offline-support/offline_support_api.test.ts
@@ -3249,6 +3249,63 @@ describe('OfflineDBSyncManager', () => {
         expect(upsertUserSyncStatusSpy).toHaveBeenCalled();
       });
 
+      // `/sync` hands back the `WSEvent` union with its timestamps still raw, because the codegen
+      // emits no decoder for a model whose only decodable field is a union. They arrive as
+      // nanosecond integers, and `new Date(1786219962651957000)` overflows the Date range, so
+      // handing one to the mappers threw `RangeError: Date value out of bounds` — which the catch
+      // in `sync()` reads as the "too many events" API error and answers with `resetDB()`.
+      describe('decoding the events the sync API returns', () => {
+        const NANOS = 1786219962651957000;
+        const EXPECTED_MS = Math.floor(NANOS / 1000000);
+
+        const syncWithEvents = async (events: unknown[]) => {
+          const recentDate = new Date();
+          recentDate.setDate(recentDate.getDate() - 10);
+          getLastSyncedAtSpy.mockResolvedValueOnce(recentDate.toString());
+          syncApiSpy.mockResolvedValueOnce({ events });
+
+          await (syncManager as any).sync();
+
+          return handleEventSpy.mock.calls.map(([{ event }]) => event);
+        };
+
+        it('turns nanosecond timestamps into dates before anything persists them', async () => {
+          const [event] = await syncWithEvents([
+            {
+              type: 'message.new',
+              cid: 'messaging:test',
+              created_at: NANOS,
+              message: { id: 'msg-1', created_at: NANOS, updated_at: NANOS },
+            },
+          ]);
+
+          expect(event.created_at).toBeInstanceOf(Date);
+          expect(event.created_at.getTime()).toBe(EXPECTED_MS);
+          // The nested message is the part that actually gets written, so the decode has to recurse.
+          expect(event.message.created_at).toBeInstanceOf(Date);
+          expect(event.message.created_at.getTime()).toBe(EXPECTED_MS);
+          expect(event.message.updated_at).toBeInstanceOf(Date);
+        });
+
+        it('yields dates the mappers can serialize', async () => {
+          const [event] = await syncWithEvents([
+            { type: 'message.new', created_at: NANOS },
+          ]);
+
+          // Undecoded, this is the exact call that threw.
+          expect(() => new Date(event.created_at).toISOString()).not.toThrow();
+        });
+
+        it('passes an event type the spec does not know through rather than dropping it', async () => {
+          const events = await syncWithEvents([
+            { type: 'some.unpublished.event', created_at: NANOS },
+          ]);
+
+          expect(events).toHaveLength(1);
+          expect(events[0].type).toBe('some.unpublished.event');
+        });
+      });
+
       it('do not reset the DB if sync API throws an AxiosError with request timeout', async () => {
         const recentDate = new Date();
         recentDate.setDate(recentDate.getDate() - 10);

--- a/test/unit/offline-support/queueableOperations.test.ts
+++ b/test/unit/offline-support/queueableOperations.test.ts
@@ -86,6 +86,75 @@ describe('runQueueableOperation', () => {
   });
 });
 
+/**
+ * Which channel instance an operation runs on.
+ *
+ * `client.channel()` returns the cached instance only while it is in `activeChannels` and not
+ * `pendingDisposal` — otherwise it CONSTRUCTS one, paginators and subscriptions included. A first
+ * attempt always has the real instance in hand, so it must never go through that lookup.
+ */
+describe('channel resolution', () => {
+  const reactionTask = {
+    channelId: 'general',
+    channelType: 'messaging',
+    messageId: 'm1',
+    payload: [{ id: 'm1', reaction: { type: 'love' } }],
+    type: 'send-reaction',
+  } as unknown as PendingTask;
+
+  it("runs on the caller's own channel instance, without looking one up", async () => {
+    const callerChannel = { _sendReaction: vi.fn(async () => ({})) };
+    const lookup = vi.fn();
+    const client = { channel: lookup } as unknown as StreamChat;
+
+    await runQueueableOperation({
+      channel: callerChannel as never,
+      client,
+      task: reactionTask,
+    });
+
+    expect(callerChannel._sendReaction).toHaveBeenCalledWith({
+      id: 'm1',
+      reaction: { type: 'love' },
+    });
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it('resolves the channel from the task when there is no caller instance (a replay)', async () => {
+    const resolved = { _sendReaction: vi.fn(async () => ({})) };
+    const lookup = vi.fn(() => resolved);
+    const client = { channel: lookup } as unknown as StreamChat;
+
+    await runQueueableOperation({ client, task: reactionTask });
+
+    expect(lookup).toHaveBeenCalledWith('messaging', 'general');
+    expect(resolved._sendReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("still runs when the task carries no channel id, as long as the caller's instance is given", async () => {
+    // A `Channel` with no id yet cannot key a task, but a direct send on it has always worked.
+    const callerChannel = { _sendReaction: vi.fn(async () => ({})) };
+    const client = { channel: vi.fn() } as unknown as StreamChat;
+
+    await runQueueableOperation({
+      channel: callerChannel as never,
+      client,
+      task: { ...reactionTask, channelId: undefined } as unknown as PendingTask,
+    });
+
+    expect(callerChannel._sendReaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws for a replay of a channel-scoped task with no channel to resolve', async () => {
+    await expect(
+      runQueueableOperation({
+        client: { channel: vi.fn() } as unknown as StreamChat,
+        task: { ...reactionTask, channelId: undefined } as unknown as PendingTask,
+      }),
+    ).rejects.toThrow(/without a channel type and id/);
+  });
+});
+
 describe('queueOrRun', () => {
   it('returns the queued result and never runs the operation directly', async () => {
     const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));

--- a/test/unit/offline-support/queueableOperations.test.ts
+++ b/test/unit/offline-support/queueableOperations.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from 'vitest';
+import { chatLoggerSystem } from '../../../src/logger';
+import {
+  QUEUEABLE_OPERATIONS,
+  queueOrRun,
+  runQueueableOperation,
+} from '../../../src/offline-support/queueableOperations';
+import type { PendingTask, PendingTaskTypes, StreamChat } from '../../../src';
+
+/**
+ * `queueOrRun` resolves BOTH paths — queued and direct — through {@link QUEUEABLE_OPERATIONS}, so a
+ * first attempt and a replay cannot describe different requests. These tests drive it through the
+ * registry rather than a hand-supplied call, which is the point of the registry existing.
+ */
+const task = {
+  channelId: 'general',
+  channelType: 'messaging',
+  messageId: 'm1',
+  payload: [{ id: 'm1' }],
+  type: 'delete-message',
+} as unknown as PendingTask;
+
+const makeClient = ({
+  deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } })),
+  offlineDb,
+}: {
+  deleteMessage?: () => Promise<unknown>;
+  offlineDb?: unknown;
+} = {}) => ({ _deleteMessage: deleteMessage, offlineDb }) as unknown as StreamChat;
+
+const dbThatQueues = (result: unknown) => ({ queueTask: vi.fn(async () => result) });
+
+const dbThatRejects = (error = new Error('offline')) => ({
+  queueTask: vi.fn(async () => {
+    throw error;
+  }),
+});
+
+describe('QUEUEABLE_OPERATIONS', () => {
+  it('has a resolver for every queueable task type', () => {
+    // The mapped type makes a missing entry a compile error; this guards the other direction, i.e. a
+    // resolver quietly dropped from the object.
+    const declared: Array<PendingTaskTypes[keyof PendingTaskTypes]> = [
+      'create-draft',
+      'delete-draft',
+      'delete-message',
+      'delete-reaction',
+      'send-message',
+      'send-reaction',
+      'update-message',
+    ];
+
+    expect(Object.keys(QUEUEABLE_OPERATIONS).sort()).toEqual([...declared].sort());
+    for (const type of declared) {
+      expect(typeof QUEUEABLE_OPERATIONS[type].run).toBe('function');
+    }
+  });
+
+  it('declares replay-only follow-up work for send-message alone', () => {
+    // A first attempt has an optimistic layer above it that settles local state; a replay does not.
+    const withOnReplay = Object.entries(QUEUEABLE_OPERATIONS)
+      .filter(([, operation]) => operation.onReplay)
+      .map(([type]) => type);
+
+    expect(withOnReplay).toEqual(['send-message']);
+  });
+});
+
+describe('runQueueableOperation', () => {
+  it('resolves the task to its operation and runs it with the payload', async () => {
+    const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));
+    const client = makeClient({ deleteMessage });
+
+    await runQueueableOperation({ client, task });
+
+    expect(deleteMessage).toHaveBeenCalledWith({ id: 'm1' });
+  });
+
+  it('throws for a task type it has no resolver for', async () => {
+    await expect(
+      runQueueableOperation({
+        client: makeClient(),
+        task: { ...task, type: 'not-a-task' } as unknown as PendingTask,
+      }),
+    ).rejects.toThrow(/invalid pending task type/);
+  });
+});
+
+describe('queueOrRun', () => {
+  it('returns the queued result and never runs the operation directly', async () => {
+    const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));
+    const offlineDb = dbThatQueues('from queue');
+
+    await expect(
+      queueOrRun({
+        client: makeClient({ deleteMessage, offlineDb }),
+        task,
+      }),
+    ).resolves.toBe('from queue');
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('runs the operation directly when there is no offline DB', async () => {
+    const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));
+
+    await queueOrRun({
+      client: makeClient({ deleteMessage }),
+      task,
+    });
+
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the operation without queueing when the task cannot be queued', async () => {
+    // A send with no message id: it still has to go out, it just cannot be keyed in the queue.
+    const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));
+    const offlineDb = dbThatQueues('from queue');
+
+    await queueOrRun({
+      client: makeClient({ deleteMessage, offlineDb }),
+      queue: false,
+      task,
+    });
+
+    expect(offlineDb.queueTask).not.toHaveBeenCalled();
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs the queued failure as the operation declares, then runs it directly', async () => {
+    const error = new Error('offline');
+    const deleteMessage = vi.fn(async () => ({ message: { id: 'm1' } }));
+    const sink = vi.fn();
+    chatLoggerSystem.configureLoggers({ default: { level: 'trace', sink } });
+
+    try {
+      await queueOrRun({
+        client: makeClient({ deleteMessage, offlineDb: dbThatRejects(error) }),
+        task,
+      });
+    } finally {
+      chatLoggerSystem.restoreDefaults();
+    }
+
+    // Wording comes off `QUEUEABLE_OPERATIONS['delete-message'].logFailureAs`, not the caller.
+    expect(sink).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('Deleting the message failed.'),
+      { error },
+    );
+    expect(deleteMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the direct attempt error, unlike the queued one', async () => {
+    const directError = new Error('still offline');
+
+    await expect(
+      queueOrRun({
+        client: makeClient({
+          deleteMessage: async () => {
+            throw directError;
+          },
+          offlineDb: dbThatRejects(),
+        }),
+        task,
+      }),
+    ).rejects.toBe(directError);
+  });
+});

--- a/test/unit/reactions.optimistic.test.ts
+++ b/test/unit/reactions.optimistic.test.ts
@@ -35,6 +35,9 @@ const enableOfflineDb = (client: StreamChat) => {
   client.setOfflineDBApi(new MockOfflineDB({ client }));
   const db = client.offlineDb as MockOfflineDB;
   db.state.partialNext({ initialized: true });
+  // Nothing queued by default: `isQueuedForReplay` reads the pending-tasks table, so a test that wants
+  // the "pending, don't revert" behaviour has to put a task there.
+  db.getPendingTasks.mockResolvedValue([]);
   db.insertReaction.mockResolvedValue([]);
   db.updateReaction.mockResolvedValue([]);
   db.deleteReaction.mockResolvedValue([]);
@@ -215,14 +218,26 @@ describe('optimistic reactions', () => {
     });
   });
 
+  // What decides keep-vs-revert is whether the mutation is sitting in the offline queue, read from the
+  // pending-tasks table — NOT the shape of the error. In production the two coincide, because
+  // `queueTask` persists a task exactly when the error is retryable; these tests set the queue state
+  // each error would really produce.
   describe('keep-vs-revert with offline support', () => {
+    let db: MockOfflineDB;
+
     beforeEach(() => {
-      enableOfflineDb(client);
+      db = enableOfflineDb(client);
     });
+
+    const queueIsHolding = (messageId: string) =>
+      db.getPendingTasks.mockResolvedValue([
+        { id: 1, messageId, payload: [], type: 'send-reaction' },
+      ]);
 
     it('keeps the optimistic reaction on a network error (no response)', async () => {
       const message = buildMessage();
       seed(channel, message);
+      queueIsHolding(message.id);
       vi.spyOn(channel, 'sendReaction').mockRejectedValue(networkError());
 
       await expect(
@@ -238,6 +253,7 @@ describe('optimistic reactions', () => {
     it('keeps the optimistic reaction when the server responds with a retryable code', async () => {
       const message = buildMessage();
       seed(channel, message);
+      queueIsHolding(message.id);
       vi.spyOn(channel, 'sendReaction').mockRejectedValue(apiError(9));
 
       await expect(
@@ -397,6 +413,45 @@ describe('optimistic reactions', () => {
       expect(ownReactionTypes(channel.messagePaginator, reply.id)).toContain('love');
 
       await pending;
+    });
+
+    /**
+     * `Channel` and `Thread` delegate to one shared implementation, so what these two cover is the
+     * delegation itself: a thread routes its REQUEST through the parent channel (reactions are
+     * channel-level) while applying the local change by message id.
+     */
+    it('routes a thread-side reaction request through the parent channel', async () => {
+      const { reply, thread } = setupDualHomed();
+      const sendReaction = vi
+        .spyOn(channel, 'sendReaction')
+        .mockResolvedValue(apiReactionResponse(generateMsg({ id: reply.id })));
+      const threadSendReaction = vi.spyOn(thread.channel, 'sendReaction');
+
+      await thread.addReactionWithLocalUpdate({
+        messageId: reply.id,
+        reaction: { type: 'love' },
+      });
+
+      expect(sendReaction).toHaveBeenCalledWith({
+        id: reply.id,
+        reaction: { type: 'love' },
+      });
+      expect(threadSendReaction).toBe(sendReaction);
+    });
+
+    it('reverts a thread-side reaction on a terminal failure', async () => {
+      const { reply, thread } = setupDualHomed();
+      vi.spyOn(channel, 'sendReaction').mockRejectedValue(apiError(4));
+
+      await expect(
+        thread.addReactionWithLocalUpdate({
+          messageId: reply.id,
+          reaction: { type: 'love' },
+        }),
+      ).rejects.toThrow();
+
+      expect(ownReactionTypes(thread.messagePaginator, reply.id)).toEqual([]);
+      expect(ownReactionTypes(channel.messagePaginator, reply.id)).toEqual([]);
     });
 
     it('reverts both copies when the request fails', async () => {

--- a/test/unit/reminders/Reminder.test.ts
+++ b/test/unit/reminders/Reminder.test.ts
@@ -35,9 +35,14 @@ describe('Reminder', () => {
       updated_at: new Date(data.updated_at),
       timeLeftMs: scheduleOffsetMs,
     });
-    expect(Math.floor((reminderState!.timeLeftMs as number) / 1000)).toBe(
-      Math.floor((remindAtDate.getTime() - now.getTime()) / 1000),
-    );
+    // Compared with a tolerance, not floored-and-equal: `timeLeftMs` is sampled inside the constructor
+    // and `now` after it, so two independent clock reads straddling a whole-second boundary made this
+    // fail intermittently under full-suite load.
+    expect(
+      Math.abs(
+        (reminderState!.timeLeftMs as number) - (remindAtDate.getTime() - now.getTime()),
+      ),
+    ).toBeLessThan(1000);
     expect(reminder.timer).toBeInstanceOf(ReminderTimer);
     expect(reminder.timer.timeout).toEqual(expect.any(Object));
   });

--- a/test/unit/test-utils/generateMessage.ts
+++ b/test/unit/test-utils/generateMessage.ts
@@ -6,6 +6,8 @@ export const generateMsg = (
 ): MessageResponse => {
   const date = msg?.date ?? new Date();
   return {
+    cid: 'messaging:general',
+    pinned: false,
     id: uuidv4(),
     text: uuidv4(),
     html: '<p>x</p>\n',


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

`MessageOperationStatePolicy` is now operation-aware: `optimistic(kind, params)` returns what it wrote,
and `success` / `failure` take the `kind`, because the three operations genuinely want different state
transitions. Four new context members — `remove`, `persist`, `purge`, `isQueued` — are supplied by
`Channel` and `Thread` through a shared `createMessageOperationsPersistence`, so the two can't drift.
`MessageOperations.delete` now goes through the same `run()` lifecycle as the rest, which is why it had
no optimism before: it was the one operation sitting outside it.

The behaviour, which is deliberate and worth reviewing as such:

| | on a definitive failure | on a QUEUED (offline) failure |
|---|---|---|
| **edit** | keeps the edit, marks the message failed + error | keeps the edit, **no** failed state |
| **delete** | **reverts** | leaves the optimistic delete in place |
| **send / retry** | marks failed | still marks **failed** |

- **An edit is never reverted** — rolling it back would destroy text the user typed.
- **A delete is reverted**, because unlike an edit there is nothing of the user's to lose, and a
  "Message deleted" placeholder on a message that still exists is a lie that only self-corrects on the
  next query. The realistic trigger is offline support disabled with no connectivity: nothing is
  queued, so nothing was deleted.
- **The queued short-circuit is scoped to update/delete.** A queued *send* still settles `failed`,
  because the retry affordance is the only way the user gets that message out. This is v9 behaviour;
  treating it as merely pending leaves it spinning forever.
- Promises still reject in every failure case, deliberately, so an integrator's error notification keeps
  firing. Snackbar yes, failed state on the message no.

Reverts are guarded by object identity — `EntityStore.upsert` replaces the canonical copy, so
`get(id) === applied` is a sound "nothing else has written since" check, and a WS event landing
mid-flight is not clobbered.

### 2. A failed message now survives a restart

Sends write ahead to the offline DB **pessimistically as `failed`**, so a process death between compose
and server ack leaves a message that hydrates as failed-and-retryable rather than vanishing. Success
overwrites it.

V9 recovered failed messages by diffing a second, lagging copy of the list (the React SDK's own state).
With a single reactive source of truth there is no second copy, so the **persisted row is that buffer**:
`Channel.reload()` unions its in-memory failed messages with the DB's, in-memory winning.

Two new **concrete** helpers on `AbstractOfflineDB`, composed from existing primitives so a custom
offline DB inherits them and has nothing new to implement:

- `getFailedMessages({ cid })` — read back through `getChannels`.
- `upsertMessageWithChannelGuard({ message })` — upserts one message, creating its channel row first if
  the DB has never seen that channel, so the optimistic write can't fail on the foreign key.
  `updateMessage` can't serve this: it is an UPDATE and no-ops when the row doesn't exist, which is
  exactly the write-ahead case.

### 3. Bug fixes found along the way

**Editing or deleting a thread parent from inside a thread was a silent no-op.** The reply paginator's
local filter is `{ cid, parent_id }` and a parent message has no `parent_id`, so routing a parent edit
through the open thread's instance — which is what the SDKs do while a thread is on screen — handed it
to a collection that could not hold it. Optimistic writes now fall back to the client-global message
store, reaching the message wherever it is held and fanning out to every collection that holds it. Same
addressing `applyReactionLocally` already used.

**An empty request response no longer overwrites local state.** `formatMessage(undefined)` doesn't
throw — it returns `{ status: 'received', created_at: <now>, updated_at: <now> }`, and because that
`updated_at` is *now* it beat the freshness check and was ingested as an id-less message. Reachable from
a custom request handler that resolves without a `message`.

**The offline channel guard is lazy now.** It attempts the write first and only probes for the channel
row when the write fails, repairing and retrying once; every statement involved is an upsert, so the
retry is idempotent. The eager probe is kept for `execute: false` callers and for `forceUpdate`. This
matters because the probe is a native round-trip, not a cheap read — measured through op-sqlite on
device at ~0.5ms against ~8–12ms for the message upsert it protects, and it sat on every message
received as well as every message written.

**The optimistic layer owns the offline-DB row for deletes.** `client.deleteMessage` soft- or
hard-deleted the row *before* it queued the request: a second uncoordinated writer, the mirror moving
ahead of the state it mirrors, and — the live bug — **a custom `deleteMessageRequest` never reaches
`client.deleteMessage`**, so with one configured the row was never marked while memory showed the
message deleted. Moved into `policy.optimistic`, after the "nothing holds this message" guard, since the
DB mirrors local state and shouldn't be told about state that doesn't exist.

### 4. Queueable operations are declared in one place

`PendingTask`'s payload union was a hand-written seven-arm type kept in step with `executeTask`'s
seven-arm `if` ladder by hand — it carried a `// TODO: Please rethink the definition of PendingTasks as
it seems awkward`.

Each operation is now declared as **the method that performs it**:

```ts
export type QueueableOperationSignatures = {
  'send-message': Channel['_sendMessage'];
  'update-message': StreamChat['_updateMessage'];
  …
};
```

`PendingTask`'s payloads derive from that map, and `QUEUEABLE_OPERATIONS` is a mapped type over its
keys — so **a task type without a resolver does not compile**, rather than failing at runtime with
`Tried to execute invalid pending task type` the first time someone queues one.

Payload types are byte-identical to before (`Parameters<Channel['sendReaction']>` ≡
`Channel['_sendReaction']`), so tasks already serialized in a user's SQLite still deserialize. **No
migration.**

`executeTask` is a lookup now, and `onReplay` became a declared field — which makes visible that
`send-message` does thread `upsertReplyLocally` + `trackLastMessage` **only on a replay**, previously
buried in an `if (isPendingTask)`. The registry is `@internal` and not exported: it's a plain mutable
object, and exporting it would let an integrator reassign what a replay runs.

### Testing

### Risks / notes for review

## Changelog

- feat: optimistic updates for editing and deleting a message
- feat: a message that failed to send now survives an app restart and stays retryable
- fix: editing or deleting a thread parent from inside an open thread is no longer a silent no-op
- fix: an offline edit whose task the queue refuses (an attachment still on a local URL) now settles as
  failed instead of appearing pending forever
- fix: a custom `deleteMessageRequest` no longer leaves the offline-DB row unmarked
- fix: a request response carrying no message no longer overwrites local state with an id-less message
- perf: the offline channel guard attempts the write first and only probes for the channel row on
  failure, taking a native round-trip off every message written and every message received
- chore: queueable operations are declared in one typed registry, so a task type without a resolver is a
  compile error
