### PR TITLE
fix: send the read request regardless of read receipt privacy settings in v10

### DIFF
--- a/src/messageDelivery/MessageDeliveryReporter.ts
+++ b/src/messageDelivery/MessageDeliveryReporter.ts
@@ -13,7 +13,7 @@ import type {
   StreamAPIError,
   StreamResponse,
 } from '../types';
-import { throttle, userHasReadReceipts } from '../utils';
+import { throttle } from '../utils';
 import { isAPIError, isErrorRetryable } from '../errors';
 
 export type MessageDeliveryReporterConfig = {
@@ -394,7 +394,6 @@ export class MessageDeliveryReporter {
    * @returns The server response, or `null` when the collection is unsupported.
    */
   public markRead = async (collection: Channel | Thread, options?: MarkReadRequest) => {
-    if (!userHasReadReceipts(this.client)) return null;
     const isThreadCollection = isThread(collection);
     const channel = isThreadCollection ? collection.channel : collection;
     const requestOptions = isThreadCollection

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,6 @@ import type {
   ReactionResponse,
   UserResponse,
 } from './types';
-import type { StreamChat } from './client';
 import type { Channel } from './channel';
 import type { AxiosRequestConfig } from 'axios';
 import { LOCAL_MESSAGE_FIELDS, RESERVED_UPDATED_MESSAGE_FIELDS } from './constants';
@@ -88,13 +87,6 @@ export const channelHasReadEvents = (channel?: Channel) => {
 export const channelTracksReadLocally = (channel?: Channel) =>
   !channelHasReadEvents(channel) &&
   !!channel?.getClient().options.isLocalUnreadCountEnabled;
-
-/**
- * userHasReadReceipts - Whether the current user allows read receipts, per their privacy settings.
- * Read receipts are treated as enabled unless the user has explicitly disabled them.
- */
-export const userHasReadReceipts = (client: StreamChat) =>
-  client.user?.privacy_settings?.read_receipts?.enabled ?? true;
 
 /**
  * retryInterval - A retry interval which increases acc to number of failures

--- a/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
+++ b/test/unit/messageDelivery/MessageDeliveryReporter.test.ts
@@ -375,16 +375,18 @@ describe('MessageDeliveryReporter', () => {
     });
   });
 
-  it('does not send a read when the user disabled read receipts', async () => {
+  // Read receipt privacy is enforced by the backend, which stops broadcasting the read to other
+  // users but still advances the caller's own last_read. Skipping the request client-side left the
+  // channel permanently unread for those users.
+  it('sends the read request when the user disabled read receipts', async () => {
     (client as any).user.privacy_settings = { read_receipts: { enabled: false } };
-    const markAsReadRequestSpy = vi
-      .spyOn(channel, 'markRead')
-      .mockResolvedValue({} as any);
+    const response = { event: {} } as any;
+    const markReadSpy = vi.spyOn(channel, 'markRead').mockResolvedValue(response);
 
     const result = await channel.markReadViaReporter();
 
-    expect(markAsReadRequestSpy).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(markReadSpy).toHaveBeenCalledTimes(1);
+    expect(result).toBe(response);
   });
 
   it('removes the pending delivery candidate upon channel.markReadViaReporter', async () => {

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -11,7 +11,6 @@ import {
   findIndexInSortedArray,
   channelHasReadEvents,
   channelTracksReadLocally,
-  userHasReadReceipts,
   formatMessage,
   generateChannelTempCid,
   localMessageToNewMessagePayload,
@@ -616,32 +615,6 @@ describe('channelTracksReadLocally', () => {
 
   it('returns false when the channel is undefined', () => {
     expect(channelTracksReadLocally(undefined)).toBe(false);
-  });
-});
-
-describe('userHasReadReceipts', () => {
-  const makeClient = (readReceiptsEnabled?: boolean) => {
-    const client = new StreamChat('apiKey');
-    client.user = {
-      id: 'user',
-      privacy_settings:
-        readReceiptsEnabled === undefined
-          ? undefined
-          : { read_receipts: { enabled: readReceiptsEnabled } },
-    };
-    return client;
-  };
-
-  it('returns true when read receipts are enabled', () => {
-    expect(userHasReadReceipts(makeClient(true))).toBe(true);
-  });
-
-  it('returns false when read receipts are explicitly disabled', () => {
-    expect(userHasReadReceipts(makeClient(false))).toBe(false);
-  });
-
-  it('returns true (assumes enabled) when privacy settings are unset', () => {
-    expect(userHasReadReceipts(makeClient(undefined))).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Goal

Port #1853 to v10.