### PR TITLE
fix(paginator): do not issue the first-page query twice

### DIFF
--- a/src/pagination/paginators/BasePaginator.ts
+++ b/src/pagination/paginators/BasePaginator.ts
@@ -2843,6 +2843,20 @@ export abstract class BasePaginator<T, Q> {
 
     if (isFirstPage && !keepPreviousItems) {
       const state = this.getStateBeforeFirstQuery();
+      // Publish the loading flag BEFORE the offline preload is awaited. `canExecuteQuery` gates on
+      // `isLoading`, so anything published after an await leaves a window in which a second call
+      // made in the same tick still reads `false` and proceeds — and on a paginator with no loaded
+      // window both directions resolve to the SAME first page, so the two calls issue byte-identical
+      // requests. A UI that loads both ends at once does exactly that: an empty list sits within the
+      // scroll threshold of its top AND its bottom, so the scroll handler calls `toTail` and `toHead`
+      // one line apart.
+      //
+      // Only the flag: `state` carries `items: undefined`, so publishing all of it here would blank
+      // a list that offline data is about to fill — the reason the full publish waits for the preload.
+      // A forced reset published it (loading included) synchronously above, so it needs nothing.
+      if (!isForcedReset) {
+        this.state.partialNext({ isLoading: true });
+      }
       let items: T[] | undefined = undefined;
       if (!this.isInitialized) {
         items =

--- a/test/unit/pagination/paginators/BasePaginator.test.ts
+++ b/test/unit/pagination/paginators/BasePaginator.test.ts
@@ -296,6 +296,35 @@ describe('BasePaginator', () => {
       expect(paginator.mockClientQuery).toHaveBeenCalledTimes(3);
     });
 
+    it('issues one request when both directions are requested in the same tick', async () => {
+      const paginator = new Paginator({ initialCursor: ZERO_PAGE_CURSOR });
+      // A list with no loaded window sits within the scroll threshold of its top AND its bottom, so
+      // a UI's scroll handler asks for both directions one line apart. With nothing loaded, both
+      // resolve to the same first page — the second must not slip past the `isLoading` gate while
+      // the first is still awaiting its offline preload.
+      const tailward = paginator.toTail();
+      const headward = paginator.toHead();
+
+      // The gate that matters: set synchronously, so the second call is turned away before the
+      // request for the first has even been built.
+      expect(paginator.isLoading).toBe(true);
+
+      // wait for the DB data first page load
+      await sleep(0);
+      expect(paginator.mockClientQuery).toHaveBeenCalledTimes(1);
+
+      paginator.queryResolve({
+        items: [{ id: 'id1' }],
+        tailward: 'next1',
+        headward: 'prev1',
+      });
+      await Promise.all([tailward, headward]);
+
+      expect(paginator.mockClientQuery).toHaveBeenCalledTimes(1);
+      expect(paginator.items).toEqual([{ id: 'id1' }]);
+      expect(paginator.isLoading).toBe(false);
+    });
+
     it('supports legacy next/prev cursor fields from query response', async () => {
       const paginator = new Paginator({ initialCursor: ZERO_PAGE_CURSOR });
 


### PR DESCRIPTION
`canExecuteQuery` gates on `isLoading`, which lives in state — and on the first-page path that flag is published only after the offline-DB preload is awaited. A second call made in the same tick therefore still reads `false` and proceeds, and with no loaded window both directions resolve to the same first page, so the two calls issue byte-identical requests.

A UI does exactly that: an empty or short list sits within the scroll threshold of its top AND its bottom, so the scroll handler calls `toTail` and `toHead` one line apart. Publishing the flag before the await closes the gap. Only the flag — publishing the whole prepared state early would blank a list that offline data is about to fill, which is why that write waits.
