### PR TITLE
chore(test-types): remove dead unflag response generators

### DIFF
--- a/test/typescript/response-generators/moderation.js
+++ b/test/typescript/response-generators/moderation.js
@@ -268,84 +268,6 @@ async function removeShadowBan() {
 	return await client.unbanUser(evilUser);
 }
 
-async function unflagMessage() {
-	//flag the user
-	const authClient = utils.getTestClient(true);
-	const serverAuthClient = utils.getTestClient(true);
-	const thierry = {
-		id: 'thierry2',
-		name: 'Thierry',
-		status: 'busy',
-		image: 'myimageurl',
-		role: 'admin',
-	};
-
-	const tommaso = {
-		id: 'tommaso',
-		name: 'Tommaso',
-		image: 'myimageurl',
-		role: 'admin',
-	};
-
-	await serverAuthClient.upsertUsers([thierry, tommaso, { id: 'thierry' }]);
-	//	delete thierry.role;
-	// await isn't needed but makes testing a bit easier
-	await authClient.connectUser(thierry);
-
-	const channel = authClient.channel('livestream', `ninja-${uuidv4()}`, {
-		mysearchablefield: 'hi',
-	});
-
-	await channel.watch();
-
-	const text = 'Flag me, i dare you mods!';
-	const messageResponse = await channel.sendMessage({ text });
-	await authClient.flagMessage(messageResponse.message.id);
-
-	return await authClient.unflagMessage(messageResponse.message.id);
-}
-
-async function unflagUser() {
-	//flag the user
-	const authClient = utils.getTestClient(true);
-	const serverAuthClient = utils.getTestClient(true);
-	const evilId = uuidv4();
-	const evil = {
-		id: evilId,
-		name: 'Eviluser',
-		status: 'busy',
-		image: 'myimageurl',
-		role: 'user',
-	};
-	const thierry = {
-		id: 'thierry2',
-		name: 'Thierry',
-		status: 'busy',
-		image: 'myimageurl',
-		role: 'admin',
-	};
-
-	const tommaso = {
-		id: 'tommaso',
-		name: 'Tommaso',
-		image: 'myimageurl',
-		role: 'admin',
-	};
-
-	await serverAuthClient.upsertUsers([thierry, tommaso, { id: 'thierry' }]);
-	//	delete thierry.role;
-	// await isn't needed but makes testing a bit easier
-	await authClient.connectUser(thierry);
-	const modUserID = uuidv4();
-
-	await utils.createUsers([modUserID]);
-	await serverAuthClient.upsertUser(evil);
-
-	await authClient.flagUser(evilId);
-
-	return await authClient.unflagUser(evilId);
-}
-
 async function unmuteUser() {
 	const user1 = uuidv4();
 	const user2 = uuidv4();
@@ -409,8 +331,6 @@ module.exports = {
 	listRoles,
 	muteUser,
 	unbanUsers,
-	unflagMessage,
-	unflagUser,
 	unmuteUser,
 	updateBlockList,
 	updatePermission,


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [ ] Code changes are tested

## Description of the changes, What, Why and How?

Follow-up to [REACT-1123](https://linear.app/stream/issue/REACT-1123/deprecate-moderationunflag-endpoint-in-react-sdk), which called for deprecating `/moderation/unflag` on v9 and removing it in the next major. [#1846](https://github.com/GetStream/stream-chat-js/pull/1846) landed the v9 deprecation; this is the v10 side.

**The methods themselves are already gone.** `client.unflagMessage()` and `client.unflagUser()` were removed from `src/` in dc49a78d (`feat!: remove hand-written types and API wrappers`, #1836) along with the rest of the hand-written API wrappers — `grep -ri unflag src/` on `release-v10` returns nothing. The migration guide already documents the outcome: "V2 has no unflag endpoint." So there is no source change to make here.

**What was left behind** is the pair of response generators in the type-test harness. This PR deletes them plus their two export entries.

To be clear about the severity: this is **dead code, not a live failure**. `test/typescript/index.js` no longer registers either generator in its `executables` list, so nothing ever invoked them — they were exported into the void. Removing them is tidiness, not a fix.

Migration guides and `CHANGELOG.md` also mention `unflag`, but those are historical record and are deliberately left untouched.

### Verification

- `prettier --check` clean; `node --check` passes on the edited file and on `response-generators/index.js`.
- No behavior to test — this removes unreachable code and touches nothing that ships in `dist/`.
- `yarn test-types` was **not** run: it hits the live Stream API and needs `API_KEY` / `API_SECRET`. See the note below before relying on it.

### ⚠️ Pre-existing breakage on `release-v10`, not addressed here

While confirming the above I found the sibling `flag` methods are in a worse state than the `unflag` ones, and it predates this PR:

`flagUser` / `flagMessage` also moved off `StreamChat` in #1836 (they now live on `Moderation`, `src/moderation.ts:34` and `:66`, reached via `client.moderation.*`). But unlike the `unflag` pair, **their generators are still registered** at `test/typescript/index.js:160-167`:

- the generators call `authClient.flagMessage(...)` / `authClient.flagUser(...)` → runtime `TypeError`, and
- they are typed `Unpacked<ReturnType<StreamChat['flagMessage']>>` → indexed access on a member that no longer exists, so the generated `data.ts` won't typecheck.

That means `yarn test-types` is already broken on this branch, independent of this PR. I left it alone because the fix is a judgment call — migrate both to `client.moderation.*` and retype against `Moderation` (preserves coverage, probably preferred), or drop them from the harness the way the `unflag` generators were already dropped. Happy to take it in a follow-up.

## Changelog

- Removed the dead `unflagMessage` / `unflagUser` response generators from the type-test harness. No public API change; the methods themselves were already removed in #1836.