### PR TITLE
fix(i18n): accept a wire timestamp where a date is rendered

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1060,8 +1060,16 @@ export class Channel extends ChannelApi {
     return result;
   }
 
+  /**
+   * Ends an active live-location share.
+   *
+   * `end_at` is owned by this method — it is set to now, overwriting anything the caller passes —
+   * so the parameter omits it. That also lets a caller hand over a location read off a message
+   * (`SharedLocationResponseData`), whose own `end_at` is a wire timestamp rather than the `Date`
+   * the request declares.
+   */
   public async stopLiveLocationSharing(
-    payload: UpdateLiveLocationRequest,
+    payload: Omit<UpdateLiveLocationRequest, 'end_at'>,
     requestOptions?: StreamRequestOptions,
   ) {
     const location = await this.getClient().updateLiveLocation(

--- a/src/i18n/formatters.ts
+++ b/src/i18n/formatters.ts
@@ -1,4 +1,5 @@
 import { isDate, isDayOrMoment, isNumberOrString } from './dayjs';
+import { nsToDate } from '../utils/time';
 import type { CalendarFormats } from './dayjs';
 import { asDynamicKey } from './translator';
 import type {
@@ -250,9 +251,24 @@ export const predefinedFormatters: PredefinedFormatters = {
  * getDateString
  * ---------------------------------------------------------------------------------------------- */
 
+/**
+ * A timestamp as something the formatters below can parse.
+ *
+ * Server-sent date fields are unix-NANOSECOND numbers, and every path here ends in `new Date(...)`
+ * or a dayjs-like parser — both of which read a bare number as MILLISECONDS and land far out of
+ * range (`.toISOString()` throws, dayjs renders `'Invalid Date'`). Converting once, here, is what
+ * lets a caller pass a message's `created_at` straight through.
+ */
+const normalizeTimestamp = <T extends string | Date | number | undefined>(
+  timestamp: T,
+): Exclude<T, number> | Date =>
+  (typeof timestamp === 'number' ? nsToDate(timestamp) : timestamp) as
+    | Exclude<T, number>
+    | Date;
+
 export type GetDateStringParams = TimestampFormatterOptions & {
-  /** The timestamp to render. */
-  messageCreatedAt?: string | Date;
+  /** The timestamp to render. Accepts a wire timestamp (unix nanoseconds) as well as a `Date`. */
+  messageCreatedAt?: string | Date | number;
   /** An integrator-supplied override, which wins over everything else. */
   formatDate?: (date: Date) => string;
   /** The key carrying a formatter expression for this timestamp, if there is one. */
@@ -274,7 +290,7 @@ export const getDateString = ({
   calendarFormats,
   format,
   formatDate,
-  messageCreatedAt,
+  messageCreatedAt: rawMessageCreatedAt,
   relativeCompact,
   relativeCompactMaxDays,
   relativeCompactMaxWeeks,
@@ -283,6 +299,7 @@ export const getDateString = ({
   tDateTimeParser,
   timestampTranslationKey,
 }: GetDateStringParams): string | number | null => {
+  const messageCreatedAt = normalizeTimestamp(rawMessageCreatedAt);
   if (
     !messageCreatedAt ||
     (typeof messageCreatedAt === 'string' && isUnparseableDateString(messageCreatedAt))
@@ -409,7 +426,7 @@ export type GetCalendarDateStringForA11yParams = {
   calendarFormatOverrides?: Partial<CalendarFormats>;
   /** Calendar wording per language. Defaults to {@link A11Y_CALENDAR_FORMATS}. */
   calendarFormats?: Record<string, CalendarFormats>;
-  messageCreatedAt?: string | Date;
+  messageCreatedAt?: string | Date | number;
   tDateTimeParser?: TDateTimeParser;
   /**
    * The UI language, used to pick calendar wording. Plain `string`: it indexes `calendarFormats`, which
@@ -435,10 +452,11 @@ export type GetCalendarDateStringForA11yParams = {
 export const getCalendarDateStringForA11y = ({
   calendarFormatOverrides,
   calendarFormats = A11Y_CALENDAR_FORMATS,
-  messageCreatedAt,
+  messageCreatedAt: rawMessageCreatedAt,
   tDateTimeParser,
   userLanguage,
 }: GetCalendarDateStringForA11yParams): string | undefined => {
+  const messageCreatedAt = normalizeTimestamp(rawMessageCreatedAt);
   if (
     !messageCreatedAt ||
     (typeof messageCreatedAt === 'string' && isUnparseableDateString(messageCreatedAt)) ||


### PR DESCRIPTION
`getDateString` and `getCalendarDateStringForA11y` declared `messageCreatedAt` as `string | Date`, but every server-sent date field is a unix-nanosecond number, so each caller had to convert first. Both now take one directly and normalize once, before any path that ends in `new Date(...)` or a dayjs-like parser — either of which reads a bare number as milliseconds and lands far out of range, rendering `Invalid Date` rather than failing.

Also narrows `stopLiveLocationSharing` to `Omit<UpdateLiveLocationRequest, 'end_at'>`: the method sets `end_at` to now itself, so a caller's value was always discarded, and declaring that lets a location read off a message be passed straight through — its `end_at` is a wire timestamp, not the `Date` the request type wants.

BREAKING CHANGE: `stopLiveLocationSharing` no longer accepts `end_at`. It was overwritten before, so no behaviour changes.