### PR TITLE
fix: send the read request regardless of read receipt privacy settings

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1222,7 +1222,8 @@ export class Channel {
   }
 
   /**
-   * markReadRequest - Send the mark read event for this user, only works if the `read_events` setting is enabled
+   * markReadRequest - Send the mark read event for this user, only works if the `read_events` setting is
+   * enabled and the user holds the `read-events` capability on this channel
    *
    * @param {MarkReadOptions} data
    * @return {Promise<EventAPIResponse | null>} Description
@@ -1230,7 +1231,13 @@ export class Channel {
   async markAsReadRequest(data: MarkReadOptions = {}) {
     this._checkInitialized();
 
-    if (!this.getConfig()?.read_events && !this.getClient()._isUsingServerAuth()) {
+    // Server-side auth acts on behalf of a user with no own capabilities, so only the client-side
+    // flow is gated. Channels the user has no `read-events` capability on do not track read state
+    // on the backend at all - see `markReadLocally` for the client-local unread count.
+    if (
+      !this.getClient()._isUsingServerAuth() &&
+      (!this.getConfig()?.read_events || !channelHasReadEvents(this))
+    ) {
       return null;
     }
 
@@ -1240,7 +1247,8 @@ export class Channel {
   }
 
   /**
-   * markUnread - Mark the channel as unread from messageID, only works if the `read_events` setting is enabled
+   * markUnread - Mark the channel as unread from messageID, only works if the `read_events` setting is
+   * enabled and the user holds the `read-events` capability on this channel
    *
    * @param {MarkUnreadOptions} data
    * @return {APIResponse} An API response
@@ -1248,7 +1256,11 @@ export class Channel {
   async markUnread(data: MarkUnreadOptions) {
     this._checkInitialized();
 
-    if (!this.getConfig()?.read_events && !this.getClient()._isUsingServerAuth()) {
+    // Gated the same way as `markAsReadRequest` - see the comment there.
+    if (
+      !this.getClient()._isUsingServerAuth() &&
+      (!this.getConfig()?.read_events || !channelHasReadEvents(this))
+    ) {
       return Promise.resolve(null);
     }
 

--- a/src/messageDelivery/MessageDeliveryReporter.ts
+++ b/src/messageDelivery/MessageDeliveryReporter.ts
@@ -10,7 +10,7 @@ import type {
   MarkReadOptions,
 } from '../types';
 import { type APIErrorResponse } from '../types';
-import { throttle, userHasReadReceipts } from '../utils';
+import { throttle } from '../utils';
 import { isAPIError, isErrorRetryable } from '../errors';
 
 const MAX_DELIVERED_MESSAGE_COUNT_IN_PAYLOAD = 100 as const;
@@ -279,8 +279,6 @@ export class MessageDeliveryReporter {
    * @param options
    */
   public markRead = async (collection: Channel | Thread, options?: MarkReadOptions) => {
-    if (!userHasReadReceipts(this.client)) return null;
-
     let result: EventAPIResponse | null = null;
     if (isChannel(collection)) {
       result = await collection.markAsReadRequest(options);
@@ -291,7 +289,10 @@ export class MessageDeliveryReporter {
       });
     }
 
-    this.removeCandidateFor(collection);
+    // A read implies delivery, so the candidate is only dropped once the request actually went
+    // out. `markAsReadRequest` returns null for channels that do not track read state on the
+    // backend, and those candidates must survive for the next delivery report.
+    if (result) this.removeCandidateFor(collection);
     return result;
   };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -156,13 +156,6 @@ export const channelTracksReadLocally = (channel?: Channel) =>
   !channelHasReadEvents(channel) &&
   !!channel?.getClient().options.isLocalUnreadCountEnabled;
 
-/**
- * userHasReadReceipts - Whether the current user allows read receipts, per their privacy settings.
- * Read receipts are treated as enabled unless the user has explicitly disabled them.
- */
-export const userHasReadReceipts = (client: StreamChat) =>
-  client.user?.privacy_settings?.read_receipts?.enabled ?? true;
-
 export function addFileToFormData(
   uri: string | NodeJS.ReadableStream | Buffer | File,
   name?: string,

--- a/test/unit/channel.test.js
+++ b/test/unit/channel.test.js
@@ -211,6 +211,129 @@ describe('Channel count unread', function () {
 	});
 });
 
