### PR TITLE
chore(client): deprecate unflagMessage and unflagUser

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3051,6 +3051,11 @@ export class StreamChat {
 
   /**
    * unflagMessage - unflag a message
+   *
+   * @deprecated The `/moderation/unflag` endpoint is deprecated and is a no-op on
+   * the backend - calling this resolves successfully but does not remove the flag.
+   * Use `client.moderation.submitAction()` against the review queue item instead.
+   *
    * @param {string} targetMessageID
    * @param {string} [options.user_id] currentUserID, only used with serverside auth
    * @returns {Promise<APIResponse>}
@@ -3064,6 +3069,11 @@ export class StreamChat {
 
   /**
    * unflagUser - unflag a user
+   *
+   * @deprecated The `/moderation/unflag` endpoint is deprecated and is a no-op on
+   * the backend - calling this resolves successfully but does not remove the flag.
+   * Use `client.moderation.submitAction()` against the review queue item instead.
+   *
    * @param {string} targetID
    * @param {string} [options.user_id] currentUserID, only used with serverside auth
    * @returns {Promise<APIResponse>}


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Closes [REACT-1123](https://linear.app/stream/issue/REACT-1123/deprecate-moderationunflag-endpoint-in-react-sdk)

**What:** Adds `@deprecated` JSDoc to `StreamChat.unflagMessage()` and `StreamChat.unflagUser()` — the only two callers of `POST /moderation/unflag`.

**Why:** The `/moderation/unflag` endpoint is deprecated on the backend and is a **no-op**. Requests resolve successfully, so callers get no signal that the flag was never removed. Silent success is the worst failure mode here — flagging it in the type surface is the cheapest way to warn integrators.

**How:** JSDoc-only, matching the existing deprecation convention in `client.ts` (`setUser`, `disconnect`, `updateUsers` are all annotated the same way, none warn at runtime). Because `tsc` emits declarations from source, the tag ships in `dist/types` and renders as strikethrough in consumers' editors.

Callers who need to actually clear a flag should use `client.moderation.submitAction()` against the review queue item, which the notice points to.

**No behavior change** — the methods still call the endpoint, so nothing breaks for existing callers.

### Notes

- **No UI SDK impact.** Swept `stream-chat-react` and `stream-chat-react-native` case-insensitively for `unflag` across ts/tsx/js/jsx/md/mdx — zero hits. Neither SDK exposes an un-flag affordance; they only ever flag.
- `test/typescript/response-generators/moderation.js` still calls both methods to generate response types against the live API. Since the endpoint returns success (just without effect), the generator keeps working and the response types stay accurate, so it's left untouched. Worth removing whenever the methods themselves are deleted.
- Per REACT-1123, the methods themselves get **removed in the next major**. This PR only lands the deprecation.
- `yarn lint` and `yarn types` are clean. No tests added — comment-only change with no runtime behavior to assert on.

## Changelog

- Deprecated `client.unflagMessage()` and `client.unflagUser()`; the underlying `/moderation/unflag` endpoint is a no-op on the backend. Use `client.moderation.submitAction()` instead.
