### PR TITLE
feat(MessageComposer): add composition middleware for pending attachment uploads

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,6 +9,7 @@ import {
   logChatPromiseExecution,
   messageSetPagination,
   normalizeQuerySort,
+  sanitizeOutgoingAttachments,
 } from './utils';
 import type { StreamChat } from './client';
 import { DEFAULT_QUERY_CHANNEL_MESSAGE_LIST_PAGE_SIZE } from './constants';
@@ -222,7 +223,9 @@ export class Channel {
     );
   }
 
-  async sendMessage(message: Message, options?: SendMessageOptions) {
+  async sendMessage(rawMessage: Message, options?: SendMessageOptions) {
+    const message = sanitizeOutgoingAttachments({ channel: this, message: rawMessage });
+
     try {
       const offlineDb = this.getClient().offlineDb;
       if (offlineDb) {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -213,19 +213,20 @@ export class Channel {
    *
    * @return {Promise<SendMessageAPIResponse>} The Server Response
    */
-  async _sendMessage(message: Message, options?: SendMessageOptions) {
-    return await this.getClient().post<SendMessageAPIResponse>(
-      this._channelURL() + '/message',
-      {
-        message,
-        ...options,
-      },
-    );
+  async _sendMessage(rawMessage: Message, options?: SendMessageOptions) {
+    const client = this.getClient();
+    const message = sanitizeOutgoingAttachments({
+      client,
+      message: rawMessage,
+    });
+
+    return await client.post<SendMessageAPIResponse>(this._channelURL() + '/message', {
+      message,
+      ...options,
+    });
   }
 
-  async sendMessage(rawMessage: Message, options?: SendMessageOptions) {
-    const message = sanitizeOutgoingAttachments({ channel: this, message: rawMessage });
-
+  async sendMessage(message: Message, options?: SendMessageOptions) {
     try {
       const offlineDb = this.getClient().offlineDb;
       if (offlineDb) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -36,6 +36,7 @@ import {
   normalizeQuerySort,
   randomId,
   retryInterval,
+  sanitizeOutgoingAttachments,
   sleep,
   toUpdatedMessagePayload,
 } from './utils';
@@ -3420,7 +3421,12 @@ export class StreamChat {
     }
 
     // should not include user object
-    const payload = toUpdatedMessagePayload(message);
+    // Sanitized at the point of sending, which is the only place every path converges: the
+    // offline replay of a queued `update-message` task calls this method directly.
+    const payload = sanitizeOutgoingAttachments({
+      client: this,
+      message: toUpdatedMessagePayload(message),
+    });
 
     // add user_id (if exists)
     if (typeof partialUserOrUserId === 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,3 +62,15 @@ export {
   promoteChannel,
 } from './utils';
 export { FixedSizeQueueCache } from './utils/FixedSizeQueueCache';
+/**
+ * Tag-keyed async runners. Exported so the UI SDKs (and integrators) serialize their own
+ * actions with the same primitive the SDK uses internally instead of hand-rolling promise
+ * chains. Tags share one process-wide map, so namespace yours (`my-app/thing/${id}`) to avoid
+ * colliding with another caller's.
+ */
+export {
+  hasPending,
+  settled,
+  withCancellation,
+  withoutConcurrency,
+} from './utils/concurrency';

--- a/src/messageComposer/attachmentIdentity.ts
+++ b/src/messageComposer/attachmentIdentity.ts
@@ -1,5 +1,6 @@
 import type { Attachment, SharedLocationResponse } from '../types';
 import type {
+  AttachmentLoadingState,
   AudioAttachment,
   FileAttachment,
   GiphyAttachment,
@@ -30,8 +31,14 @@ export const isLocalUploadAttachment = (
 /**
  * Upload states meaning "the bytes are not on the CDN yet, but they are on their way".
  * `blocked` and `failed` are excluded - those never resolve on their own.
+ *
+ * Typed against {@link AttachmentLoadingState} rather than `string`, so renaming a state fails
+ * the build instead of silently making this list match nothing - it decides what gets sent.
  */
-const PENDING_UPLOAD_STATES: ReadonlyArray<string> = ['pending', 'uploading'];
+const PENDING_UPLOAD_STATES: ReadonlyArray<AttachmentLoadingState> = [
+  'pending',
+  'uploading',
+];
 
 /** Whether an upload for this attachment is still expected to resolve. */
 export const isPendingUpload = (

--- a/src/messageComposer/attachmentIdentity.ts
+++ b/src/messageComposer/attachmentIdentity.ts
@@ -27,6 +27,26 @@ export const isLocalUploadAttachment = (
 ): attachment is LocalUploadAttachment =>
   !!(attachment as LocalAttachment)?.localMetadata?.uploadState;
 
+/**
+ * Upload states meaning "the bytes are not on the CDN yet, but they are on their way".
+ * `blocked` and `failed` are excluded - those never resolve on their own.
+ */
+const PENDING_UPLOAD_STATES: ReadonlyArray<string> = ['pending', 'uploading'];
+
+/** Whether an upload for this attachment is still expected to resolve. */
+export const isPendingUpload = (
+  attachment: unknown,
+): attachment is LocalUploadAttachment =>
+  isLocalUploadAttachment(attachment) &&
+  PENDING_UPLOAD_STATES.includes(attachment.localMetadata.uploadState);
+
+/** Whether this attachment's upload already resolved to a URL. */
+export const isFinishedUpload = (
+  attachment: unknown,
+): attachment is LocalUploadAttachment =>
+  isLocalUploadAttachment(attachment) &&
+  attachment.localMetadata.uploadState === 'finished';
+
 export const isFileAttachment = (
   attachment: Attachment | LocalAttachment,
   supportedVideoFormat: string[] = [],

--- a/src/messageComposer/attachmentManager.ts
+++ b/src/messageComposer/attachmentManager.ts
@@ -27,6 +27,7 @@ import type {
   FileLike,
   FileReference,
   LocalAttachment,
+  LocalAttachmentUploadMetadata,
   LocalNotImageAttachment,
   LocalUploadAttachment,
   UploadPermissionCheckResult,
@@ -34,6 +35,7 @@ import type {
 import type { ChannelResponse, DraftMessage, LocalMessage } from '../types';
 import type { MessageComposer } from './messageComposer';
 import { mergeWithDiff } from '../utils/mergeWith';
+import { isUploadCancellation } from '../uploadManager';
 
 export type FileUploadFilter = (file: Partial<LocalUploadAttachment>) => boolean;
 
@@ -233,6 +235,7 @@ export class AttachmentManager {
       ...attachment,
       localMetadata: {
         ...attachment.localMetadata,
+        uploadConfirmationPending: false,
         uploadProgress: undefined,
         uploadState: 'failed',
       },
@@ -332,8 +335,27 @@ export class AttachmentManager {
     }
   };
 
+  /**
+   * Releases a local preview URL the SDK minted, if it minted one.
+   *
+   * Only `blob:` URLs are ours to revoke: `toLocalUploadAttachment` puts a
+   * `URL.createObjectURL` result in `previewUri` for a `File`, but for a React Native
+   * `FileReference` it stores the caller's own native file URI, which must be left alone.
+   */
+  private revokePreviewUri = (attachment: LocalAttachment) => {
+    const previewUri = (
+      attachment.localMetadata as Partial<LocalAttachmentUploadMetadata>
+    )?.previewUri;
+
+    if (previewUri?.startsWith('blob:')) URL.revokeObjectURL?.(previewUri);
+  };
+
   removeAttachments = (localAttachmentIds: string[]) => {
     if (!localAttachmentIds.length) return;
+
+    const removedAttachments = this.attachments.filter((attachment) =>
+      localAttachmentIds.includes(attachment.localMetadata?.id),
+    );
 
     this.state.partialNext({
       attachments: this.attachments.filter(
@@ -344,6 +366,18 @@ export class AttachmentManager {
     for (const id of localAttachmentIds) {
       this.client.uploadManager.deleteUploadRecord(id);
     }
+
+    // Removal is the end of the line for these attachments, so the preview blob goes with
+    // them - otherwise every removed (or cancelled mid-upload) attachment leaks one blob URL
+    // until the page unloads. Revoked after the record is deleted, so nothing is still
+    // rendering from it.
+    //
+    // Deliberately not done in `initState`/`restoreSnapshot`: those drop the composer's *view*
+    // of the attachments without ending their life. A finished upload has already had its
+    // `previewUri` revoked and removed by the post-upload middleware, and an unfinished one may
+    // still be rendered by whoever took it over (an optimistic message sent with the upload
+    // still in flight, for instance).
+    removedAttachments.forEach(this.revokePreviewUri);
   };
 
   getUploadConfigCheck = async (
@@ -619,21 +653,30 @@ export class AttachmentManager {
           ...attachment.localMetadata,
           uploadState: 'failed',
           uploadProgress: undefined,
+          // `false`, not `undefined`: these updates go through `updateAttachment`, which merges
+          // via `mergeWith` — and that skips `undefined` source values, so `undefined` would
+          // leave a stale `true` in place.
+          uploadConfirmationPending: false,
         },
       };
 
-      this.client.notifications.addError({
-        message: 'Error uploading attachment',
-        origin: {
-          emitter: 'AttachmentManager',
-          context: { attachment, failedAttachment },
-        },
-        options: {
-          type: 'api:attachment:upload:failed',
-          metadata: { reason },
-          originalError: error instanceof Error ? error : undefined,
-        },
-      });
+      // A cancellation is the user getting what they asked for, so it gets no error
+      // notification. This path predates the post-upload middleware chain and notifies
+      // directly, so it needs the same guard `createUploadErrorHandlerMiddleware` applies.
+      if (!isUploadCancellation(error)) {
+        this.client.notifications.addError({
+          message: 'Error uploading attachment',
+          origin: {
+            emitter: 'AttachmentManager',
+            context: { attachment, failedAttachment },
+          },
+          options: {
+            type: 'api:attachment:upload:failed',
+            metadata: { reason },
+            originalError: error instanceof Error ? error : undefined,
+          },
+        });
+      }
 
       this.updateAttachment(failedAttachment);
       return failedAttachment;
@@ -654,6 +697,8 @@ export class AttachmentManager {
         ...attachment.localMetadata,
         uploadState: 'finished',
         uploadProgress: undefined,
+        // See the note in the failure branch: `undefined` cannot clear through `mergeWith`.
+        uploadConfirmationPending: false,
       },
     };
 
@@ -715,6 +760,8 @@ export class AttachmentManager {
             ...attachment.localMetadata,
             uploadState: error ? 'failed' : 'finished',
             uploadProgress: undefined,
+            // See the note in `uploadAttachment`: `undefined` cannot clear through `mergeWith`.
+            uploadConfirmationPending: false,
           },
         },
         error,
@@ -759,6 +806,7 @@ export class AttachmentManager {
           ...attachment.localMetadata,
           uploadState: 'uploading',
           uploadProgress: this.config.trackUploadProgress ? 0 : undefined,
+          uploadConfirmationPending: false,
         },
       },
     ]);
@@ -773,6 +821,7 @@ export class AttachmentManager {
             ...attachment.localMetadata,
             uploadState: 'uploading',
             uploadProgress: nextUpload.uploadProgress,
+            uploadConfirmationPending: nextUpload.uploadConfirmationPending,
           },
         });
       },

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -434,44 +434,49 @@ export class MessageComposer extends WithSubscriptions {
   }
 
   /**
-   * Sendability for a UI SDK that supports sending while attachments are still uploading.
+   * Whether the installed composition middleware composes messages whose uploads are still in
+   * flight — see `MessageCompositionMiddleware.allowsPendingUploads`.
    *
-   * Differs from {@link hasSendableData} in that an upload in flight does not block the send, and
-   * a pending attachment counts as content in its own right — otherwise an attachment-only
-   * message could never be sent before its upload finished, which is the point of the flow.
-   * `failed` and `blocked` attachments still do not count: a message whose only attachment was
-   * rejected must not look sendable.
+   * Derived from the chain rather than from config, so there is exactly one switch: the UI SDK
+   * that implements the rest of the flow installs the middleware, and everything that has to
+   * follow from that (starting with {@link hasSendableData}) follows on its own.
    *
-   * Read this instead of `hasSendableData` when
-   * {@link createSendWithPendingUploadsAttachmentsMiddleware} is installed. There is no config
-   * option choosing between the two — the switch belongs to the UI SDK that implements the flow.
+   * **Temporary API.** In v10 sending with pending uploads becomes part of the composer
+   * configuration (`MessageComposerConfig`, set through `updateConfig`), and this getter,
+   * together with the middleware declaration it reads, is replaced by that config field.
    */
-  get hasSendableDataWithPendingUploads() {
-    const hasSendableAttachment = this.attachmentManager.attachments.some(
-      (attachment) => isFinishedUpload(attachment) || isPendingUpload(attachment),
-    );
-
-    return (
-      this.isCommandSendable &&
-      !!(
-        !this.textComposer.textIsEmpty ||
-        hasSendableAttachment ||
-        this.pollId ||
-        this.locationComposer.validLocation
-      )
+  get allowsPendingUploads() {
+    return this.compositionMiddlewareExecutor.installedMiddleware.some(
+      (middleware) => middleware.allowsPendingUploads,
     );
   }
 
   get hasSendableData() {
-    return (
-      this.isCommandSendable &&
-      !!(
-        (!this.attachmentManager.uploadsInProgressCount &&
-          (!this.textComposer.textIsEmpty ||
-            this.attachmentManager.successfulUploadsCount > 0)) ||
+    if (!this.isCommandSendable) return false;
+
+    if (this.allowsPendingUploads) {
+      // An upload in flight is no longer a blocker, and a pending attachment counts as content
+      // in its own right — otherwise an attachment-only message could never be sent before its
+      // upload finished, which is the point of the flow. `failed` and `blocked` attachments
+      // still do not count: a message whose only attachment was rejected must not look sendable.
+      const hasSendableAttachment = this.attachmentManager.attachments.some(
+        (attachment) => isFinishedUpload(attachment) || isPendingUpload(attachment),
+      );
+
+      return !!(
+        !this.textComposer.textIsEmpty ||
+        hasSendableAttachment ||
         this.pollId ||
-        !!this.locationComposer.validLocation
-      )
+        this.locationComposer.validLocation
+      );
+    }
+
+    return !!(
+      (!this.attachmentManager.uploadsInProgressCount &&
+        (!this.textComposer.textIsEmpty ||
+          this.attachmentManager.successfulUploadsCount > 0)) ||
+      this.pollId ||
+      !!this.locationComposer.validLocation
     );
   }
 

--- a/src/messageComposer/messageComposer.ts
+++ b/src/messageComposer/messageComposer.ts
@@ -1,4 +1,5 @@
 import { AttachmentManager } from './attachmentManager';
+import { isFinishedUpload, isPendingUpload } from './attachmentIdentity';
 import { CustomDataManager } from './CustomDataManager';
 import { LinkPreviewsManager } from './linkPreviewsManager';
 import { LocationComposer } from './LocationComposer';
@@ -430,6 +431,35 @@ export class MessageComposer extends WithSubscriptions {
   get isCommandSendable() {
     const currentCommand = this.textComposer.command;
     return !currentCommand || this.validateCommandSendability(currentCommand).ready;
+  }
+
+  /**
+   * Sendability for a UI SDK that supports sending while attachments are still uploading.
+   *
+   * Differs from {@link hasSendableData} in that an upload in flight does not block the send, and
+   * a pending attachment counts as content in its own right — otherwise an attachment-only
+   * message could never be sent before its upload finished, which is the point of the flow.
+   * `failed` and `blocked` attachments still do not count: a message whose only attachment was
+   * rejected must not look sendable.
+   *
+   * Read this instead of `hasSendableData` when
+   * {@link createSendWithPendingUploadsAttachmentsMiddleware} is installed. There is no config
+   * option choosing between the two — the switch belongs to the UI SDK that implements the flow.
+   */
+  get hasSendableDataWithPendingUploads() {
+    const hasSendableAttachment = this.attachmentManager.attachments.some(
+      (attachment) => isFinishedUpload(attachment) || isPendingUpload(attachment),
+    );
+
+    return (
+      this.isCommandSendable &&
+      !!(
+        !this.textComposer.textIsEmpty ||
+        hasSendableAttachment ||
+        this.pollId ||
+        this.locationComposer.validLocation
+      )
+    );
   }
 
   get hasSendableData() {

--- a/src/messageComposer/middleware/attachmentManager/postUpload/AttachmentPostUploadMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/AttachmentPostUploadMiddlewareExecutor.ts
@@ -14,7 +14,7 @@ export class AttachmentPostUploadMiddlewareExecutor extends MiddlewareExecutor<
     super();
     this.use([
       createUploadErrorHandlerMiddleware(composer),
-      createPostUploadAttachmentEnrichmentMiddleware(),
+      createPostUploadAttachmentEnrichmentMiddleware(composer),
     ]);
   }
 }

--- a/src/messageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.ts
@@ -4,41 +4,66 @@ import type {
   AttachmentPostUploadMiddlewareState,
 } from '../types';
 import { isLocalImageAttachment } from '../../../attachmentIdentity';
+import type { MessageComposer } from '../../../messageComposer';
 import type { LocalNotImageAttachment } from '../../../types';
 
-export const createPostUploadAttachmentEnrichmentMiddleware =
-  (): AttachmentPostUploadMiddleware => ({
-    id: 'stream-io/attachment-manager-middleware/post-upload-enrichment',
-    handlers: {
-      postProcess: ({
-        state,
-        discard,
-        forward,
-        next,
-      }: MiddlewareHandlerParams<AttachmentPostUploadMiddlewareState>) => {
-        const { attachment, error, response } = state;
-        if (error) return forward();
-        if (!attachment || !response) return discard();
+/**
+ * Writes the uploaded URL onto the attachment and releases its local preview.
+ *
+ * The preview is a blob URL the composer created for the file. Releasing it once the CDN URL is
+ * in is what keeps the browser from holding the file in memory.
+ *
+ * Pass `composer` and the preview is released only while the attachment is still one of the
+ * composer's own — still listed in `attachmentManager.attachments`, i.e. still shown above the
+ * input, waiting to be sent.
+ *
+ * This runs when an upload finishes, which can be after the composer was cleared: `uploadFile`
+ * executes this chain before the (by then no-op) `updateAttachment`. If the attachment is gone
+ * from the composer, a message is rendering from the preview instead, and releasing it would
+ * blank that message out. A message can be sent with uploads still running — see
+ * `createSendWithPendingUploadsAttachmentsMiddleware`.
+ *
+ * Omit `composer` and the preview is always released.
+ */
+export const createPostUploadAttachmentEnrichmentMiddleware = (
+  composer?: MessageComposer,
+): AttachmentPostUploadMiddleware => ({
+  id: 'stream-io/attachment-manager-middleware/post-upload-enrichment',
+  handlers: {
+    postProcess: ({
+      state,
+      discard,
+      forward,
+      next,
+    }: MiddlewareHandlerParams<AttachmentPostUploadMiddlewareState>) => {
+      const { attachment, error, response } = state;
+      if (error) return forward();
+      if (!attachment || !response) return discard();
 
-        const enrichedAttachment = { ...attachment };
-        const previewUri = attachment.localMetadata.previewUri;
-        if (previewUri) {
-          if (previewUri.startsWith('blob:')) URL.revokeObjectURL(previewUri);
-          delete enrichedAttachment.localMetadata.previewUri;
-        }
-        if (isLocalImageAttachment(attachment)) {
-          enrichedAttachment.image_url = response.file;
-        } else {
-          (enrichedAttachment as LocalNotImageAttachment).asset_url = response.file;
-        }
-        if (response.thumb_url) {
-          (enrichedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
-        }
+      const enrichedAttachment = { ...attachment };
+      const { id, previewUri } = attachment.localMetadata;
+      // `attachmentsById` is built from the composer's current attachment state, so a hit means
+      // the attachment is still in the composer and its preview is not in use elsewhere.
+      const attachmentIsStillInComposer =
+        !composer || !!composer.attachmentManager.attachmentsById[id];
 
-        return next({
-          ...state,
-          attachment: enrichedAttachment,
-        });
-      },
+      if (previewUri && attachmentIsStillInComposer) {
+        if (previewUri.startsWith('blob:')) URL.revokeObjectURL?.(previewUri);
+        delete enrichedAttachment.localMetadata.previewUri;
+      }
+      if (isLocalImageAttachment(attachment)) {
+        enrichedAttachment.image_url = response.file;
+      } else {
+        (enrichedAttachment as LocalNotImageAttachment).asset_url = response.file;
+      }
+      if (response.thumb_url) {
+        (enrichedAttachment as LocalNotImageAttachment).thumb_url = response.thumb_url;
+      }
+
+      return next({
+        ...state,
+        attachment: enrichedAttachment,
+      });
     },
-  });
+  },
+});

--- a/src/messageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.ts
+++ b/src/messageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.ts
@@ -4,6 +4,7 @@ import type {
   AttachmentPostUploadMiddleware,
   AttachmentPostUploadMiddlewareState,
 } from '../types';
+import { isUploadCancellation } from '../../../../uploadManager';
 
 export const createUploadErrorHandlerMiddleware = (
   composer: MessageComposer,
@@ -18,6 +19,9 @@ export const createUploadErrorHandlerMiddleware = (
       const { attachment, error } = state;
       if (!error) return forward();
       if (!attachment) return discard();
+      // A cancellation is the user getting what they asked for, so it gets no error
+      // notification. `StreamChat.doAxiosRequest` draws the same line for the same reason.
+      if (isUploadCancellation(error)) return forward();
 
       const reason = error instanceof Error ? error.message : 'unknown error';
       composer.client.notifications.addError({

--- a/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
+++ b/src/messageComposer/middleware/messageComposer/MessageComposerMiddlewareExecutor.ts
@@ -23,6 +23,7 @@ import { createCompositionDataCleanupMiddleware } from './cleanData';
 import type {
   MessageComposerMiddlewareExecutorOptions,
   MessageComposerMiddlewareState,
+  MessageCompositionMiddleware,
   MessageDraftComposerMiddlewareExecutorOptions,
   MessageDraftComposerMiddlewareValueState,
 } from './types';
@@ -54,6 +55,14 @@ export class MessageComposerMiddlewareExecutor extends MiddlewareExecutor<
       createCompositionValidationMiddleware(composer),
       createCompositionDataCleanupMiddleware(composer),
     ]);
+  }
+
+  /**
+   * Narrows the base accessor to the composition middleware type, so callers can read the
+   * declarations it carries (`allowsPendingUploads`) without casting.
+   */
+  get installedMiddleware(): ReadonlyArray<MessageCompositionMiddleware> {
+    return super.installedMiddleware as ReadonlyArray<MessageCompositionMiddleware>;
   }
 }
 

--- a/src/messageComposer/middleware/messageComposer/attachments.ts
+++ b/src/messageComposer/middleware/messageComposer/attachments.ts
@@ -61,16 +61,24 @@ const composeWithPendingUploads = ({
 
   if (!localAttachments.length && !messageAttachments.length) return state;
 
+  // Each payload gets the `attachments` key only when there is something to put in it, matching
+  // the default middleware. An empty array is not "nothing to say": on an edit the API reads it
+  // as "remove every attachment", and a message whose uploads are all still in flight produces
+  // exactly that - no finished upload to put in `message.attachments` yet.
   return {
     ...state,
-    localMessage: {
-      ...state.localMessage,
-      attachments: localAttachments,
-    },
-    message: {
-      ...state.message,
-      attachments: messageAttachments,
-    },
+    localMessage: localAttachments.length
+      ? {
+          ...state.localMessage,
+          attachments: localAttachments,
+        }
+      : state.localMessage,
+    message: messageAttachments.length
+      ? {
+          ...state.message,
+          attachments: messageAttachments,
+        }
+      : state.message,
   };
 };
 

--- a/src/messageComposer/middleware/messageComposer/attachments.ts
+++ b/src/messageComposer/middleware/messageComposer/attachments.ts
@@ -95,16 +95,20 @@ const composeWithPendingUploads = ({
  * wire — `message.attachments` omits everything that has no URL yet. Whoever performs the send
  * has to await those uploads (`UploadManager.upload` is idempotent by `localMetadata.id`, so
  * calling it again returns the in-flight promise), write the resolved URLs in, and send after
- * that. Sendability has to be relaxed too, or the send can never be triggered — see
- * {@link MessageComposer.hasSendableDataWithPendingUploads}.
+ * that.
+ *
+ * Sendability follows on its own: the `allowsPendingUploads` declaration below is what
+ * {@link MessageComposer.hasSendableData} reads to stop treating an upload in flight as a
+ * blocker, so installing this middleware is the only switch there is.
  *
  * This is why there is no config option turning it on: the switch belongs to the UI SDK that
- * implements the other half. stream-chat-react exposes it as a `Channel` prop;
+ * implements the other half. stream-chat-react exposes it as a `Chat` prop;
  * stream-chat-react-native as `allowSendBeforeAttachmentsUpload` on the message input.
  */
 export const createSendWithPendingUploadsAttachmentsMiddleware = (
   composer: MessageComposer,
 ): MessageCompositionMiddleware => ({
+  allowsPendingUploads: true,
   id: 'stream-io/message-composer-middleware/attachments',
   handlers: {
     compose: ({

--- a/src/messageComposer/middleware/messageComposer/attachments.ts
+++ b/src/messageComposer/middleware/messageComposer/attachments.ts
@@ -1,3 +1,4 @@
+import { isFinishedUpload, isPendingUpload } from '../../attachmentIdentity';
 import type { MiddlewareHandlerParams } from '../../../middleware';
 import type { Attachment } from '../../../types';
 import type { MessageComposer } from '../../messageComposer';
@@ -14,6 +15,102 @@ const localAttachmentToAttachment = (localAttachment: LocalAttachment) => {
   const { localMetadata, ...attachment } = localAttachment;
   return attachment as Attachment;
 };
+
+/**
+ * The composition step used by {@link createSendWithPendingUploadsAttachmentsMiddleware}.
+ *
+ * The two payloads part ways here: `localMessage.attachments` keeps `localMetadata` for
+ * anything still uploading - `id` (the `client.uploadManager` key), `file` (the handle needed
+ * to await the upload) and `previewUri` (so the message list can render the user's own file
+ * meanwhile) - while `message.attachments`, which goes to the API, carries only attachments
+ * that already resolved to a URL. Whoever performs the send fills in the rest once the uploads
+ * settle.
+ */
+const composeWithPendingUploads = ({
+  composer,
+  state,
+}: {
+  composer: MessageComposer;
+  state: MessageComposerMiddlewareState;
+}): MessageComposerMiddlewareState => {
+  // `useSubmitHandler` in the UI SDKs deliberately skips `MessageComposer.clear()` when the
+  // composition carries a poll - it keeps the composer's contents as a draft. Handing a
+  // still-uploading attachment to such a message would leave the same `localMetadata.id` owned
+  // by both the sent message and the composer: the user could send it a second time, and the
+  // second `UploadManager.upload` call would restart the request under an id whose in-flight
+  // entry had already been cleaned up. So a pending upload stays in the composer in that case
+  // and rides along with the next message once it finishes.
+  const composerIsKeptAsDraft = !!composer.pollId;
+
+  // Composer order is preserved in both payloads so previews do not reshuffle when an upload
+  // settles.
+  const relevantAttachments = composer.attachmentManager.attachments.filter(
+    (attachment) =>
+      isFinishedUpload(attachment) ||
+      (!composerIsKeptAsDraft && isPendingUpload(attachment)),
+  );
+
+  const localAttachments = (state.localMessage.attachments ?? []).concat(
+    relevantAttachments.map((attachment) =>
+      isPendingUpload(attachment) ? attachment : localAttachmentToAttachment(attachment),
+    ),
+  );
+  const messageAttachments = (state.message.attachments ?? []).concat(
+    relevantAttachments.filter(isFinishedUpload).map(localAttachmentToAttachment),
+  );
+
+  if (!localAttachments.length && !messageAttachments.length) return state;
+
+  return {
+    ...state,
+    localMessage: {
+      ...state.localMessage,
+      attachments: localAttachments,
+    },
+    message: {
+      ...state.message,
+      attachments: messageAttachments,
+    },
+  };
+};
+
+/**
+ * Drop-in replacement for {@link createAttachmentsCompositionMiddleware} that lets a message be
+ * composed while its attachments are still uploading.
+ *
+ * Reuses the same middleware id, so installing it with
+ * `compositionMiddlewareExecutor.replace([...])` keeps its position in the chain. The default
+ * refuses instead: it warns "Wait until all attachments have uploaded" and discards the
+ * composition.
+ *
+ * **Installing this is only half of the flow.** The composition it produces is not ready for the
+ * wire — `message.attachments` omits everything that has no URL yet. Whoever performs the send
+ * has to await those uploads (`UploadManager.upload` is idempotent by `localMetadata.id`, so
+ * calling it again returns the in-flight promise), write the resolved URLs in, and send after
+ * that. Sendability has to be relaxed too, or the send can never be triggered — see
+ * {@link MessageComposer.hasSendableDataWithPendingUploads}.
+ *
+ * This is why there is no config option turning it on: the switch belongs to the UI SDK that
+ * implements the other half. stream-chat-react exposes it as a `Channel` prop;
+ * stream-chat-react-native as `allowSendBeforeAttachmentsUpload` on the message input.
+ */
+export const createSendWithPendingUploadsAttachmentsMiddleware = (
+  composer: MessageComposer,
+): MessageCompositionMiddleware => ({
+  id: 'stream-io/message-composer-middleware/attachments',
+  handlers: {
+    compose: ({
+      state,
+      next,
+      forward,
+    }: MiddlewareHandlerParams<MessageComposerMiddlewareState>) => {
+      const { attachmentManager } = composer;
+      if (!attachmentManager) return forward();
+
+      return next(composeWithPendingUploads({ composer, state }));
+    },
+  },
+});
 
 export const createAttachmentsCompositionMiddleware = (
   composer: MessageComposer,

--- a/src/messageComposer/middleware/messageComposer/types.ts
+++ b/src/messageComposer/middleware/messageComposer/types.ts
@@ -32,7 +32,28 @@ export type MessageDraftComposerMiddlewareExecutorOptions = {
 export type MessageCompositionMiddleware = Middleware<
   MessageComposerMiddlewareState,
   'compose'
->;
+> & {
+  /**
+   * Declares that this middleware composes messages whose attachment uploads are still in
+   * flight, instead of refusing to compose until they finish.
+   *
+   * {@link MessageComposer.hasSendableData} reads this: an upload in flight must not block the
+   * send while such a middleware is installed, or the send could never be triggered. Any
+   * middleware implementing that contract may set it - the composer keys off the declaration,
+   * not off a middleware id, so a custom implementation is treated the same as the one shipped
+   * here.
+   *
+   * Composing this way is only half of the flow: whoever performs the send has to await those
+   * uploads and write the resolved URLs into the payload. See
+   * {@link createSendWithPendingUploadsAttachmentsMiddleware}.
+   *
+   * **Temporary API.** In v10 sending with pending uploads becomes part of the composer
+   * configuration (`MessageComposerConfig`, set through `updateConfig`), and this declaration,
+   * together with {@link MessageComposer.allowsPendingUploads}, is replaced by that config
+   * field.
+   */
+  allowsPendingUploads?: boolean;
+};
 
 export type MessageDraftCompositionMiddleware = Middleware<
   MessageDraftComposerMiddlewareValueState,

--- a/src/messageComposer/types.ts
+++ b/src/messageComposer/types.ts
@@ -119,6 +119,11 @@ export type LocalAttachmentUploadMetadata = {
    */
   previewUri?: string;
   uploadState: AttachmentLoadingState;
+  /**
+   * Mirrors {@link UploadRecord.uploadConfirmationPending}: every byte has been sent, but the server has
+   * not confirmed yet - not returned response to the upload request. Render an indeterminate indicator rather than a full bar.
+   */
+  uploadConfirmationPending?: boolean;
   uploadPermissionCheck?: UploadPermissionCheckResult; // added new
   /** 0–100 while uploading when progress tracking is enabled; undefined otherwise or when indeterminate */
   uploadProgress?: number;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -58,6 +58,17 @@ export class MiddlewareExecutor<TValue, THandlers extends string> {
     this.id = generateUUIDv4();
   }
 
+  /**
+   * The middleware currently installed, in execution order.
+   *
+   * Read-only: use `use` / `insert` / `replace` / `setOrder` / `remove` to change the chain. It
+   * exists so components can ask what the chain is capable of - a middleware may declare
+   * behaviour its host has to account for, and the host has no other way to find out.
+   */
+  get installedMiddleware(): ReadonlyArray<Middleware<TValue, THandlers>> {
+    return this.middleware;
+  }
+
   use(middleware: Middleware<TValue, THandlers> | Middleware<TValue, THandlers>[]) {
     this.middleware = this.middleware.concat(middleware);
     return this;

--- a/src/uploadManager.ts
+++ b/src/uploadManager.ts
@@ -168,12 +168,18 @@ export class UploadManager {
         const onProgress = trackProgress
           ? (progress?: number) => {
               this.updateUpload({
-                // The record is removed in the `finally` below, so a record that still exists
-                // while reporting 100% can only mean "flushed, awaiting the response".
-                uploadConfirmationPending:
-                  typeof progress === 'number' && progress >= 100,
                 id,
                 uploadProgress: progress,
+                // Only a number says anything about the flush, so a report without one leaves
+                // the flag alone: `undefined` means the transport cannot measure this upload,
+                // not that bytes were un-sent. Lowering it there would drop a UI that had
+                // already gone indeterminate back to a determinate one with nothing to show.
+                //
+                // The record is removed in the `finally` below, so a record that still exists
+                // while reporting 100% can only mean "flushed, awaiting the response".
+                ...(typeof progress === 'number'
+                  ? { uploadConfirmationPending: progress >= 100 }
+                  : {}),
               });
             }
           : undefined;

--- a/src/uploadManager.ts
+++ b/src/uploadManager.ts
@@ -1,10 +1,44 @@
+import axios from 'axios';
+
 import type { StreamChat } from './client';
 import type { UploadRequestOptions } from './messageComposer/configuration/types';
 import { StateStore } from './store';
 import type { AttachmentManager } from '.';
 
+/**
+ * Whether an upload ended because it was aborted rather than because it failed.
+ *
+ * {@link UploadManager.deleteUploadRecord} and {@link UploadManager.cancelAllUploads} abort the
+ * request through its `AbortController`, which is what happens when an attachment is removed
+ * from the composer mid-upload or the client disconnects. Axios reports that as a
+ * `CanceledError` (`axios.isCancel`); a custom `doUploadRequest` on another transport
+ * conventionally throws a `DOMException` named `AbortError`.
+ *
+ * Callers use this to keep a deliberate cancellation from being reported as an error.
+ */
+export const isUploadCancellation = (error: unknown) =>
+  axios.isCancel(error) || (error instanceof Error && error.name === 'AbortError');
+
 export type UploadRecord = {
   id: string;
+  /**
+   * `true` once every byte has been handed to the transport but the server has not responded
+   * yet.
+   *
+   * Upload progress measures bytes *written to the connection*, not bytes the server
+   * acknowledged, so it reaches 100% the moment the request body is flushed — then the
+   * connection sits idle while the CDN ingests the file and the response travels back. On a
+   * large file over a slow link that window is long, and a UI that renders 100% as "done"
+   * claims the upload is confirmed while it is not.
+   *
+   * Nothing measurable happens during that window, so it is the point at which a determinate
+   * progress bar should hand over to an indeterminate one. Confirmation is the record being
+   * removed, not progress reaching 100.
+   *
+   * Requires `AttachmentManagerConfig.trackUploadProgress`; without progress reporting there is
+   * no way to tell when the flush happened, and this stays `false`.
+   */
+  uploadConfirmationPending?: boolean;
   uploadProgress?: number;
 };
 
@@ -126,6 +160,7 @@ export class UploadManager {
       const trackProgress = attachmentManager.config.trackUploadProgress;
       try {
         this.upsertUpload({
+          uploadConfirmationPending: false,
           id,
           uploadProgress: trackProgress ? 0 : undefined,
         });
@@ -133,6 +168,10 @@ export class UploadManager {
         const onProgress = trackProgress
           ? (progress?: number) => {
               this.updateUpload({
+                // The record is removed in the `finally` below, so a record that still exists
+                // while reporting 100% can only mean "flushed, awaiting the response".
+                uploadConfirmationPending:
+                  typeof progress === 'number' && progress >= 100,
                 id,
                 uploadProgress: progress,
               });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import FormData from 'form-data';
 import type {
   AscDesc,
+  Attachment,
   ChannelFilters,
   ChannelQueryOptions,
   ChannelSort,
@@ -381,6 +382,75 @@ export function unformatMessage(message: LocalMessage): MessageResponse {
     quoted_message: toMessageResponseBase((message as LocalMessage).quoted_message),
   } as MessageResponse;
 }
+
+/**
+ * Strips composer-internal state from a message's attachments, and drops any whose upload never
+ * resolved.
+ *
+ * `localMetadata` is how `AttachmentManager` tracks an upload (its id, the `File`, the local
+ * preview); it must never reach the API. An attachment that still carries it and has no URL was
+ * never settled — which is what happens when
+ * `createSendWithPendingUploadsAttachmentsMiddleware` is installed by a UI SDK that does not
+ * implement the rest of the flow (awaiting those uploads before sending). Sending it would store
+ * an attachment pointing at nothing, so it is dropped and reported instead.
+ *
+ * Returns the same message object when there was nothing to change.
+ */
+export const sanitizeOutgoingAttachments = ({
+  channel,
+  message,
+}: {
+  channel: Channel;
+  message: Message;
+}): Message => {
+  const attachments = message.attachments;
+  if (!attachments?.length) return message;
+
+  const unresolved: Attachment[] = [];
+  let changed = false;
+
+  const sanitized = attachments.reduce<Attachment[]>((acc, attachment) => {
+    const { localMetadata, ...rest } = attachment as Attachment & {
+      localMetadata?: Record<string, unknown>;
+    };
+
+    if (!localMetadata) {
+      acc.push(attachment);
+      return acc;
+    }
+
+    changed = true;
+
+    // Any of these means the attachment resolved to something the API can store.
+    const hasSource = !!(
+      rest.asset_url ||
+      rest.image_url ||
+      rest.og_scrape_url ||
+      rest.title_link
+    );
+
+    if (hasSource) {
+      acc.push(rest as Attachment);
+    } else {
+      unresolved.push(rest as Attachment);
+    }
+
+    return acc;
+  }, []);
+
+  if (unresolved.length) {
+    channel.getClient().notifications.addWarning({
+      message: `Dropped ${unresolved.length} attachment(s) whose upload never completed. Sending while attachments are still uploading requires a UI SDK that awaits them before sending.`,
+      origin: {
+        emitter: 'Channel',
+        context: { attachments: unresolved, channel },
+      },
+      options: { type: 'validation:attachment:unresolved-upload' },
+    });
+  }
+
+  return changed ? { ...message, attachments: sanitized } : message;
+};
 
 export const localMessageToNewMessagePayload = (localMessage: LocalMessage): Message => {
   /* eslint-disable @typescript-eslint/no-unused-vars */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -397,17 +397,17 @@ const isRemoteUrl = (url?: string) => !!url && /^https?:\/\//i.test(url.trim());
  * URL was never settled — which is what happens when
  * `createSendWithPendingUploadsAttachmentsMiddleware` is installed by a UI SDK that does not
  * implement the rest of the flow (awaiting those uploads before sending). Sending it would store
- * an attachment pointing at nothing, so it is dropped and reported instead.
+ * an attachment pointing at nothing, so it is dropped and logged instead.
  *
  * Returns the same message object when there was nothing to change.
  */
-export const sanitizeOutgoingAttachments = ({
-  channel,
+export const sanitizeOutgoingAttachments = <T extends { attachments?: Attachment[] }>({
+  client,
   message,
 }: {
-  channel: Channel;
-  message: Message;
-}): Message => {
+  client: StreamChat;
+  message: T;
+}): T => {
   const attachments = message.attachments;
   if (!attachments?.length) return message;
 
@@ -444,14 +444,11 @@ export const sanitizeOutgoingAttachments = ({
   }, []);
 
   if (unresolved.length) {
-    channel.getClient().notifications.addWarning({
-      message: `Dropped ${unresolved.length} attachment(s) whose upload never completed. Sending while attachments are still uploading requires a UI SDK that awaits them before sending.`,
-      origin: {
-        emitter: 'Channel',
-        context: { attachments: unresolved, channel },
-      },
-      options: { type: 'validation:attachment:unresolved-upload' },
-    });
+    const text = `Dropped ${unresolved.length} attachment(s) whose upload never completed. Composing with pending uploads requires awaiting them before sending.`;
+    const extraData = { attachments: unresolved, message, tags: ['attachments'] };
+
+    client.logger('warn', text, extraData);
+    console.warn(text, extraData);
   }
 
   return changed ? { ...message, attachments: sanitized } : message;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -384,12 +384,17 @@ export function unformatMessage(message: LocalMessage): MessageResponse {
 }
 
 /**
+ * Whether a URL points at something the API and other devices can actually fetch.
+ */
+const isRemoteUrl = (url?: string) => !!url && /^https?:\/\//i.test(url.trim());
+
+/**
  * Strips composer-internal state from a message's attachments, and drops any whose upload never
  * resolved.
  *
  * `localMetadata` is how `AttachmentManager` tracks an upload (its id, the `File`, the local
- * preview); it must never reach the API. An attachment that still carries it and has no URL was
- * never settled — which is what happens when
+ * preview); it must never reach the API. An attachment that still carries it and has no remote
+ * URL was never settled — which is what happens when
  * `createSendWithPendingUploadsAttachmentsMiddleware` is installed by a UI SDK that does not
  * implement the rest of the flow (awaiting those uploads before sending). Sending it would store
  * an attachment pointing at nothing, so it is dropped and reported instead.
@@ -421,15 +426,15 @@ export const sanitizeOutgoingAttachments = ({
 
     changed = true;
 
-    // Any of these means the attachment resolved to something the API can store.
-    const hasSource = !!(
-      rest.asset_url ||
-      rest.image_url ||
-      rest.og_scrape_url ||
-      rest.title_link
-    );
+    // Any of these pointing at a remote URL means the attachment resolved to something the API
+    // can store and other devices can load.
+    const hasRemoteSource =
+      isRemoteUrl(rest.asset_url) ||
+      isRemoteUrl(rest.image_url) ||
+      isRemoteUrl(rest.og_scrape_url) ||
+      isRemoteUrl(rest.title_link);
 
-    if (hasSource) {
+    if (hasRemoteSource) {
       acc.push(rest as Attachment);
     } else {
       unresolved.push(rest as Attachment);

--- a/test/unit/MessageComposer/attachmentManager.test.ts
+++ b/test/unit/MessageComposer/attachmentManager.test.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { describe, expect, it, vi } from 'vitest';
 import {
   API_MAX_FILES_ALLOWED_PER_MESSAGE,
@@ -781,6 +782,64 @@ describe('AttachmentManager', () => {
       ]);
     });
 
+    it('revokes the preview blob URL of every removed attachment', () => {
+      // Without this each removed attachment - including one cancelled mid-upload - leaks a
+      // blob URL until the page unloads.
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation();
+
+      attachmentManager.upsertAttachments([
+        { localMetadata: { id: 'kept', previewUri: 'blob:kept' } },
+        { localMetadata: { id: 'removed', previewUri: 'blob:removed' } },
+      ]);
+
+      attachmentManager.removeAttachments(['removed']);
+
+      expect(revokeObjectURLSpy).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:removed');
+
+      revokeObjectURLSpy.mockRestore();
+    });
+
+    it('leaves a non-blob previewUri alone when removing', () => {
+      // React Native puts the caller's own `FileReference.uri` in the same field; it is not
+      // ours to revoke.
+      const {
+        messageComposer: { attachmentManager },
+      } = setup();
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation();
+
+      attachmentManager.upsertAttachments([
+        { localMetadata: { id: 'native', previewUri: 'file://local/photo.jpg' } },
+      ]);
+
+      attachmentManager.removeAttachments(['native']);
+
+      expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+
+      revokeObjectURLSpy.mockRestore();
+    });
+
+    it('does not revoke preview blob URLs when the composer is only cleared', () => {
+      // `initState` drops the composer's view of the attachments without ending their life -
+      // an attachment handed to an optimistic message while its upload is still running is
+      // still rendered from that blob.
+      const { messageComposer } = setup();
+      const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation();
+
+      messageComposer.attachmentManager.upsertAttachments([
+        { localMetadata: { id: 'in-flight', previewUri: 'blob:in-flight' } },
+      ]);
+
+      messageComposer.clear();
+
+      expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+
+      revokeObjectURLSpy.mockRestore();
+    });
+
     it('should delete matching upload records when removing upload attachments', async () => {
       const {
         messageComposer: { attachmentManager },
@@ -888,15 +947,94 @@ describe('AttachmentManager', () => {
       attachmentManager.removeAttachments([uploadId!]);
       expect(attachmentManager.attachments).toEqual([]);
 
-      mockClient.uploadManager.state.partialNext((current) => ({
-        ...current,
+      mockClient.uploadManager.state.partialNext({
         uploads: {
-          ...current.uploads,
+          ...mockClient.uploadManager.uploads,
           [uploadId!]: { id: uploadId!, uploadProgress: 77 },
         },
-      }));
+      });
 
       expect(attachmentManager.attachments).toEqual([]);
+    });
+  });
+
+  describe('uploadConfirmationPending mirroring', () => {
+    it('mirrors uploadConfirmationPending from the upload record onto the attachment', async () => {
+      const {
+        messageComposer: { attachmentManager },
+        mockClient,
+      } = setup({ config: { trackUploadProgress: true } });
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () => new Promise(() => {}),
+      );
+
+      void attachmentManager.uploadFile(new File([], 'p.png', { type: 'image/png' }));
+
+      await vi.waitFor(() => {
+        expect(Object.keys(mockClient.uploadManager.uploads).length).toBeGreaterThan(0);
+      });
+      const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
+
+      mockClient.uploadManager.state.partialNext({
+        uploads: {
+          [uploadId!]: {
+            uploadConfirmationPending: true,
+            id: uploadId!,
+            uploadProgress: 100,
+          },
+        },
+      });
+
+      expect(
+        attachmentManager.attachments[0].localMetadata.uploadConfirmationPending,
+      ).toBe(true);
+    });
+
+    it('clears uploadConfirmationPending once the upload finishes', async () => {
+      // Regression guard for a subtle trap: these updates go through `updateAttachment`, which
+      // merges via `mergeWith` — and `mergeWith` skips `undefined` source values. Clearing the
+      // flag with `undefined` silently left a stale `true` behind, so it must be `false`.
+      const {
+        messageComposer: { attachmentManager },
+        mockClient,
+      } = setup({ config: { trackUploadProgress: true } });
+      let resolveUpload!: (value: { file: string }) => void;
+      vi.spyOn(attachmentManager, 'doUploadRequest').mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveUpload = resolve;
+          }),
+      );
+
+      const uploading = attachmentManager.uploadFile(
+        new File([], 'p.png', { type: 'image/png' }),
+      );
+
+      await vi.waitFor(() => {
+        expect(Object.keys(mockClient.uploadManager.uploads).length).toBeGreaterThan(0);
+      });
+      const uploadId = Object.keys(mockClient.uploadManager.uploads)[0];
+
+      mockClient.uploadManager.state.partialNext({
+        uploads: {
+          [uploadId!]: {
+            uploadConfirmationPending: true,
+            id: uploadId!,
+            uploadProgress: 100,
+          },
+        },
+      });
+      expect(
+        attachmentManager.attachments[0].localMetadata.uploadConfirmationPending,
+      ).toBe(true);
+
+      resolveUpload({ file: 'https://cdn.example/p.png' });
+      await uploading;
+
+      expect(attachmentManager.attachments[0].localMetadata.uploadState).toBe('finished');
+      expect(
+        attachmentManager.attachments[0].localMetadata.uploadConfirmationPending,
+      ).toBe(false);
     });
   });
 
@@ -1364,6 +1502,7 @@ describe('AttachmentManager', () => {
         fallback: 'test.jpg',
         file_size: 0,
         localMetadata: {
+          uploadConfirmationPending: false,
           id: expect.any(String),
           file,
           uploadState: 'failed',
@@ -1432,6 +1571,38 @@ describe('AttachmentManager', () => {
           metadata: { reason: 'size_limit' },
         },
       });
+    });
+
+    it.each([
+      ['an axios cancellation', new axios.Cancel('canceled')],
+      ['a DOMException AbortError', new DOMException('Upload aborted', 'AbortError')],
+    ])('does not notify when the upload was cancelled by %s', async (_label, error) => {
+      // Cancelling from the composer aborts the request via `UploadManager`, so the rejection
+      // that lands here is the user's own doing. This path notifies directly instead of going
+      // through `createUploadErrorHandlerMiddleware`, so it needs its own guard.
+      const {
+        messageComposer: { attachmentManager },
+        mockClient,
+      } = setup();
+
+      attachmentManager.setCustomUploadFn(vi.fn().mockRejectedValue(error));
+
+      const attachment = {
+        type: 'image',
+        localMetadata: {
+          id: 'test-id',
+          file: new File([''], 'test.jpg', { type: 'image/jpeg' }),
+          uploadState: 'pending',
+        },
+      };
+      vi.spyOn(attachmentManager, 'ensureLocalUploadAttachment').mockResolvedValue(
+        attachment,
+      );
+
+      const result = await attachmentManager.uploadAttachment(attachment);
+
+      expect(result?.localMetadata.uploadState).toBe('failed');
+      expect(mockClient.notifications.addError).not.toHaveBeenCalled();
     });
 
     it('should use custom upload function when provided', async () => {
@@ -1968,6 +2139,7 @@ describe('AttachmentManager', () => {
           fallback: 'test.jpg',
           file_size: 0,
           localMetadata: {
+            uploadConfirmationPending: false,
             id: expect.any(String),
             file,
             uploadState: 'failed',

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -5,6 +5,8 @@ import {
   ChannelAPIResponse,
   ChannelConfigWithInfo,
   ChannelResponse,
+  createAttachmentsCompositionMiddleware,
+  createSendWithPendingUploadsAttachmentsMiddleware,
   LocalMessage,
   MessageComposerConfig,
   StaticLocationPayload,
@@ -576,7 +578,7 @@ describe('MessageComposer', () => {
       expect(messageComposer.hasSendableData).toBe(false);
     });
 
-    it('hasSendableDataWithPendingUploads counts an upload in flight as content', () => {
+    it('counts an upload in flight as content once a middleware allows pending uploads', () => {
       const { messageComposer } = setup();
 
       messageComposer.attachmentManager.state.partialNext({
@@ -585,14 +587,45 @@ describe('MessageComposer', () => {
         ],
       });
 
-      // `hasSendableData` is false for the same state — that is what disables the send button
-      // and Enter-to-submit while an upload runs.
+      // Default chain: an upload in flight disables the send button and Enter-to-submit.
+      expect(messageComposer.allowsPendingUploads).toBe(false);
       expect(messageComposer.hasSendableData).toBe(false);
-      expect(messageComposer.hasSendableDataWithPendingUploads).toBe(true);
+
+      messageComposer.compositionMiddlewareExecutor.replace([
+        createSendWithPendingUploadsAttachmentsMiddleware(messageComposer),
+      ]);
+
+      // Installing the middleware is the whole switch - nothing else has to be told.
+      expect(messageComposer.allowsPendingUploads).toBe(true);
+      expect(messageComposer.hasSendableData).toBe(true);
     });
 
-    it('hasSendableDataWithPendingUploads still refuses attachments that will never resolve', () => {
+    it('recognizes the declaration on a custom middleware, whatever its id', () => {
+      // The composer keys off `allowsPendingUploads`, not off a middleware id, so a UI SDK that
+      // ships its own attachments composition gets the matching sendability rule.
       const { messageComposer } = setup();
+
+      messageComposer.attachmentManager.state.partialNext({
+        attachments: [
+          { type: 'x', localMetadata: { id: 'a1', uploadState: 'uploading', file: {} } },
+        ],
+      });
+
+      messageComposer.compositionMiddlewareExecutor.use({
+        allowsPendingUploads: true,
+        id: 'custom/attachments-with-pending-uploads',
+        handlers: { compose: ({ forward }) => forward() },
+      });
+
+      expect(messageComposer.allowsPendingUploads).toBe(true);
+      expect(messageComposer.hasSendableData).toBe(true);
+    });
+
+    it('still refuses attachments that will never resolve', () => {
+      const { messageComposer } = setup();
+      messageComposer.compositionMiddlewareExecutor.replace([
+        createSendWithPendingUploadsAttachmentsMiddleware(messageComposer),
+      ]);
 
       messageComposer.attachmentManager.state.partialNext({
         attachments: [
@@ -602,7 +635,27 @@ describe('MessageComposer', () => {
       });
 
       // A message whose only attachments were rejected must not look sendable.
-      expect(messageComposer.hasSendableDataWithPendingUploads).toBe(false);
+      expect(messageComposer.hasSendableData).toBe(false);
+    });
+
+    it('goes back to the default rule when the middleware is uninstalled', () => {
+      const { messageComposer } = setup();
+      messageComposer.compositionMiddlewareExecutor.replace([
+        createSendWithPendingUploadsAttachmentsMiddleware(messageComposer),
+      ]);
+      messageComposer.attachmentManager.state.partialNext({
+        attachments: [
+          { type: 'x', localMetadata: { id: 'a1', uploadState: 'uploading', file: {} } },
+        ],
+      });
+      expect(messageComposer.hasSendableData).toBe(true);
+
+      messageComposer.compositionMiddlewareExecutor.replace([
+        createAttachmentsCompositionMiddleware(messageComposer),
+      ]);
+
+      expect(messageComposer.allowsPendingUploads).toBe(false);
+      expect(messageComposer.hasSendableData).toBe(false);
     });
 
     it('should account for command sendability in hasSendableData', () => {

--- a/test/unit/MessageComposer/messageComposer.test.ts
+++ b/test/unit/MessageComposer/messageComposer.test.ts
@@ -576,6 +576,35 @@ describe('MessageComposer', () => {
       expect(messageComposer.hasSendableData).toBe(false);
     });
 
+    it('hasSendableDataWithPendingUploads counts an upload in flight as content', () => {
+      const { messageComposer } = setup();
+
+      messageComposer.attachmentManager.state.partialNext({
+        attachments: [
+          { type: 'x', localMetadata: { id: 'a1', uploadState: 'uploading', file: {} } },
+        ],
+      });
+
+      // `hasSendableData` is false for the same state — that is what disables the send button
+      // and Enter-to-submit while an upload runs.
+      expect(messageComposer.hasSendableData).toBe(false);
+      expect(messageComposer.hasSendableDataWithPendingUploads).toBe(true);
+    });
+
+    it('hasSendableDataWithPendingUploads still refuses attachments that will never resolve', () => {
+      const { messageComposer } = setup();
+
+      messageComposer.attachmentManager.state.partialNext({
+        attachments: [
+          { type: 'x', localMetadata: { id: 'a1', uploadState: 'failed', file: {} } },
+          { type: 'x', localMetadata: { id: 'a2', uploadState: 'blocked', file: {} } },
+        ],
+      });
+
+      // A message whose only attachments were rejected must not look sendable.
+      expect(messageComposer.hasSendableDataWithPendingUploads).toBe(false);
+    });
+
     it('should account for command sendability in hasSendableData', () => {
       const validator = vi.fn(({ command, mentionedUsersInText }) =>
         mentionedUsersInText.length > 0

--- a/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/postUpload/attachmentEnrichment.test.ts
@@ -34,7 +34,71 @@ const getInitialState = (
   ),
 });
 
+const makeComposerOwning = (ids: string[]) =>
+  ({
+    attachmentManager: {
+      get attachmentsById() {
+        return Object.fromEntries(ids.map((id) => [id, { localMetadata: { id } }]));
+      },
+    },
+  }) as unknown as MessageComposer;
+
 describe('createPostUploadAttachmentEnrichmentMiddleware', () => {
+  it('leaves the preview blob alone once the composer no longer owns the attachment', async () => {
+    // With `attachments.sendWithPendingUploads` an attachment can be handed to a message while
+    // its upload is still running. Revoking here would blank out the preview of a message that
+    // is still waiting on its other uploads.
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation();
+    const attachment = AttachmentManager.toLocalUploadAttachment(
+      new File([''], 'handed-over.pdf', { type: 'application/pdf' }),
+    );
+    attachment.localMetadata.previewUri = 'blob:handed-over';
+
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware(
+      makeComposerOwning([]),
+    );
+
+    const result = await middleware.handlers.postProcess(
+      setupHandlerParams({
+        attachment,
+        response: { file: 'https://example.com/file/url' },
+      }),
+    );
+
+    expect(revokeObjectURLSpy).not.toHaveBeenCalled();
+    expect(result.state.attachment?.localMetadata.previewUri).toBe('blob:handed-over');
+    // Enrichment itself still happens.
+    expect(result.state.attachment).toMatchObject({
+      asset_url: 'https://example.com/file/url',
+    });
+
+    revokeObjectURLSpy.mockRestore();
+  });
+
+  it('revokes the preview blob while the composer still owns the attachment', async () => {
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation();
+    const attachment = AttachmentManager.toLocalUploadAttachment(
+      new File([''], 'still-mine.pdf', { type: 'application/pdf' }),
+    );
+    attachment.localMetadata.previewUri = 'blob:still-mine';
+
+    const middleware = createPostUploadAttachmentEnrichmentMiddleware(
+      makeComposerOwning([attachment.localMetadata.id]),
+    );
+
+    const result = await middleware.handlers.postProcess(
+      setupHandlerParams({
+        attachment,
+        response: { file: 'https://example.com/file/url' },
+      }),
+    );
+
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:still-mine');
+    expect(result.state.attachment?.localMetadata.previewUri).toBeUndefined();
+
+    revokeObjectURLSpy.mockRestore();
+  });
+
   it('revokes blob: previewUri when enriching attachment', async () => {
     const middleware = createPostUploadAttachmentEnrichmentMiddleware();
     const revokeObjectURLSpy = vi

--- a/test/unit/MessageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.test.ts
+++ b/test/unit/MessageComposer/middleware/attachmentManager/postUpload/uploadErrorHandler.test.ts
@@ -1,3 +1,5 @@
+import axios from 'axios';
+
 import { MessageComposer, MiddlewareStatus } from '../../../../../../src';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -50,6 +52,32 @@ describe('createUploadErrorHandlerMiddleware', () => {
       .spyOn(composer.client.notifications, 'addError')
       .mockImplementation();
     const { status } = await middleware.handlers.postProcess(setupHandlerParams({}));
+    expect(status).toBeUndefined();
+    expect(addErrorNotificationSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['an axios cancellation', new axios.Cancel('canceled')],
+    ['a DOMException AbortError', new DOMException('Upload aborted', 'AbortError')],
+  ])('does not publish an error notification for %s', async (_label, error) => {
+    // Removing an attachment mid-upload aborts the request through
+    // `UploadManager.deleteUploadRecord`. That is the user getting what they asked for, so it
+    // must not surface as "Attachment upload failed".
+    const { composer, middleware } = setup();
+    const addErrorNotificationSpy = vi
+      .spyOn(composer.client.notifications, 'addError')
+      .mockImplementation();
+
+    const { status } = await middleware.handlers.postProcess(
+      setupHandlerParams({
+        attachment: {
+          localMetadata: { id: 'test-id', uploadState: 'failed' },
+          type: 'file',
+        } as AttachmentPostUploadMiddlewareState['attachment'],
+        error,
+      }),
+    );
+
     expect(status).toBeUndefined();
     expect(addErrorNotificationSpy).not.toHaveBeenCalled();
   });

--- a/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Channel } from '../../../../../src/channel';
 import { StreamChat } from '../../../../../src/client';
 import { MessageComposer } from '../../../../../src/messageComposer/messageComposer';
-import { createAttachmentsCompositionMiddleware } from '../../../../../src/messageComposer/middleware/messageComposer/attachments';
+import {
+  createAttachmentsCompositionMiddleware,
+  createSendWithPendingUploadsAttachmentsMiddleware,
+} from '../../../../../src/messageComposer/middleware/messageComposer/attachments';
 import {
   AttachmentLoadingState,
   LocalImageAttachment,
@@ -72,6 +75,12 @@ describe('stream-io/message-composer-middleware/attachments', () => {
     };
 
     const attachmentManager = {
+      get attachments() {
+        return [];
+      },
+      get config() {
+        return { sendWithPendingUploads: false };
+      },
       get uploadsInProgressCount() {
         return 0;
       },
@@ -520,5 +529,142 @@ describe('stream-io/message-composer-middleware/draft-attachments', () => {
 
     expect(result.status).toBeUndefined();
     expect(result.state.draft.attachments).toBeUndefined();
+  });
+});
+
+describe('createSendWithPendingUploadsAttachmentsMiddleware', () => {
+  const finished = {
+    type: 'image',
+    image_url: 'https://example.com/done.jpg',
+    localMetadata: {
+      id: 'done',
+      file: new File([], 'done.jpg', { type: 'image/jpeg' }),
+      uploadState: 'finished' as AttachmentLoadingState,
+    },
+  };
+  const pending = {
+    type: 'image',
+    localMetadata: {
+      id: 'in-flight',
+      file: new File([], 'in-flight.jpg', { type: 'image/jpeg' }),
+      previewUri: 'blob:in-flight',
+      uploadState: 'uploading' as AttachmentLoadingState,
+    },
+  };
+
+  const emptyState = (): MessageComposerMiddlewareState => ({
+    message: { id: 'test-id', parent_id: undefined, type: 'regular' },
+    localMessage: {
+      attachments: [],
+      created_at: new Date(),
+      deleted_at: null,
+      error: undefined,
+      id: 'test-id',
+      mentioned_users: [],
+      parent_id: undefined,
+      pinned_at: null,
+      reaction_groups: null,
+      status: 'sending',
+      text: '',
+      type: 'regular',
+      updated_at: new Date(),
+    },
+    sendOptions: {},
+  });
+
+  const setupComposer = ({ attachments }: { attachments: unknown[] }) => {
+    const client = {
+      userID: 'currentUser',
+      user: { id: 'currentUser' },
+      notifications: { addWarning: vi.fn() },
+    } as any;
+    const messageComposer = {
+      client,
+      get pollId() {
+        return null;
+      },
+      attachmentManager: {
+        get attachments() {
+          return attachments;
+        },
+        get uploadsInProgressCount() {
+          return attachments.filter(
+            (a: any) => a.localMetadata.uploadState === 'uploading',
+          ).length;
+        },
+        get successfulUploads() {
+          return attachments.filter(
+            (a: any) => a.localMetadata.uploadState === 'finished',
+          );
+        },
+      },
+    } as any;
+
+    return {
+      client,
+      messageComposer,
+      middleware: createSendWithPendingUploadsAttachmentsMiddleware(messageComposer),
+    };
+  };
+
+  it('does not discard or warn while an upload is in flight', async () => {
+    const { client, middleware } = setupComposer({ attachments: [pending] });
+
+    const result = await middleware.handlers.compose(setup(emptyState()));
+
+    expect(result.status).toBeUndefined();
+    expect(client.notifications.addWarning).not.toHaveBeenCalled();
+  });
+
+  it('keeps localMetadata on the optimistic message and off the API payload', async () => {
+    const { middleware } = setupComposer({ attachments: [finished, pending] });
+
+    const result = await middleware.handlers.compose(setup(emptyState()));
+
+    // The optimistic message carries the in-flight attachment with its localMetadata - that is
+    // what lets the message list join it to the live `uploadManager` record and render the
+    // local preview meanwhile.
+    expect(result.state.localMessage.attachments).toHaveLength(2);
+    expect(result.state.localMessage.attachments?.[1]).toHaveProperty(
+      'localMetadata.id',
+      'in-flight',
+    );
+    // Composer order is preserved so previews do not reshuffle when an upload settles.
+    expect(result.state.localMessage.attachments?.[0]).not.toHaveProperty(
+      'localMetadata',
+    );
+
+    // The API payload only holds what already resolved to a URL.
+    expect(result.state.message.attachments).toHaveLength(1);
+    expect(result.state.message.attachments?.[0]).toMatchObject({
+      image_url: 'https://example.com/done.jpg',
+    });
+    expect(result.state.message.attachments?.[0]).not.toHaveProperty('localMetadata');
+  });
+
+  it('leaves pending uploads in the composer when it is kept as a draft for a poll', async () => {
+    // `useSubmitHandler` skips `clear()` for a poll composition, so handing the same
+    // localMetadata.id to the message would leave it owned by both.
+    const { messageComposer, middleware } = setupComposer({
+      attachments: [finished, pending],
+    });
+    vi.spyOn(messageComposer, 'pollId', 'get').mockReturnValue('poll-id');
+
+    const result = await middleware.handlers.compose(setup(emptyState()));
+
+    expect(result.state.localMessage.attachments).toHaveLength(1);
+    expect(result.state.localMessage.attachments?.[0]).not.toHaveProperty(
+      'localMetadata',
+    );
+    expect(result.state.message.attachments).toHaveLength(1);
+  });
+
+  it('forwards unchanged when there is nothing to attach', async () => {
+    const { middleware } = setupComposer({ attachments: [] });
+
+    const result = await middleware.handlers.compose(setup(emptyState()));
+
+    expect(result.state.message.attachments ?? []).toHaveLength(0);
+    expect(result.state.localMessage.attachments ?? []).toHaveLength(0);
   });
 });

--- a/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
@@ -659,6 +659,29 @@ describe('createSendWithPendingUploadsAttachmentsMiddleware', () => {
     expect(result.state.message.attachments).toHaveLength(1);
   });
 
+  it('does not introduce an empty attachments array into the API payload', async () => {
+    // Nothing has finished uploading yet, so there is nothing to send. An empty array is not
+    // the same as an absent key: on an edit the API reads `attachments: []` as "remove every
+    // attachment".
+    const { middleware } = setupComposer({ attachments: [pending] });
+
+    const result = await middleware.handlers.compose(setup(emptyState()));
+
+    expect(result.state.message).not.toHaveProperty('attachments');
+    expect(result.state.localMessage.attachments).toHaveLength(1);
+  });
+
+  it('keeps attachments already present on the API payload', async () => {
+    const { middleware } = setupComposer({ attachments: [pending] });
+    const state = emptyState();
+    const scraped = { type: 'image', og_scrape_url: 'https://example.com' };
+    state.message.attachments = [scraped];
+
+    const result = await middleware.handlers.compose(setup(state));
+
+    expect(result.state.message.attachments).toEqual([scraped]);
+  });
+
   it('forwards unchanged when there is nothing to attach', async () => {
     const { middleware } = setupComposer({ attachments: [] });
 

--- a/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
+++ b/test/unit/MessageComposer/middleware/messageComposer/attachments.test.ts
@@ -607,6 +607,14 @@ describe('createSendWithPendingUploadsAttachmentsMiddleware', () => {
     };
   };
 
+  it('declares that it allows pending uploads', () => {
+    // `MessageComposer.hasSendableData` reads this declaration, so installing the middleware is
+    // the only switch a UI SDK has to flip.
+    const { middleware } = setupComposer({ attachments: [] });
+
+    expect(middleware.allowsPendingUploads).toBe(true);
+  });
+
   it('does not discard or warn while an upload is in flight', async () => {
     const { client, middleware } = setupComposer({ attachments: [pending] });
 

--- a/test/unit/MessageComposer/uploadManager.test.ts
+++ b/test/unit/MessageComposer/uploadManager.test.ts
@@ -146,6 +146,69 @@ describe('UploadManager', () => {
     expect(manager.getUpload('u1')).toBeUndefined();
   });
 
+  it('keeps uploadConfirmationPending when a later report carries no number', async () => {
+    // A report without a number means the transport cannot measure this upload, not that the
+    // bytes it already flushed were un-sent.
+    const { manager, doUploadRequest } = createManager();
+    let onProgress!: (p?: number) => void;
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    doUploadRequest.mockImplementation(
+      async (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+        onProgress = opts!.onProgress!;
+        return gate;
+      },
+    );
+
+    const promise = manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+
+    onProgress(100);
+    onProgress(undefined);
+
+    expect(manager.getUpload('u1')).toMatchObject({ uploadConfirmationPending: true });
+
+    finish();
+    await promise;
+  });
+
+  it('lowers uploadConfirmationPending only on a number below 100', async () => {
+    const { manager, doUploadRequest } = createManager();
+    let onProgress!: (p?: number) => void;
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    doUploadRequest.mockImplementation(
+      async (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+        onProgress = opts!.onProgress!;
+        return gate;
+      },
+    );
+
+    const promise = manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+
+    onProgress(100);
+    onProgress(40);
+
+    expect(manager.getUpload('u1')).toMatchObject({
+      uploadConfirmationPending: false,
+      uploadProgress: 40,
+    });
+
+    finish();
+    await promise;
+  });
+
   it('never flags uploadConfirmationPending when progress is not computable', async () => {
     const { manager, doUploadRequest } = createManager();
     let onProgress!: (p?: number) => void;

--- a/test/unit/MessageComposer/uploadManager.test.ts
+++ b/test/unit/MessageComposer/uploadManager.test.ts
@@ -34,6 +34,7 @@ describe('UploadManager', () => {
 
     expect(manager.uploads).toEqual({
       'local-a': {
+        uploadConfirmationPending: false,
         id: 'local-a',
         uploadProgress: 0,
       },
@@ -100,6 +101,69 @@ describe('UploadManager', () => {
     onProgress(undefined);
     expect(manager.getUpload('u1')?.uploadProgress).toBeUndefined();
     await start;
+  });
+
+  it('flags uploadConfirmationPending once progress reaches 100 and clears it with the record', async () => {
+    // Upload progress counts bytes written to the connection, not bytes the server
+    // acknowledged, so it hits 100% while the CDN is still ingesting. Consumers need to tell
+    // "flushed, waiting" apart from "confirmed" — a bar parked at 100% claims the latter.
+    const { manager, doUploadRequest } = createManager();
+    let onProgress!: (p?: number) => void;
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    doUploadRequest.mockImplementation(
+      async (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+        onProgress = opts!.onProgress!;
+        return gate;
+      },
+    );
+
+    const promise = manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+
+    onProgress(50);
+    expect(manager.getUpload('u1')).toMatchObject({
+      uploadConfirmationPending: false,
+      uploadProgress: 50,
+    });
+
+    onProgress(100);
+    expect(manager.getUpload('u1')).toMatchObject({
+      uploadConfirmationPending: true,
+      // The percentage stays honest: those bytes really were sent, so a byte readout can still
+      // show full/full. Only the *indicator* should go indeterminate.
+      uploadProgress: 100,
+    });
+
+    // Confirmation is the record disappearing, not progress reaching 100.
+    finish();
+    await promise;
+    expect(manager.getUpload('u1')).toBeUndefined();
+  });
+
+  it('never flags uploadConfirmationPending when progress is not computable', async () => {
+    const { manager, doUploadRequest } = createManager();
+    let onProgress!: (p?: number) => void;
+    doUploadRequest.mockImplementation(
+      async (_file: unknown, opts?: { onProgress?: (n?: number) => void }) => {
+        onProgress = opts!.onProgress!;
+      },
+    );
+
+    const promise = manager.upload({
+      id: 'u1',
+      channelCid: TEST_CID,
+      file: new File([], 'x'),
+    });
+    onProgress(undefined);
+
+    expect(manager.getUpload('u1')).toMatchObject({ uploadConfirmationPending: false });
+    await promise;
   });
 
   it('on failure, removes record and rejects the promise', async () => {
@@ -169,8 +233,16 @@ describe('UploadManager', () => {
     const p1 = manager.upload({ id: 'm1', channelCid: TEST_CID, file });
     const p2 = manager.upload({ id: 'm2', channelCid: TEST_CID, file });
 
-    expect(manager.getUpload('m1')).toEqual({ id: 'm1', uploadProgress: 0 });
-    expect(manager.getUpload('m2')).toEqual({ id: 'm2', uploadProgress: 0 });
+    expect(manager.getUpload('m1')).toEqual({
+      uploadConfirmationPending: false,
+      id: 'm1',
+      uploadProgress: 0,
+    });
+    expect(manager.getUpload('m2')).toEqual({
+      uploadConfirmationPending: false,
+      id: 'm2',
+      uploadProgress: 0,
+    });
 
     const p1Again = manager.upload({ id: 'm1', channelCid: TEST_CID, file });
     expect(p1Again).toBe(p1);
@@ -244,7 +316,11 @@ describe('UploadManager', () => {
 
       manager.deleteUploadRecord('other');
 
-      expect(manager.getUpload('m1')).toEqual({ id: 'm1', uploadProgress: 0 });
+      expect(manager.getUpload('m1')).toEqual({
+        uploadConfirmationPending: false,
+        id: 'm1',
+        uploadProgress: 0,
+      });
       expect(doUploadRequest).toHaveBeenCalledTimes(1);
     });
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2584,6 +2584,87 @@ describe('message sending flow', () => {
 			vi.resetAllMocks();
 		});
 
+		it('strips composer-internal localMetadata from outgoing attachments', async () => {
+			client.offlineDb = undefined;
+			const msg = {
+				...message,
+				attachments: [
+					{
+						asset_url: 'https://cdn.example.com/f.pdf',
+						localMetadata: { file: {}, id: 'a1', uploadState: 'finished' },
+						type: 'file',
+					},
+				],
+			};
+
+			await channel.sendMessage(msg, options);
+
+			const sent = channel._sendMessage.mock.calls[0][0];
+			expect(sent.attachments).toHaveLength(1);
+			expect(sent.attachments[0]).not.toHaveProperty('localMetadata');
+			expect(sent.attachments[0].asset_url).toBe('https://cdn.example.com/f.pdf');
+		});
+
+		it('drops an attachment whose upload never resolved, and warns', async () => {
+			// Reachable when a UI installs createSendWithPendingUploadsAttachmentsMiddleware but
+			// does not await the uploads: without this the API would store an attachment pointing
+			// at nothing.
+			client.offlineDb = undefined;
+			const addWarningSpy = vi
+				.spyOn(client.notifications, 'addWarning')
+				.mockImplementation(() => {});
+			const msg = {
+				...message,
+				attachments: [
+					{ asset_url: 'https://cdn.example.com/ok.pdf', type: 'file' },
+					{
+						localMetadata: { file: {}, id: 'a2', uploadState: 'uploading' },
+						type: 'file',
+					},
+				],
+			};
+
+			await channel.sendMessage(msg, options);
+
+			const sent = channel._sendMessage.mock.calls[0][0];
+			expect(sent.attachments).toHaveLength(1);
+			expect(sent.attachments[0].asset_url).toBe('https://cdn.example.com/ok.pdf');
+			expect(addWarningSpy).toHaveBeenCalledWith(
+				expect.objectContaining({
+					options: expect.objectContaining({
+						type: 'validation:attachment:unresolved-upload',
+					}),
+				}),
+			);
+		});
+
+		it('keeps a scraped-link attachment that has no asset_url', async () => {
+			// og_scrape_url / title_link are valid sources; only a missing source counts as unresolved.
+			client.offlineDb = undefined;
+			const msg = {
+				...message,
+				attachments: [
+					{
+						localMetadata: { id: 'a3', uploadState: 'finished' },
+						og_scrape_url: 'https://example.com',
+						type: 'image',
+					},
+				],
+			};
+
+			await channel.sendMessage(msg, options);
+
+			expect(channel._sendMessage.mock.calls[0][0].attachments).toHaveLength(1);
+		});
+
+		it('leaves a message without attachments untouched', async () => {
+			client.offlineDb = undefined;
+
+			await channel.sendMessage(message, options);
+
+			expect(channel._sendMessage).toHaveBeenCalledWith(message, options);
+		});
+
 		it('queues task if offlineDb exists and message has ID', async () => {
 			const result = await channel.sendMessage(message, options);
 

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -2575,17 +2575,10 @@ describe('message sending flow', () => {
 		vi.resetAllMocks();
 	});
 
-	describe('sendMessage', () => {
-		beforeEach(() => {
-			vi.spyOn(channel, '_sendMessage').mockResolvedValue({});
-		});
-
-		afterEach(() => {
-			vi.resetAllMocks();
-		});
-
+	describe('_sendMessage', () => {
+		// Sanitization lives here rather than in `sendMessage` because this is where every path
+		// converges - including the offline replay of a queued task, which calls it directly.
 		it('strips composer-internal localMetadata from outgoing attachments', async () => {
-			client.offlineDb = undefined;
 			const msg = {
 				...message,
 				attachments: [
@@ -2597,9 +2590,9 @@ describe('message sending flow', () => {
 				],
 			};
 
-			await channel.sendMessage(msg, options);
+			await channel._sendMessage(msg, options);
 
-			const sent = channel._sendMessage.mock.calls[0][0];
+			const sent = postSpy.mock.calls[0][1].message;
 			expect(sent.attachments).toHaveLength(1);
 			expect(sent.attachments[0]).not.toHaveProperty('localMetadata');
 			expect(sent.attachments[0].asset_url).toBe('https://cdn.example.com/f.pdf');
@@ -2609,10 +2602,7 @@ describe('message sending flow', () => {
 			// Reachable when a UI installs createSendWithPendingUploadsAttachmentsMiddleware but
 			// does not await the uploads: without this the API would store an attachment pointing
 			// at nothing.
-			client.offlineDb = undefined;
-			const addWarningSpy = vi
-				.spyOn(client.notifications, 'addWarning')
-				.mockImplementation(() => {});
+			vi.spyOn(console, 'warn').mockImplementation(() => {});
 			const msg = {
 				...message,
 				attachments: [
@@ -2624,23 +2614,20 @@ describe('message sending flow', () => {
 				],
 			};
 
-			await channel.sendMessage(msg, options);
+			await channel._sendMessage(msg, options);
 
-			const sent = channel._sendMessage.mock.calls[0][0];
+			const sent = postSpy.mock.calls[0][1].message;
 			expect(sent.attachments).toHaveLength(1);
 			expect(sent.attachments[0].asset_url).toBe('https://cdn.example.com/ok.pdf');
-			expect(addWarningSpy).toHaveBeenCalledWith(
-				expect.objectContaining({
-					options: expect.objectContaining({
-						type: 'validation:attachment:unresolved-upload',
-					}),
-				}),
+			expect(loggerSpy).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('Dropped 1 attachment(s)'),
+				expect.objectContaining({ attachments: expect.any(Array) }),
 			);
 		});
 
 		it('keeps a scraped-link attachment that has no asset_url', async () => {
 			// og_scrape_url / title_link are valid sources; only a missing source counts as unresolved.
-			client.offlineDb = undefined;
 			const msg = {
 				...message,
 				attachments: [
@@ -2652,9 +2639,25 @@ describe('message sending flow', () => {
 				],
 			};
 
-			await channel.sendMessage(msg, options);
+			await channel._sendMessage(msg, options);
 
-			expect(channel._sendMessage.mock.calls[0][0].attachments).toHaveLength(1);
+			expect(postSpy.mock.calls[0][1].message.attachments).toHaveLength(1);
+		});
+
+		it('leaves a message without attachments untouched', async () => {
+			await channel._sendMessage(message, options);
+
+			expect(postSpy.mock.calls[0][1].message).toBe(message);
+		});
+	});
+
+	describe('sendMessage', () => {
+		beforeEach(() => {
+			vi.spyOn(channel, '_sendMessage').mockResolvedValue({});
+		});
+
+		afterEach(() => {
+			vi.resetAllMocks();
 		});
 
 		it('leaves a message without attachments untouched', async () => {

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -573,6 +573,61 @@ describe('message update', () => {
 		vi.resetAllMocks();
 	});
 
+	describe('_updateMessage', () => {
+		// Sanitization lives here rather than in `updateMessage` because this is where every path
+		// converges - including the offline replay of a queued `update-message` task, and the
+		// replay of a `send-message` task that a failed edit was merged into.
+		let postSpy;
+
+		beforeEach(() => {
+			_updateMessageSpy.mockRestore();
+			postSpy = vi.spyOn(client, 'post').mockResolvedValue({});
+		});
+
+		it('strips composer-internal localMetadata from outgoing attachments', async () => {
+			const message = generateMsg({
+				id: 'msg-123',
+				attachments: [
+					{
+						type: 'image',
+						image_url: 'https://example.com/image.jpg',
+						localMetadata: { file: {}, id: 'local-1', uploadState: 'finished' },
+					},
+				],
+			});
+
+			await client._updateMessage(message);
+
+			const sent = postSpy.mock.calls[0][1].message;
+			expect(sent.attachments).toHaveLength(1);
+			expect(sent.attachments[0]).not.toHaveProperty('localMetadata');
+			expect(sent.attachments[0].image_url).toBe('https://example.com/image.jpg');
+		});
+
+		it('drops an attachment whose upload never resolved, and warns', async () => {
+			vi.spyOn(console, 'warn').mockImplementation(() => {});
+			const message = generateMsg({
+				id: 'msg-123',
+				attachments: [
+					{
+						type: 'image',
+						image_url: 'blob:http://localhost/9f3c',
+						localMetadata: { id: 'local-1', uploadState: 'uploading' },
+					},
+				],
+			});
+
+			await client._updateMessage(message);
+
+			expect(postSpy.mock.calls[0][1].message.attachments).toEqual([]);
+			expect(loggerSpy).toHaveBeenCalledWith(
+				'warn',
+				expect.stringContaining('Dropped 1 attachment(s)'),
+				expect.objectContaining({ attachments: expect.any(Array) }),
+			);
+		});
+	});
+
 	describe('updateMessage', () => {
 		it('queues replayable updates through offlineDb', async () => {
 			const message = generateMsg({

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1344,6 +1344,55 @@ describe('sanitizeOutgoingAttachments', () => {
   });
 
   it.each([
+    ['a blob: preview (web)', 'blob:http://localhost/9f3c'],
+    ['a file: URI (React Native)', 'file:///var/mobile/tmp/IMG_0001.HEIC'],
+    ['a content: URI (Android)', 'content://media/external/images/media/42'],
+    ['an inline data: payload', 'data:image/png;base64,iVBORw0KGgo='],
+  ])('drops an attachment whose only source is %s', (_label, image_url) => {
+    // These resolve only on the device that produced them. React Native keeps the picked file's
+    // URI in `image_url` from selection onwards, so a presence check would call this resolved.
+    const { addWarning, channel } = setup();
+    const message = {
+      attachments: [
+        {
+          image_url,
+          localMetadata: { id: 'a4', uploadState: 'uploading' },
+          type: 'image',
+        },
+      ],
+    };
+
+    const result = sanitizeOutgoingAttachments({ channel, message });
+
+    expect(result.attachments).toEqual([]);
+    expect(addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { type: 'validation:attachment:unresolved-upload' },
+      }),
+    );
+  });
+
+  it('keeps an attachment whose local URL sits next to a remote one', () => {
+    // A finished upload can still carry the local preview alongside the CDN URL.
+    const { addWarning, channel } = setup();
+    const message = {
+      attachments: [
+        {
+          asset_url: 'https://cdn.example.com/v.mp4',
+          image_url: 'file:///var/mobile/tmp/thumb.jpg',
+          localMetadata: { id: 'a5', uploadState: 'finished' },
+          type: 'video',
+        },
+      ],
+    };
+
+    const result = sanitizeOutgoingAttachments({ channel, message });
+
+    expect(result.attachments).toHaveLength(1);
+    expect(addWarning).not.toHaveBeenCalled();
+  });
+
+  it.each([
     ['image_url', { image_url: 'https://cdn.example.com/i.png' }],
     ['og_scrape_url', { og_scrape_url: 'https://example.com' }],
     ['title_link', { title_link: 'https://example.com' }],

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1277,32 +1277,30 @@ describe('userHasReadReceipts', () => {
 describe('sanitizeOutgoingAttachments', () => {
   const setup = () => {
     const client = getClientWithUser();
-    const channel = client.channel('messaging', 'id');
-    const addWarning = vi
-      .spyOn(client.notifications, 'addWarning')
-      .mockImplementation(() => undefined);
-    return { addWarning, channel };
+    const logger = vi.spyOn(client, 'logger').mockImplementation(() => undefined);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    return { client, logger };
   };
 
   it('returns the same message when there are no attachments', () => {
-    const { channel } = setup();
+    const { client } = setup();
     const message = { text: 'hi' };
 
-    expect(sanitizeOutgoingAttachments({ channel, message })).toBe(message);
+    expect(sanitizeOutgoingAttachments({ client, message })).toBe(message);
   });
 
   it('returns the same message when no attachment carries localMetadata', () => {
-    const { channel } = setup();
+    const { client } = setup();
     const message = {
       attachments: [{ asset_url: 'https://cdn.example.com/f.pdf', type: 'file' }],
       text: 'hi',
     };
 
-    expect(sanitizeOutgoingAttachments({ channel, message })).toBe(message);
+    expect(sanitizeOutgoingAttachments({ client, message })).toBe(message);
   });
 
   it('strips localMetadata from an attachment that resolved', () => {
-    const { addWarning, channel } = setup();
+    const { client, logger } = setup();
     const message = {
       attachments: [
         {
@@ -1313,17 +1311,17 @@ describe('sanitizeOutgoingAttachments', () => {
       ],
     };
 
-    const result = sanitizeOutgoingAttachments({ channel, message });
+    const result = sanitizeOutgoingAttachments({ client, message });
 
     expect(result).not.toBe(message);
     expect(result.attachments).toEqual([
       { asset_url: 'https://cdn.example.com/f.pdf', type: 'file' },
     ]);
-    expect(addWarning).not.toHaveBeenCalled();
+    expect(logger).not.toHaveBeenCalled();
   });
 
   it('drops an attachment that never resolved, and warns', () => {
-    const { addWarning, channel } = setup();
+    const { client, logger } = setup();
     const message = {
       attachments: [
         { asset_url: 'https://cdn.example.com/ok.pdf', type: 'file' },
@@ -1331,15 +1329,34 @@ describe('sanitizeOutgoingAttachments', () => {
       ],
     };
 
-    const result = sanitizeOutgoingAttachments({ channel, message });
+    const result = sanitizeOutgoingAttachments({ client, message });
 
     expect(result.attachments).toEqual([
       { asset_url: 'https://cdn.example.com/ok.pdf', type: 'file' },
     ]);
-    expect(addWarning).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: { type: 'validation:attachment:unresolved-upload' },
-      }),
+    expect(logger).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('Dropped 1 attachment(s)'),
+      expect.objectContaining({ attachments: expect.any(Array) }),
+    );
+  });
+
+  it('also reaches the console', () => {
+    // `client.logger` is a no-op unless the integrator configured one, and this only fires on a
+    // bug — dropping attachments with no trace at all is the worst outcome.
+    const { client } = setup();
+    const consoleWarn = vi.mocked(console.warn);
+    const message = {
+      attachments: [
+        { localMetadata: { id: 'a6', uploadState: 'uploading' }, type: 'file' },
+      ],
+    };
+
+    sanitizeOutgoingAttachments({ client, message });
+
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Dropped 1 attachment(s)'),
+      expect.objectContaining({ attachments: expect.any(Array) }),
     );
   });
 
@@ -1351,7 +1368,7 @@ describe('sanitizeOutgoingAttachments', () => {
   ])('drops an attachment whose only source is %s', (_label, image_url) => {
     // These resolve only on the device that produced them. React Native keeps the picked file's
     // URI in `image_url` from selection onwards, so a presence check would call this resolved.
-    const { addWarning, channel } = setup();
+    const { client, logger } = setup();
     const message = {
       attachments: [
         {
@@ -1362,19 +1379,19 @@ describe('sanitizeOutgoingAttachments', () => {
       ],
     };
 
-    const result = sanitizeOutgoingAttachments({ channel, message });
+    const result = sanitizeOutgoingAttachments({ client, message });
 
     expect(result.attachments).toEqual([]);
-    expect(addWarning).toHaveBeenCalledWith(
-      expect.objectContaining({
-        options: { type: 'validation:attachment:unresolved-upload' },
-      }),
+    expect(logger).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('Dropped 1 attachment(s)'),
+      expect.objectContaining({ attachments: expect.any(Array) }),
     );
   });
 
   it('keeps an attachment whose local URL sits next to a remote one', () => {
     // A finished upload can still carry the local preview alongside the CDN URL.
-    const { addWarning, channel } = setup();
+    const { client, logger } = setup();
     const message = {
       attachments: [
         {
@@ -1386,10 +1403,10 @@ describe('sanitizeOutgoingAttachments', () => {
       ],
     };
 
-    const result = sanitizeOutgoingAttachments({ channel, message });
+    const result = sanitizeOutgoingAttachments({ client, message });
 
     expect(result.attachments).toHaveLength(1);
-    expect(addWarning).not.toHaveBeenCalled();
+    expect(logger).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -1397,7 +1414,7 @@ describe('sanitizeOutgoingAttachments', () => {
     ['og_scrape_url', { og_scrape_url: 'https://example.com' }],
     ['title_link', { title_link: 'https://example.com' }],
   ])('keeps an attachment whose only source is %s', (_label, source) => {
-    const { addWarning, channel } = setup();
+    const { client, logger } = setup();
     const message = {
       attachments: [
         {
@@ -1408,9 +1425,9 @@ describe('sanitizeOutgoingAttachments', () => {
       ],
     };
 
-    const result = sanitizeOutgoingAttachments({ channel, message });
+    const result = sanitizeOutgoingAttachments({ client, message });
 
     expect(result.attachments).toHaveLength(1);
-    expect(addWarning).not.toHaveBeenCalled();
+    expect(logger).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -9,6 +9,7 @@ import { getClientWithUser } from './test-utils/getClient';
 import { generateUUIDv4 as uuidv4 } from '../../src/utils';
 
 import {
+  sanitizeOutgoingAttachments,
   getAndWatchChannel,
   addToMessageList,
   findIndexInSortedArray,
@@ -1270,5 +1271,97 @@ describe('userHasReadReceipts', () => {
 
   it('returns true (assumes enabled) when privacy settings are unset', () => {
     expect(userHasReadReceipts(makeClient(undefined))).toBe(true);
+  });
+});
+
+describe('sanitizeOutgoingAttachments', () => {
+  const setup = () => {
+    const client = getClientWithUser();
+    const channel = client.channel('messaging', 'id');
+    const addWarning = vi
+      .spyOn(client.notifications, 'addWarning')
+      .mockImplementation(() => undefined);
+    return { addWarning, channel };
+  };
+
+  it('returns the same message when there are no attachments', () => {
+    const { channel } = setup();
+    const message = { text: 'hi' };
+
+    expect(sanitizeOutgoingAttachments({ channel, message })).toBe(message);
+  });
+
+  it('returns the same message when no attachment carries localMetadata', () => {
+    const { channel } = setup();
+    const message = {
+      attachments: [{ asset_url: 'https://cdn.example.com/f.pdf', type: 'file' }],
+      text: 'hi',
+    };
+
+    expect(sanitizeOutgoingAttachments({ channel, message })).toBe(message);
+  });
+
+  it('strips localMetadata from an attachment that resolved', () => {
+    const { addWarning, channel } = setup();
+    const message = {
+      attachments: [
+        {
+          asset_url: 'https://cdn.example.com/f.pdf',
+          localMetadata: { id: 'a1', uploadState: 'finished' },
+          type: 'file',
+        },
+      ],
+    };
+
+    const result = sanitizeOutgoingAttachments({ channel, message });
+
+    expect(result).not.toBe(message);
+    expect(result.attachments).toEqual([
+      { asset_url: 'https://cdn.example.com/f.pdf', type: 'file' },
+    ]);
+    expect(addWarning).not.toHaveBeenCalled();
+  });
+
+  it('drops an attachment that never resolved, and warns', () => {
+    const { addWarning, channel } = setup();
+    const message = {
+      attachments: [
+        { asset_url: 'https://cdn.example.com/ok.pdf', type: 'file' },
+        { localMetadata: { id: 'a2', uploadState: 'uploading' }, type: 'file' },
+      ],
+    };
+
+    const result = sanitizeOutgoingAttachments({ channel, message });
+
+    expect(result.attachments).toEqual([
+      { asset_url: 'https://cdn.example.com/ok.pdf', type: 'file' },
+    ]);
+    expect(addWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { type: 'validation:attachment:unresolved-upload' },
+      }),
+    );
+  });
+
+  it.each([
+    ['image_url', { image_url: 'https://cdn.example.com/i.png' }],
+    ['og_scrape_url', { og_scrape_url: 'https://example.com' }],
+    ['title_link', { title_link: 'https://example.com' }],
+  ])('keeps an attachment whose only source is %s', (_label, source) => {
+    const { addWarning, channel } = setup();
+    const message = {
+      attachments: [
+        {
+          ...source,
+          localMetadata: { id: 'a3', uploadState: 'finished' },
+          type: 'image',
+        },
+      ],
+    };
+
+    const result = sanitizeOutgoingAttachments({ channel, message });
+
+    expect(result.attachments).toHaveLength(1);
+    expect(addWarning).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Goal

Make it possible to compose a message while its attachment uploads are still in flight.

Today that is refused twice over: the attachments composition middleware discards any composition with uploads running (warning `Wait until all attachments have uploaded`), and `MessageComposer.hasSendableData` returns `false` for as long as `uploadsInProgressCount > 0`. A UI SDK therefore cannot offer sending before every transfer has finished, however long that takes.

This PR adds the composer-side half of that flow, plus the fixes it exposed in upload state, cancellation and preview lifecycle.

It is deliberately only half. The composition produced is not ready for the wire — `message.attachments` omits every attachment that has no URL yet — so the other half belongs to whoever performs the send: await the pending uploads, write the resolved URLs into the payload, then make the request. That is why nothing here is enabled by a config option.

Backwards compatible except in one respect: outgoing attachments are now sanitized on every send and every update, which strips composer-internal state that was previously forwarded to the API. Everything else takes effect only once a UI SDK installs the new middleware.

## Implementation details

### Composing with pending uploads

`createSendWithPendingUploadsAttachmentsMiddleware` replaces the default attachments composition middleware and shares its id, so `replace()` keeps its position in the chain. It splits the two payloads instead of discarding the composition:

- `localMessage.attachments` keeps `localMetadata` for anything still uploading — the `UploadManager` id, the file handle needed to await the upload, the local preview URI;
- `message.attachments` carries only attachments that already resolved to a URL.

Neither key is introduced when its list is empty, matching the default middleware — an empty `attachments` array is not "nothing to say", it reads as "remove every attachment" on an edit.

Attachments still uploading stay in the composer when the composition carries a poll. A poll composition does not clear the composer, so handing the attachment over would leave the same `localMetadata.id` owned by both the message and the composer, and a second `UploadManager.upload` call would restart a request whose in-flight entry had already been cleaned up.

### One switch: the middleware declares what it does

`MessageCompositionMiddleware.allowsPendingUploads` is a declaration a composition middleware sets on itself, and `MessageComposer.hasSendableData` reads it: while such a middleware is installed, an upload in flight is no longer a blocker and a pending attachment counts as content in its own right. `failed` and `blocked` attachments still do not count, so a message whose only attachment was rejected is not sendable.

Installing the middleware is therefore the whole switch — there is no second flag for a UI SDK to keep in sync with it, and a custom middleware implementing the same contract is recognised regardless of the id it uses.

Reading the declaration needs `MiddlewareExecutor.installedMiddleware`, a new read-only view of the chain (`MessageComposerMiddlewareExecutor` narrows it to the composition middleware type). Both the declaration and `MessageComposer.allowsPendingUploads` are marked temporary: v10 moves this into the composer configuration.

### The window between the last byte and the response

`UploadRecord.uploadConfirmationPending` marks the gap between the request body being flushed and the server answering, and is mirrored onto `localMetadata`. Upload progress counts bytes written to the connection, not bytes acknowledged, so it reaches 100% while the file is still being ingested — long enough to matter for a large file on a slow link. The flag is lowered only by a progress report carrying a number below 100: a report with no number means the transport cannot measure this upload, not that flushed bytes were un-sent.

### Outgoing attachments are sanitized

`sanitizeOutgoingAttachments` strips `localMetadata` and drops any attachment that never resolved, reporting the drop through `client.logger` and `console.warn`. It runs in `channel._sendMessage` and `client._updateMessage` — the two methods every path converges on, including the offline replay of a queued task, which calls them directly with a payload that a merged failed edit may have rewritten since it was stored.

"Resolved" means a remote `http(s)` URL, not merely the presence of one. A local reference — `blob:`, `file:`, `content:`, an inline `data:` payload — resolves only on the device that produced it, and forwarding it would store an attachment nobody else can load. Reaching that branch means the code that composed the message has a bug, so it is logged rather than raised as a notification, which is a channel for things an end user can act on. `partialUpdateMessage` is deliberately not covered: its `set` is a caller-authored patch that no composer output flows through.

### Cancellation is not a failure

Removing an attachment mid-upload aborts the request through its `AbortController`. `isUploadCancellation` recognises the result — an axios cancellation, or a `DOMException` named `AbortError`, which is what a custom transport conventionally throws — and both the post-upload error middleware and the deprecated `uploadAttachment` path now stay quiet instead of raising an upload error for something the user asked for.

### Preview lifecycle

`removeAttachments` releases the removed attachment's `blob:` preview, which previously leaked one object URL per removal.

The post-upload enrichment middleware releases a preview only while the composer still holds the attachment, which its new optional `composer` argument is what tells it. The middleware runs when an upload finishes, and that can now happen after the composer was cleared — at which point something else is rendering from that preview and releasing it would blank it out.

### New exports

`isPendingUpload` / `isFinishedUpload` (upload-state predicates, typed against `AttachmentLoadingState`), `isUploadCancellation`, and the tag-keyed async runners `withoutConcurrency`, `withCancellation`, `hasPending`, `settled` — so a UI SDK can serialise its own actions with the primitive this SDK already uses internally instead of hand-rolling promise chains.

### What a UI SDK has to implement

1. Install `createSendWithPendingUploadsAttachmentsMiddleware` on the composers it wants this for. Sendability follows from the declaration; nothing else needs switching.
2. In its send path, await the uploads still in flight (`UploadManager.upload` is idempotent by `localMetadata.id`, so calling it again returns the in-flight promise), write the resolved URLs into `message.attachments`, and only then make the request. Doing this in the send path rather than at submit time also covers resending a failed message, and skipping attachments that already carry a URL makes a retry re-upload only what failed.
3. Decide what ordering it wants. Two sends started in quick succession now differ in duration by however long an upload takes, and `created_at` is stamped when the request arrives — `withoutConcurrency` is exported for serialising them per channel.

`uploadConfirmationPending` is available for both a composer attachment (from `localMetadata`) and a message attachment (from the live `UploadManager` record) if the SDK wants to distinguish "sending" from "sent but unconfirmed".

### Tests

39 cases across the composition middleware, `hasSendableData`, `UploadManager`, `AttachmentManager`, the post-upload middlewares, `sanitizeOutgoingAttachments`, and the `channel` / `client` send and update paths.
