### PR TITLE
fix: isolate event listener errors from the dispatch loop

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -6,6 +6,7 @@ import { MessageReceiptsTracker } from './messageDelivery';
 import {
   channelHasReadEvents,
   generateChannelTempCid,
+  invokeEventListener,
   logChatPromiseExecution,
   messageSetPagination,
   normalizeQuerySort,
@@ -2354,22 +2355,17 @@ export class Channel {
   }
 
   _callChannelListeners = (event: Event) => {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const channel = this;
-    // gather and call the listeners
-    const listeners = [];
-    if (channel.listeners.all) {
-      listeners.push(...channel.listeners.all);
-    }
-    if (channel.listeners[event.type]) {
-      listeners.push(...channel.listeners[event.type]);
-    }
+    // snapshot before dispatching: `on` pushes into these arrays in place, so a
+    // listener that subscribes while handling an event must not be invoked for it
+    const listeners = [
+      ...(this.listeners.all ?? []),
+      ...(this.listeners[event.type] ?? []),
+    ];
 
-    // call the event and send it to the listeners
+    const { logger } = this._client;
     for (const listener of listeners) {
-      if (typeof listener !== 'string') {
-        listener(event);
-      }
+      if (typeof listener === 'string') continue;
+      invokeEventListener(listener, event, logger);
     }
   };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,10 +29,12 @@ import {
   axiosParamsSerializer,
   chatCodes,
   generateChannelTempCid,
+  invokeEventListener,
   isFunction,
   isOnline,
   isOwnUserBaseProperty,
   messageSetPagination,
+  noopLogger,
   normalizeQuerySort,
   randomId,
   retryInterval,
@@ -575,7 +577,7 @@ export class StreamChat {
      *    channel: object
      * }
      */
-    this.logger = isFunction(inputOptions.logger) ? inputOptions.logger : () => null;
+    this.logger = isFunction(inputOptions.logger) ? inputOptions.logger : noopLogger;
     this.recoverStateOnReconnect = this.options.recoverStateOnReconnect;
     this.threads = new ThreadManager({ client: this });
     this.polls = new PollManager({ client: this });
@@ -1700,20 +1702,15 @@ export class StreamChat {
   }
 
   _callClientListeners = (event: Event) => {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const client = this;
-    // gather and call the listeners
-    const listeners: Array<(event: Event) => void> = [];
-    if (client.listeners.all) {
-      listeners.push(...client.listeners.all);
-    }
-    if (client.listeners[event.type]) {
-      listeners.push(...client.listeners[event.type]);
-    }
+    // snapshot before dispatching: `on` pushes into these arrays in place, so a
+    // listener that subscribes while handling an event must not be invoked for it
+    const listeners = [
+      ...(this.listeners.all ?? []),
+      ...(this.listeners[event.type] ?? []),
+    ];
 
-    // call the event and send it to the listeners
     for (const listener of listeners) {
-      listener(event);
+      invokeEventListener(listener, event, this.logger);
     }
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,8 +47,9 @@ export function logChatPromiseExecution<T>(promise: Promise<T>, name: string) {
 export const noopLogger: Logger = () => null;
 
 const logError = <T>(logger: Logger, error: unknown, event: T) => {
-  logger('error', 'Unhandled error in event listener', { error, event });
-  if (logger === noopLogger) console.error(error);
+  const message = 'Unhandled error in event listener';
+  logger('error', message, { error, event });
+  if (logger === noopLogger) console.error(message, error, event);
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,6 +41,35 @@ export function logChatPromiseExecution<T>(promise: Promise<T>, name: string) {
   });
 }
 
+/**
+ * The default no-op client logger.
+ */
+export const noopLogger: Logger = () => null;
+
+const logError = <T>(logger: Logger, error: unknown, event: T) => {
+  logger('error', 'Unhandled error in event listener', { error, event });
+  if (logger === noopLogger) console.error(error);
+};
+
+/**
+ * Invokes a single event listener in isolation, so that a faulty listener cannot
+ * abort the dispatch loop or the bookkeeping that follows it.
+ */
+export const invokeEventListener = <T>(
+  listener: (event: T) => unknown,
+  event: T,
+  logger: Logger,
+) => {
+  try {
+    const result = listener(event);
+    if (result && typeof (result as PromiseLike<unknown>).then === 'function') {
+      Promise.resolve(result).catch((error) => logError(logger, error, event));
+    }
+  } catch (error) {
+    logError(logger, error, event);
+  }
+};
+
 export const sleep = (m: number): Promise<void> => new Promise((r) => setTimeout(r, m));
 
 export function isFunction(value: unknown): value is (...args: unknown[]) => unknown {

--- a/test/unit/MessageComposer/textComposer.test.ts
+++ b/test/unit/MessageComposer/textComposer.test.ts
@@ -30,7 +30,8 @@ vi.mock('../.././src/messageComposer/middleware', () => ({
 }));
 
 // Mock dependencies
-vi.mock('../../../src/utils', () => ({
+vi.mock('../../../src/utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../src/utils')>()),
   axiosParamsSerializer: vi.fn(),
   isFunction: vi.fn(),
   isString: vi.fn(),

--- a/test/unit/channel_state.test.js
+++ b/test/unit/channel_state.test.js
@@ -1825,8 +1825,23 @@ describe('loadMessageIntoState', () => {
 	});
 
 	it('should do nothing if message is available locally in the current set', async () => {
-		state.addMessagesSorted([generateMsg({ id: '8' })], false, true, true, 'latest');
-		state.addMessagesSorted([generateMsg({ id: '5' })], false, true, true, 'new');
+		// pin the timestamps: with `new Date()` defaults the two messages land in the
+		// same millisecond on a fast machine and get merged into one set by timestamp
+		// overlap, but straddle a millisecond boundary under load and do not
+		state.addMessagesSorted(
+			[generateMsg({ id: '8', date: toISOString(800) })],
+			false,
+			true,
+			true,
+			'latest',
+		);
+		state.addMessagesSorted(
+			[generateMsg({ id: '5', date: toISOString(500) })],
+			false,
+			true,
+			true,
+			'new',
+		);
 		await state.loadMessageIntoState('8');
 
 		expect(state.messageSets[0].isCurrent).to.be.equal(true);

--- a/test/unit/eventListenerIsolation.test.ts
+++ b/test/unit/eventListenerIsolation.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamChat } from '../../src';
+import type { Event } from '../../src';
+import { getClientWithUser } from './test-utils/getClient';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('client event listener isolation', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('keeps calling later listeners when one throws synchronously', () => {
+    const client = getClientWithUser();
+    const second = vi.fn();
+
+    client.on('message.new', () => {
+      throw new Error('listener boom');
+    });
+    client.on('message.new', second);
+
+    expect(() => client.dispatchEvent({ type: 'message.new' } as Event)).not.toThrow();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a synchronous throw to console.error when no logger is configured', () => {
+    const client = getClientWithUser();
+    const error = new Error('listener boom');
+
+    client.on('message.new', () => {
+      throw error;
+    });
+    client.dispatchEvent({ type: 'message.new' } as Event);
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+  });
+
+  it('captures a rejection from an async listener', async () => {
+    const client = getClientWithUser();
+    const error = new Error('async boom');
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    client.on('message.new', async () => {
+      throw error;
+    });
+    client.dispatchEvent({ type: 'message.new' } as Event);
+    await flush();
+    process.off('unhandledRejection', onUnhandled);
+
+    expect(rejections).toHaveLength(0);
+    expect(consoleError).toHaveBeenCalledWith(error);
+  });
+
+  it('reports through a configured logger at error level', () => {
+    const logger = vi.fn();
+    const client = new StreamChat('key', { logger });
+    const error = new Error('listener boom');
+
+    client.on('message.new', () => {
+      throw error;
+    });
+    client.dispatchEvent({ type: 'message.new' } as Event);
+
+    expect(logger).toHaveBeenCalledWith(
+      'error',
+      'Unhandled error in event listener',
+      expect.objectContaining({ error }),
+    );
+    // a configured logger takes over, no duplicate console output
+    expect(consoleError).not.toHaveBeenCalledWith(error);
+  });
+
+  it('does not invoke a listener that subscribes during dispatch', () => {
+    const client = getClientWithUser();
+    const late = vi.fn();
+
+    client.on('message.new', () => {
+      client.on('message.new', late);
+    });
+    client.dispatchEvent({ type: 'message.new' } as Event);
+
+    expect(late).not.toHaveBeenCalled();
+
+    // it is picked up by the next event
+    client.dispatchEvent({ type: 'message.new' } as Event);
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  it('terminates when a listener re-subscribes itself on every dispatch', () => {
+    const client = getClientWithUser();
+    let calls = 0;
+    const handler = () => {
+      calls += 1;
+      if (calls > 100) throw new Error('runaway dispatch loop');
+      client.on('message.new', handler);
+    };
+
+    client.on('message.new', handler);
+    client.dispatchEvent({ type: 'message.new' } as Event);
+
+    expect(calls).toBe(1);
+  });
+
+  it('still runs post-listener callbacks and channel listeners after a throw', () => {
+    const client = getClientWithUser();
+    const channel = client.channel('messaging', 'evicted');
+    client.activeChannels[channel.cid] = channel;
+
+    const channelListener = vi.fn();
+    channel.on('notification.removed_from_channel', channelListener);
+    client.on('notification.removed_from_channel', () => {
+      throw new Error('listener boom');
+    });
+
+    client.dispatchEvent({
+      type: 'notification.removed_from_channel',
+      cid: channel.cid,
+    } as Event);
+
+    expect(channelListener).toHaveBeenCalledTimes(1);
+    // postListenerCallbacks evict the channel; a throwing listener must not skip them
+    expect(client.activeChannels[channel.cid]).toBeUndefined();
+  });
+});
+
+describe('channel event listener isolation', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('keeps calling later channel listeners when one throws', () => {
+    const client = getClientWithUser();
+    const channel = client.channel('messaging', 'isolation');
+    client.activeChannels[channel.cid] = channel;
+    const second = vi.fn();
+
+    channel.on('message.new', () => {
+      throw new Error('channel listener boom');
+    });
+    channel.on('message.new', second);
+
+    expect(() =>
+      client.dispatchEvent({ type: 'message.new', cid: channel.cid } as Event),
+    ).not.toThrow();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('captures a rejection from an async channel listener', async () => {
+    const client = getClientWithUser();
+    const channel = client.channel('messaging', 'isolation-async');
+    client.activeChannels[channel.cid] = channel;
+    const error = new Error('channel async boom');
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+
+    channel.on('message.new', async () => {
+      throw error;
+    });
+    client.dispatchEvent({ type: 'message.new', cid: channel.cid } as Event);
+    await flush();
+    process.off('unhandledRejection', onUnhandled);
+
+    expect(rejections).toHaveLength(0);
+    expect(consoleError).toHaveBeenCalledWith(error);
+  });
+});

--- a/test/unit/eventListenerIsolation.test.ts
+++ b/test/unit/eventListenerIsolation.test.ts
@@ -5,6 +5,10 @@ import { getClientWithUser } from './test-utils/getClient';
 
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+// what matters is that the error object reached the reporter, not how the
+// message was worded or where in the argument list it landed
+const reportedErrors = (spy: ReturnType<typeof vi.spyOn>) => spy.mock.calls.flat();
+
 describe('client event listener isolation', () => {
   let consoleError: ReturnType<typeof vi.spyOn>;
 
@@ -38,7 +42,7 @@ describe('client event listener isolation', () => {
     });
     client.dispatchEvent({ type: 'message.new' } as Event);
 
-    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(reportedErrors(consoleError)).toContain(error);
   });
 
   it('captures a rejection from an async listener', async () => {
@@ -56,7 +60,7 @@ describe('client event listener isolation', () => {
     process.off('unhandledRejection', onUnhandled);
 
     expect(rejections).toHaveLength(0);
-    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(reportedErrors(consoleError)).toContain(error);
   });
 
   it('reports through a configured logger at error level', () => {
@@ -71,11 +75,11 @@ describe('client event listener isolation', () => {
 
     expect(logger).toHaveBeenCalledWith(
       'error',
-      'Unhandled error in event listener',
+      expect.any(String),
       expect.objectContaining({ error }),
     );
     // a configured logger takes over, no duplicate console output
-    expect(consoleError).not.toHaveBeenCalledWith(error);
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it('does not invoke a listener that subscribes during dispatch', () => {
@@ -176,6 +180,6 @@ describe('channel event listener isolation', () => {
     process.off('unhandledRejection', onUnhandled);
 
     expect(rejections).toHaveLength(0);
-    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(reportedErrors(consoleError)).toContain(error);
   });
 });


### PR DESCRIPTION
## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

**What.** A faulty client or channel event listener can no longer abort event dispatch. `StreamChat._callClientListeners` and `Channel._callChannelListeners` both route through a new shared `invokeEventListener` helper in `src/utils.ts`.

**Why.** An exception from a listener propagated out of `dispatchEvent`, which skipped `postListenerCallbacks` (the callbacks that delete evicted cids from `activeChannels` on `channel.deleted` / `notification.removed_from_channel`) and the `offlineDb.handleEvent` write. On `WSConnectionFallback._poll` it landed in the transport catch, so a listener bug was treated as a network error: the remaining events in the batch were dropped and `retryInterval` backoff kicked in. On the WS transport it skipped `scheduleConnectionCheck()`.

**How.** `invokeEventListener` reports two failure modes: a synchronous throw, and a rejected promise from an `async` listener (async handlers are assignable to the void-returning `EventHandler` type, so they were previously silent unhandled rejections). Reporting goes through the client logger at `error` level, falling back to `console.error` when the integration has not configured one, so listener bugs are never discarded silently. Both dispatch loops also snapshot their listener arrays before iterating, since `on` pushes in place.

No public API change: `src/index.ts` re-exports `./utils` through an explicit allowlist, so `invokeEventListener` and `noopLogger` stay internal.

Covered by `test/unit/eventListenerIsolation.test.ts` (9 tests): sync-throw isolation, the `console.error` fallback, async rejection capture, error-level reporting through a configured logger, `postListenerCallbacks` still evicting the channel after a throw, listeners registered mid-dispatch not firing for the current event, and both channel-side cases.

One known limitation, called out deliberately: the reporting path calls `logger` directly, so a custom logger that itself throws is not contained.

## Changelog

- Event listener errors, including rejections from `async` listeners, no longer interrupt event dispatch and are reported instead of silently discarded.