+describe('Channel markAsReadRequest and markUnread', function () {
+	const user = { id: 'user' };
+
+	const setup = ({ ownCapabilities, readEvents = true, serverSide = false } = {}) => {
+		const client = serverSide
+			? new StreamChat('apiKey', 'secret')
+			: getClientWithUser(user);
+		const channel = client.channel('messaging', 'channel-id');
+		channel.initialized = true;
+		channel.data = { ...channel.data, own_capabilities: ownCapabilities };
+		client.configs[channel.cid] = { read_events: readEvents };
+		const post = vi.spyOn(client, 'post').mockResolvedValue({ event: {} });
+		return { channel, post };
+	};
+
+	it('sends the request when the user holds the read-events capability', async () => {
+		const { channel, post } = setup({ ownCapabilities: ['read-events'] });
+
+		await channel.markAsReadRequest();
+
+		expect(post).toHaveBeenCalledTimes(1);
+		expect(post.mock.calls[0][0]).to.contain('/read');
+	});
+
+	// Channels the user has no read-events capability on do not track read state on the backend;
+	// `markReadLocally` is the client-local path for those.
+	it('does not send the request when the read-events capability is missing', async () => {
+		const { channel, post } = setup({ ownCapabilities: [] });
+
+		const result = await channel.markAsReadRequest();
+
+		expect(post).not.toHaveBeenCalled();
+		expect(result).to.be.null;
+	});
+
+	// own_capabilities can be absent on partially hydrated or offline state - fail open there,
+	// otherwise a cold start would stop clearing the unread count.
+	it('sends the request when own_capabilities is absent', async () => {
+		const { channel, post } = setup({ ownCapabilities: undefined });
+
+		await channel.markAsReadRequest();
+
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not send the request when read events are disabled for the channel type', async () => {
+		const { channel, post } = setup({
+			ownCapabilities: ['read-events'],
+			readEvents: false,
+		});
+
+		const result = await channel.markAsReadRequest();
+
+		expect(post).not.toHaveBeenCalled();
+		expect(result).to.be.null;
+	});
+
+	// Server-side auth acts on behalf of a user whose own capabilities the client never sees.
+	it('sends the request server-side regardless of capabilities and config', async () => {
+		const { channel, post } = setup({
+			ownCapabilities: [],
+			readEvents: false,
+			serverSide: true,
+		});
+
+		await channel.markAsReadRequest({ user_id: user.id });
+
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	// markUnread is gated the same way - the UI SDKs already hide the affordance without the
+	// `read-events` capability.
+	it('markUnread sends the request when the user holds the read-events capability', async () => {
+		const { channel, post } = setup({ ownCapabilities: ['read-events'] });
+
+		await channel.markUnread({ message_id: 'm1' });
+
+		expect(post).toHaveBeenCalledTimes(1);
+		expect(post.mock.calls[0][0]).to.contain('/unread');
+	});
+
+	it('markUnread does not send the request when the read-events capability is missing', async () => {
+		const { channel, post } = setup({ ownCapabilities: [] });
+
+		const result = await channel.markUnread({ message_id: 'm1' });
+
+		expect(post).not.toHaveBeenCalled();
+		expect(result).to.be.null;
+	});
+
+	it('markUnread sends the request when own_capabilities is absent', async () => {
+		const { channel, post } = setup({ ownCapabilities: undefined });
+
+		await channel.markUnread({ message_id: 'm1' });
+
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+
+	it('markUnread does not send the request when read events are disabled for the channel type', async () => {
+		const { channel, post } = setup({
+			ownCapabilities: ['read-events'],
+			readEvents: false,
+		});
+
+		const result = await channel.markUnread({ message_id: 'm1' });
+
+		expect(post).not.toHaveBeenCalled();
+		expect(result).to.be.null;
+	});
+
+	it('markUnread sends the request server-side regardless of capabilities and config', async () => {
+		const { channel, post } = setup({
+			ownCapabilities: [],
+			readEvents: false,
+			serverSide: true,
+		});
+
+		await channel.markUnread({ message_id: 'm1', user_id: user.id });
+
+		expect(post).toHaveBeenCalledTimes(1);
+	});
+});
+
 describe('Channel localized unread count (isLocalUnreadCountEnabled)', function () {
 	const user = { id: 'user' };
 	const otherUser = { id: 'other-user' };

--- a/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
+++ b/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
@@ -7,7 +7,9 @@ import {
   Event,
   EventAPIResponse,
   StreamChat,
+  Thread,
 } from '../../../src';
+import { generateThreadResponse } from '../test-utils/generateThreadResponse';
 import type { AxiosResponse } from 'axios';
 
 const channelType = 'messaging';
@@ -295,16 +297,40 @@ describe('MessageDeliveryReporter', () => {
     });
   });
 
-  it('does not send a read when the user disabled read receipts', async () => {
+  // Read receipt privacy is enforced by the backend, which stops broadcasting the read to other
+  // users but still advances the caller's own last_read. Skipping the request client-side left the
+  // channel permanently unread for those users.
+  it('sends the read request when the user disabled read receipts', async () => {
     (client as any).user.privacy_settings = { read_receipts: { enabled: false } };
+    const response = { event: {} } as any;
     const markAsReadRequestSpy = vi
       .spyOn(channel, 'markAsReadRequest')
-      .mockResolvedValue({} as any);
+      .mockResolvedValue(response);
 
     const result = await channel.markRead();
 
-    expect(markAsReadRequestSpy).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(markAsReadRequestSpy).toHaveBeenCalledTimes(1);
+    expect(result).toBe(response);
+  });
+
+  it('sends the thread read request when the user disabled read receipts', async () => {
+    (client as any).user.privacy_settings = { read_receipts: { enabled: false } };
+    const response = { event: {} } as any;
+    const markAsReadRequestSpy = vi
+      .spyOn(channel, 'markAsReadRequest')
+      .mockResolvedValue(response);
+    const thread = new Thread({
+      client,
+      threadData: generateThreadResponse(
+        { type: channelType, id: channelId, cid: channel.cid },
+        mkMsg('parent', 1000),
+      ),
+    });
+
+    const result = await client.messageDeliveryReporter.markRead(thread);
+
+    expect(markAsReadRequestSpy).toHaveBeenCalledWith({ thread_id: thread.id });
+    expect(result).toBe(response);
   });
 
   it('removes the pending delivery candidate upon channel.markRead', async () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -15,7 +15,6 @@ import {
   findIndexInSortedArray,
   channelHasReadEvents,
   channelTracksReadLocally,
-  userHasReadReceipts,
   formatMessage,
   generateChannelTempCid,
   shouldConsiderArchivedChannels,
@@ -1245,32 +1244,6 @@ describe('channelTracksReadLocally', () => {
 
   it('returns false when the channel is undefined', () => {
     expect(channelTracksReadLocally(undefined)).toBe(false);
-  });
-});
-
-describe('userHasReadReceipts', () => {
-  const makeClient = (readReceiptsEnabled?: boolean) => {
-    const client = new StreamChat('apiKey');
-    client.user = {
-      id: 'user',
-      privacy_settings:
-        readReceiptsEnabled === undefined
-          ? undefined
-          : { read_receipts: { enabled: readReceiptsEnabled } },
-    };
-    return client;
-  };
-
-  it('returns true when read receipts are enabled', () => {
-    expect(userHasReadReceipts(makeClient(true))).toBe(true);
-  });
-
-  it('returns false when read receipts are explicitly disabled', () => {
-    expect(userHasReadReceipts(makeClient(false))).toBe(false);
-  });
-
-  it('returns true (assumes enabled) when privacy settings are unset', () => {
-    expect(userHasReadReceipts(makeClient(undefined))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Goal

1. Do not guard marking channel or thread read by read-receipts setting (`privacy_settings.read_receipts.enabled`). It is unrelated to the ability to mark a channel / thread. 
2. The PR also adds user permission check to mark channel read or unread to already existing channel config check.
