### PR TITLE
feat(client): support custom_set and custom_unset in batch channel update

### DIFF
--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -4,6 +4,7 @@ import type {
   BatchChannelDataUpdate,
   NewMemberPayload,
   UpdateChannelsBatchFilters,
+  UpdateChannelsBatchOptions,
   UpdateChannelsBatchResponse,
 } from './types';
 
@@ -194,18 +195,26 @@ export class ChannelBatchUpdater {
   /**
    * updateData - Update data on channels matching the filter
    *
+   * `data.custom` replaces the channel's whole custom object. To patch
+   * individual custom keys instead, pass `custom_set` / `custom_unset`, which
+   * the client sends at the request root rather than inside `data`; `data` may
+   * then be omitted.
+   *
    * @param {UpdateChannelsBatchFilters} filter Filter to select channels
    * @param {BatchChannelDataUpdate} data Data to update
+   * @param {Pick<UpdateChannelsBatchOptions, 'custom_set' | 'custom_unset'>} customPatch Custom keys to merge in or delete
    * @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
    */
   async updateData(
     filter: UpdateChannelsBatchFilters,
-    data: BatchChannelDataUpdate,
+    data?: BatchChannelDataUpdate,
+    customPatch?: Pick<UpdateChannelsBatchOptions, 'custom_set' | 'custom_unset'>,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
     return await this.client.updateChannelsBatch({
       operation: 'updateData',
       filter,
       data,
+      ...customPatch,
     });
   }
 }

--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -222,12 +222,16 @@ export class ChannelBatchUpdater {
     filter: UpdateChannelsBatchFilters,
     update: BatchChannelDataUpdate | ChannelBatchDataUpdateOptions,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
-    const options = isChannelBatchDataUpdateOptions(update) ? update : { data: update };
+    const { data, custom_set, custom_unset } = isChannelBatchDataUpdateOptions(update)
+      ? update
+      : { data: update };
 
     return await this.client.updateChannelsBatch({
       operation: 'updateData',
       filter,
-      ...options,
+      ...(data && { data }),
+      ...(custom_set && { custom_set }),
+      ...(custom_unset && { custom_unset }),
     });
   }
 }

--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -212,14 +212,6 @@ export class ChannelBatchUpdater {
    */
   async updateData(
     filter: UpdateChannelsBatchFilters,
-    data: BatchChannelDataUpdate,
-  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
-  async updateData(
-    filter: UpdateChannelsBatchFilters,
-    options: ChannelBatchDataUpdateOptions,
-  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
-  async updateData(
-    filter: UpdateChannelsBatchFilters,
     update: BatchChannelDataUpdate | ChannelBatchDataUpdateOptions,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
     const options = isChannelBatchDataUpdateOptions(update) ? update : { data: update };

--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -212,6 +212,14 @@ export class ChannelBatchUpdater {
    */
   async updateData(
     filter: UpdateChannelsBatchFilters,
+    data: BatchChannelDataUpdate,
+  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
+  async updateData(
+    filter: UpdateChannelsBatchFilters,
+    options: ChannelBatchDataUpdateOptions,
+  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
+  async updateData(
+    filter: UpdateChannelsBatchFilters,
     update: BatchChannelDataUpdate | ChannelBatchDataUpdateOptions,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
     const options = isChannelBatchDataUpdateOptions(update) ? update : { data: update };

--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -2,11 +2,16 @@ import type { StreamChat } from './client';
 import type {
   APIResponse,
   BatchChannelDataUpdate,
-  ChannelCustomPatch,
+  ChannelBatchDataUpdateOptions,
   NewMemberPayload,
   UpdateChannelsBatchFilters,
   UpdateChannelsBatchResponse,
 } from './types';
+
+const isChannelBatchDataUpdateOptions = (
+  update: BatchChannelDataUpdate | ChannelBatchDataUpdateOptions,
+): update is ChannelBatchDataUpdateOptions =>
+  'data' in update || 'custom_set' in update || 'custom_unset' in update;
 
 /**
  * ChannelBatchUpdater - A class that provides convenience methods for batch channel operations
@@ -196,55 +201,33 @@ export class ChannelBatchUpdater {
    * updateData - Update data on channels matching the filter
    *
    * `data.custom` replaces the channel's whole custom object. To patch
-   * individual custom keys alongside other channel data, pass `customPatch`,
-   * which the client sends at the request root rather than inside `data`;
-   * `data` may then be omitted. To send a patch on its own, prefer
-   * `updateCustom`.
+   * individual custom keys, pass an options object with `custom_set` or
+   * `custom_unset`. The client sends those fields at the request root rather
+   * than inside `data`. The options object can also include `data` to update
+   * channel fields in the same request.
    *
    * @param {UpdateChannelsBatchFilters} filter Filter to select channels
-   * @param {BatchChannelDataUpdate} data Data to update
-   * @param {ChannelCustomPatch} customPatch Custom keys to merge in or delete
+   * @param {BatchChannelDataUpdate | ChannelBatchDataUpdateOptions} update Data or update options
    * @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
    */
   async updateData(
     filter: UpdateChannelsBatchFilters,
-    data?: BatchChannelDataUpdate,
-    customPatch?: ChannelCustomPatch,
-  ): Promise<APIResponse & UpdateChannelsBatchResponse> {
-    return await this.client.updateChannelsBatch({
-      operation: 'updateData',
-      filter,
-      data,
-      ...customPatch,
-    });
-  }
-
-  /**
-   * updateCustom - Patch individual custom keys on channels matching the filter
-   *
-   * `customSet` merges its keys into each matched channel's existing custom
-   * object and `customUnset` deletes its keys, both leaving every other custom
-   * key untouched — unlike `data.custom`, which replaces the whole object. Keys
-   * are dot-paths. No `data` is sent, so nothing but the named custom keys
-   * changes; to update other channel data in the same call, use `updateData`.
-   *
-   * The backend owns the rules for the combinations it rejects.
-   *
-   * @param {UpdateChannelsBatchFilters} filter Filter to select channels
-   * @param {Record<string, unknown>} customSet Custom keys to merge in
-   * @param {string[]} customUnset Custom keys to delete
-   * @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
-   */
-  async updateCustom(
+    data: BatchChannelDataUpdate,
+  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
+  async updateData(
     filter: UpdateChannelsBatchFilters,
-    customSet?: Record<string, unknown>,
-    customUnset?: string[],
+    options: ChannelBatchDataUpdateOptions,
+  ): Promise<APIResponse & UpdateChannelsBatchResponse>;
+  async updateData(
+    filter: UpdateChannelsBatchFilters,
+    update: BatchChannelDataUpdate | ChannelBatchDataUpdateOptions,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
+    const options = isChannelBatchDataUpdateOptions(update) ? update : { data: update };
+
     return await this.client.updateChannelsBatch({
       operation: 'updateData',
       filter,
-      custom_set: customSet,
-      custom_unset: customUnset,
+      ...options,
     });
   }
 }

--- a/src/channel_batch_updater.ts
+++ b/src/channel_batch_updater.ts
@@ -2,9 +2,9 @@ import type { StreamChat } from './client';
 import type {
   APIResponse,
   BatchChannelDataUpdate,
+  ChannelCustomPatch,
   NewMemberPayload,
   UpdateChannelsBatchFilters,
-  UpdateChannelsBatchOptions,
   UpdateChannelsBatchResponse,
 } from './types';
 
@@ -196,25 +196,55 @@ export class ChannelBatchUpdater {
    * updateData - Update data on channels matching the filter
    *
    * `data.custom` replaces the channel's whole custom object. To patch
-   * individual custom keys instead, pass `custom_set` / `custom_unset`, which
-   * the client sends at the request root rather than inside `data`; `data` may
-   * then be omitted.
+   * individual custom keys alongside other channel data, pass `customPatch`,
+   * which the client sends at the request root rather than inside `data`;
+   * `data` may then be omitted. To send a patch on its own, prefer
+   * `updateCustom`.
    *
    * @param {UpdateChannelsBatchFilters} filter Filter to select channels
    * @param {BatchChannelDataUpdate} data Data to update
-   * @param {Pick<UpdateChannelsBatchOptions, 'custom_set' | 'custom_unset'>} customPatch Custom keys to merge in or delete
+   * @param {ChannelCustomPatch} customPatch Custom keys to merge in or delete
    * @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
    */
   async updateData(
     filter: UpdateChannelsBatchFilters,
     data?: BatchChannelDataUpdate,
-    customPatch?: Pick<UpdateChannelsBatchOptions, 'custom_set' | 'custom_unset'>,
+    customPatch?: ChannelCustomPatch,
   ): Promise<APIResponse & UpdateChannelsBatchResponse> {
     return await this.client.updateChannelsBatch({
       operation: 'updateData',
       filter,
       data,
       ...customPatch,
+    });
+  }
+
+  /**
+   * updateCustom - Patch individual custom keys on channels matching the filter
+   *
+   * `customSet` merges its keys into each matched channel's existing custom
+   * object and `customUnset` deletes its keys, both leaving every other custom
+   * key untouched — unlike `data.custom`, which replaces the whole object. Keys
+   * are dot-paths. No `data` is sent, so nothing but the named custom keys
+   * changes; to update other channel data in the same call, use `updateData`.
+   *
+   * The backend owns the rules for the combinations it rejects.
+   *
+   * @param {UpdateChannelsBatchFilters} filter Filter to select channels
+   * @param {Record<string, unknown>} customSet Custom keys to merge in
+   * @param {string[]} customUnset Custom keys to delete
+   * @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
+   */
+  async updateCustom(
+    filter: UpdateChannelsBatchFilters,
+    customSet?: Record<string, unknown>,
+    customUnset?: string[],
+  ): Promise<APIResponse & UpdateChannelsBatchResponse> {
+    return await this.client.updateChannelsBatch({
+      operation: 'updateData',
+      filter,
+      custom_set: customSet,
+      custom_unset: customUnset,
     });
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -5306,6 +5306,10 @@ export class StreamChat {
   /**
    *  Update Channels Batch
    *
+   *  For the `updateData` operation, `data.custom` replaces the channel's whole
+   *  custom object, while the root-level `custom_set` / `custom_unset` patch
+   *  individual keys and leave the rest untouched.
+   *
    *  @param {UpdateChannelsBatchOptions} payload for updating channels in batch
    *  @return {Promise<APIResponse & UpdateChannelsBatchResponse>} The server response
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -4998,6 +4998,25 @@ export type UpdateChannelsBatchOptions = {
   filter: UpdateChannelsBatchFilters;
   members?: string[] | Array<NewMemberPayload>;
   data?: BatchChannelDataUpdate;
+  /**
+   * `updateData` only. Merges these keys into each matched channel's existing
+   * custom object, leaving every other custom key untouched — unlike
+   * `data.custom`, which replaces the whole object. Keys are dot-paths, so
+   * `a.b` sets key `b` inside object `a` (the parent object must already
+   * exist). Cannot be combined with `data.custom`.
+   *
+   * Lives at the request root, not inside `data`.
+   */
+  custom_set?: Record<string, unknown>;
+  /**
+   * `updateData` only. Deletes these keys from each matched channel's existing
+   * custom object, leaving every other custom key untouched. Keys are
+   * dot-paths; deleting a key that does not exist is a no-op. Cannot be
+   * combined with `data.custom`.
+   *
+   * Lives at the request root, not inside `data`.
+   */
+  custom_unset?: string[];
 };
 
 export type UpdateChannelsBatchFilters = QueryFilters<{

--- a/src/types.ts
+++ b/src/types.ts
@@ -5020,13 +5020,13 @@ export type UpdateChannelsBatchOptions = {
 };
 
 /**
- * The `custom_set` / `custom_unset` pair of `UpdateChannelsBatchOptions`, as a
- * value on its own: a patch of individual custom keys to merge in and to
- * delete. See the two fields for their semantics.
+ * Options for {@link ChannelBatchUpdater.updateData}. `custom_set` and
+ * `custom_unset` are sent at the request root, while `data` contains the
+ * channel fields to update.
  */
-export type ChannelCustomPatch = Pick<
+export type ChannelBatchDataUpdateOptions = Pick<
   UpdateChannelsBatchOptions,
-  'custom_set' | 'custom_unset'
+  'data' | 'custom_set' | 'custom_unset'
 >;
 
 export type UpdateChannelsBatchFilters = QueryFilters<{

--- a/src/types.ts
+++ b/src/types.ts
@@ -5019,6 +5019,16 @@ export type UpdateChannelsBatchOptions = {
   custom_unset?: string[];
 };
 
+/**
+ * The `custom_set` / `custom_unset` pair of `UpdateChannelsBatchOptions`, as a
+ * value on its own: a patch of individual custom keys to merge in and to
+ * delete. See the two fields for their semantics.
+ */
+export type ChannelCustomPatch = Pick<
+  UpdateChannelsBatchOptions,
+  'custom_set' | 'custom_unset'
+>;
+
 export type UpdateChannelsBatchFilters = QueryFilters<{
   cids?:
     | RequireOnlyOne<Pick<QueryFilter<string>, '$in' | '$eq'>>

--- a/test/typescript/unit-test.ts
+++ b/test/typescript/unit-test.ts
@@ -88,6 +88,19 @@ const singletonClient2: StreamChat = StreamChat.getInstance(apiKey, {
   timeout: 3000,
 });
 
+const channelBatchUpdater = client.channelBatchUpdater();
+channelBatchUpdater.updateData({}, { frozen: true });
+channelBatchUpdater.updateData({}, { custom_set: { group: 'new' } });
+channelBatchUpdater.updateData(
+  {},
+  {
+    data: { frozen: true },
+    custom_set: { group: 'new' },
+  },
+);
+// @ts-expect-error channel data fields must be nested under data in the options form
+channelBatchUpdater.updateData({}, { frozen: true, custom_set: { group: 'new' } });
+
 const devToken: string = client.devToken('joshua');
 const token: string = client.createToken('james', 3600);
 const authType: string = client.getAuthType();

--- a/test/unit/channel_batch_update.test.ts
+++ b/test/unit/channel_batch_update.test.ts
@@ -107,4 +107,21 @@ describe('updateChannelsBatch', () => {
       custom_unset: ['location_id'],
     });
   });
+
+  it('does not let update options override the operation or filter', async () => {
+    const filter = { cids: { $eq: 'messaging:a' } } as const;
+    const options = {
+      operation: 'hide' as const,
+      filter: { cids: { $eq: 'messaging:b' } } as const,
+      data: { frozen: true },
+    };
+
+    await client.channelBatchUpdater().updateData(filter, options);
+
+    expect(putSpy).toHaveBeenCalledWith(`${client.baseURL}/channels/batch`, {
+      operation: 'updateData',
+      filter,
+      data: { frozen: true },
+    });
+  });
 });

--- a/test/unit/channel_batch_update.test.ts
+++ b/test/unit/channel_batch_update.test.ts
@@ -75,4 +75,42 @@ describe('updateChannelsBatch', () => {
     expect(body.custom_unset).toEqual(['location_id']);
     expect(body.data).toBeUndefined();
   });
+
+  it('sends only a custom patch from channelBatchUpdater().updateCustom', async () => {
+    await client
+      .channelBatchUpdater()
+      .updateCustom(
+        { cids: { $in: ['messaging:a', 'messaging:b'] } },
+        { group: 'new', 'expiration.value': 3 },
+        ['location_id'],
+      );
+
+    expect(putSpy).toHaveBeenCalledWith(`${client.baseURL}/channels/batch`, {
+      operation: 'updateData',
+      filter: { cids: { $in: ['messaging:a', 'messaging:b'] } },
+      custom_set: { group: 'new', 'expiration.value': 3 },
+      custom_unset: ['location_id'],
+    });
+
+    // Both fields are siblings of `operation` and `filter`, and no `data` key
+    // is sent at all — a `data.custom` next to a patch is a 400, and `data` is
+    // the extra-fields sink that would swallow a misplaced `custom_set`.
+    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
+    expect(Object.keys(body)).toContain('custom_set');
+    expect(Object.keys(body)).toContain('custom_unset');
+    expect(Object.keys(body)).not.toContain('data');
+  });
+
+  it('sends updateCustom with only the keys it was given', async () => {
+    await client
+      .channelBatchUpdater()
+      .updateCustom({ types: { $eq: 'messaging' } }, { group: 'new' });
+
+    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
+    expect(body.operation).toBe('updateData');
+    expect(body.filter).toEqual({ types: { $eq: 'messaging' } });
+    expect(body.custom_set).toEqual({ group: 'new' });
+    expect(body.custom_unset).toBeUndefined();
+    expect(Object.keys(body)).not.toContain('data');
+  });
 });

--- a/test/unit/channel_batch_update.test.ts
+++ b/test/unit/channel_batch_update.test.ts
@@ -61,56 +61,50 @@ describe('updateChannelsBatch', () => {
     expect(body).not.toHaveProperty('custom_unset');
   });
 
-  it('forwards a custom patch from channelBatchUpdater().updateData to the root', async () => {
+  it('keeps the existing channelBatchUpdater().updateData data argument', async () => {
     await client
       .channelBatchUpdater()
-      .updateData({ cids: { $eq: 'messaging:a' } }, undefined, {
+      .updateData({ cids: { $eq: 'messaging:a' } }, { frozen: true });
+
+    expect(putSpy).toHaveBeenCalledWith(`${client.baseURL}/channels/batch`, {
+      operation: 'updateData',
+      filter: { cids: { $eq: 'messaging:a' } },
+      data: { frozen: true },
+    });
+  });
+
+  it('forwards a custom patch from channelBatchUpdater().updateData to the root', async () => {
+    await client.channelBatchUpdater().updateData(
+      { cids: { $eq: 'messaging:a' } },
+      {
         custom_set: { group: 'new' },
         custom_unset: ['location_id'],
-      });
+      },
+    );
 
     const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
     expect(body.operation).toBe('updateData');
     expect(body.custom_set).toEqual({ group: 'new' });
     expect(body.custom_unset).toEqual(['location_id']);
-    expect(body.data).toBeUndefined();
+    expect(body).not.toHaveProperty('data');
   });
 
-  it('sends only a custom patch from channelBatchUpdater().updateCustom', async () => {
-    await client
-      .channelBatchUpdater()
-      .updateCustom(
-        { cids: { $in: ['messaging:a', 'messaging:b'] } },
-        { group: 'new', 'expiration.value': 3 },
-        ['location_id'],
-      );
+  it('updates channel data and custom fields in one updateData call', async () => {
+    await client.channelBatchUpdater().updateData(
+      { cids: { $in: ['messaging:a', 'messaging:b'] } },
+      {
+        data: { frozen: true },
+        custom_set: { group: 'new', 'expiration.value': 3 },
+        custom_unset: ['location_id'],
+      },
+    );
 
     expect(putSpy).toHaveBeenCalledWith(`${client.baseURL}/channels/batch`, {
       operation: 'updateData',
       filter: { cids: { $in: ['messaging:a', 'messaging:b'] } },
+      data: { frozen: true },
       custom_set: { group: 'new', 'expiration.value': 3 },
       custom_unset: ['location_id'],
     });
-
-    // Both fields are siblings of `operation` and `filter`, and no `data` key
-    // is sent at all — a `data.custom` next to a patch is a 400, and `data` is
-    // the extra-fields sink that would swallow a misplaced `custom_set`.
-    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
-    expect(Object.keys(body)).toContain('custom_set');
-    expect(Object.keys(body)).toContain('custom_unset');
-    expect(Object.keys(body)).not.toContain('data');
-  });
-
-  it('sends updateCustom with only the keys it was given', async () => {
-    await client
-      .channelBatchUpdater()
-      .updateCustom({ types: { $eq: 'messaging' } }, { group: 'new' });
-
-    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
-    expect(body.operation).toBe('updateData');
-    expect(body.filter).toEqual({ types: { $eq: 'messaging' } });
-    expect(body.custom_set).toEqual({ group: 'new' });
-    expect(body.custom_unset).toBeUndefined();
-    expect(Object.keys(body)).not.toContain('data');
   });
 });

--- a/test/unit/channel_batch_update.test.ts
+++ b/test/unit/channel_batch_update.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { StreamChat } from '../../src/client';
+import type {
+  APIResponse,
+  UpdateChannelsBatchOptions,
+  UpdateChannelsBatchResponse,
+} from '../../src/types';
+
+describe('updateChannelsBatch', () => {
+  let client: StreamChat;
+  let putSpy: ReturnType<typeof vi.spyOn>;
+
+  const mockResponse: APIResponse & UpdateChannelsBatchResponse = {
+    duration: '0.01s',
+    result: {},
+    task_id: 'task-id',
+  };
+
+  beforeEach(() => {
+    client = new StreamChat('api_key', 'api_secret');
+    putSpy = vi.spyOn(client, 'put').mockResolvedValue(mockResponse);
+  });
+
+  it('sends custom_set and custom_unset at the request root', async () => {
+    const options: UpdateChannelsBatchOptions = {
+      operation: 'updateData',
+      filter: { cids: { $in: ['messaging:a', 'messaging:b'] } },
+      custom_set: { group: 'old', 'expiration.value': 3 },
+      custom_unset: ['location_id'],
+    };
+
+    await client.updateChannelsBatch(options);
+
+    expect(putSpy).toHaveBeenCalledWith(`${client.baseURL}/channels/batch`, {
+      operation: 'updateData',
+      filter: { cids: { $in: ['messaging:a', 'messaging:b'] } },
+      custom_set: { group: 'old', 'expiration.value': 3 },
+      custom_unset: ['location_id'],
+    });
+
+    // The two fields are siblings of `operation` and `filter`. `data` is an
+    // extra-fields sink on the v1 routes, so a `custom_set` key sent inside it
+    // would mean "replace custom with a key named custom_set" instead.
+    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
+    expect(Object.keys(body)).toContain('custom_set');
+    expect(Object.keys(body)).toContain('custom_unset');
+    expect(body.data).toBeUndefined();
+  });
+
+  it('omits custom_set and custom_unset when they are not provided', async () => {
+    const options: UpdateChannelsBatchOptions = {
+      operation: 'updateData',
+      filter: { types: { $eq: 'messaging' } },
+      data: { frozen: true },
+    };
+
+    await client.updateChannelsBatch(options);
+
+    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
+    expect(body).not.toHaveProperty('custom_set');
+    expect(body).not.toHaveProperty('custom_unset');
+  });
+
+  it('forwards a custom patch from channelBatchUpdater().updateData to the root', async () => {
+    await client
+      .channelBatchUpdater()
+      .updateData({ cids: { $eq: 'messaging:a' } }, undefined, {
+        custom_set: { group: 'new' },
+        custom_unset: ['location_id'],
+      });
+
+    const body = putSpy.mock.calls[0][1] as UpdateChannelsBatchOptions;
+    expect(body.operation).toBe('updateData');
+    expect(body.custom_set).toEqual({ group: 'new' });
+    expect(body.custom_unset).toEqual(['location_id']);
+    expect(body.data).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Ticket

[CHA-3618](https://linear.app/stream/issue/CHA-3618/batch-channel-update-add-support-to-setunset-fields)

## Problem

`PUT /channels/batch` gained two root-level fields in [GetStream/chat#15840](https://github.com/GetStream/chat/pull/15840) (merged 2026-09-01, first released in `v237.13.0`): `custom_set` and `custom_unset`. They patch individual keys of a channel's `custom` object, unlike `data.custom`, which replaces the whole object — and since a channel's display `name` lives inside `custom`, a full replace that omits `name` deletes the channel name. `UpdateChannelsBatchOptions` carries only `operation`, `filter`, `members` and `data`, so this SDK cannot send them.

## Solution

`UpdateChannelsBatchOptions` gets `custom_set?: Record<string, unknown>` (the same value type as `BatchChannelDataUpdate.custom`) and `custom_unset?: string[]`. `custom_set` merges its keys into each matched channel's existing `custom`, `custom_unset` deletes its keys, and every other custom key is left untouched.

Both sit at the **request root**, next to `operation` and `filter`, not inside `data`. That placement is load-bearing: on the v1 routes `data` is decoded through an extra-fields sink, so `data: { custom_set: … }` is already a valid payload today meaning "replace `custom` with a key literally named `custom_set`". The request root has no sink.

`ChannelBatchUpdater` keeps one operation-aligned helper, `updateData`:

- Existing `updateData(filter, data)` calls remain source- and runtime-compatible.
- `updateData(filter, { custom_set, custom_unset })` sends a custom-only patch without an `undefined` placeholder or a `data` key.
- `updateData(filter, { data, custom_set, custom_unset })` combines channel data and custom-key changes in one request.

The exported `ChannelBatchDataUpdateOptions` type names the options-object form. The client normalizes only the legacy form into the root-level request shape; the wire format is unchanged.

Validation stays server-side: the backend owns the rules for which field combinations it rejects (patch together with `data.custom`, a patch on any operation other than `updateData`, the same or overlapping key in both, empty dot-path segments, whitespace in keys — all 400s). The SDK only carries the fields.

## How to verify

1. `yarn vitest run test/unit/channel_batch_update.test.ts` — 5 tests, no API credentials needed. They pin both JSON key names and their placement at the request root, the legacy `updateData(filter, data)` request, the custom-only options form with no `data` key, and the combined form.
2. `yarn types`, `yarn run-types-gen`, `yarn lint`, and `yarn build` pass.
3. Full `yarn vitest run` passes: 80 files, 3151 tests passed, 1 skipped.

