### PR TITLE
fix(paginator): correct windows filled by hydration rather than by a query

### DIFF
--- a/src/pagination/paginators/BasePaginator.ts
+++ b/src/pagination/paginators/BasePaginator.ts
@@ -2569,10 +2569,25 @@ export abstract class BasePaginator<T, Q> {
       return newState;
     });
 
-    // A populated page means a first page is effectively "loaded". Record a query shape so the
-    // paginator counts as initialized and the next pagination continues from this page - otherwise
-    // an undefined `_lastQueryShape` makes the first query look like a shape change, triggering a
-    // first page reset that wipes the seeded items and re-fetches the first page before paginating.
+    this.recordLoadedWindowQueryShape();
+  }
+
+  /**
+   * Records the shape a query would have used to produce the currently loaded window, so the next
+   * pagination counts as a continuation rather than a shape change.
+   *
+   * Server data reaches a window without a query on two paths — a seeded page (`setItems`) and a
+   * hydrate (`mergeNewestPage`). Leaving `_lastQueryShape` undefined afterwards makes the next
+   * query look like a shape change, so `executeQuery` takes its first-page branch and publishes
+   * `getStateBeforeFirstQuery()` (items `undefined`) BEFORE the request. A response with items
+   * rebuilds the window from the surviving intervals, so that case merely churns; an empty one — a
+   * tailward query on a thread whose replies are all loaded — has nothing to rebuild from and the
+   * loaded window is lost.
+   *
+   * Only meaningful with items in hand: an empty window has no shape to continue from, and the
+   * flags already say there is nothing more to fetch.
+   */
+  protected recordLoadedWindowQueryShape() {
     if (
       typeof this._lastQueryShape === 'undefined' &&
       (this.state.getLatestValue().items?.length ?? 0) > 0

--- a/src/pagination/paginators/MessageIntervalPaginator.ts
+++ b/src/pagination/paginators/MessageIntervalPaginator.ts
@@ -719,7 +719,18 @@ export class MessageIntervalPaginator extends BasePaginator<
    * @param page - The fetched newest window (may be empty). `created_at` order is normalized on ingest.
    * @param options - See {@link MergeNewestPageOptions}. Omit to prune only within the page's own span.
    */
+  /**
+   * Merges a freshly fetched newest page into the loaded window (the hydrate path). Wraps the
+   * implementation so the query shape is recorded on EVERY exit — the body returns early in
+   * several places, and a window left without a shape loses itself on the next pagination (see
+   * `recordLoadedWindowQueryShape`).
+   */
   mergeNewestPage = (page: LocalMessage[], options?: MergeNewestPageOptions) => {
+    this._mergeNewestPage(page, options);
+    this.recordLoadedWindowQueryShape();
+  };
+
+  private _mergeNewestPage = (page: LocalMessage[], options?: MergeNewestPageOptions) => {
     const headInterval = this.itemIntervals[0] as Interval | undefined;
     if (!headInterval?.isHead) {
       // Live content no page has anchored yet, the first query came back empty and the reply the

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -593,10 +593,22 @@ export class Thread extends WithSubscriptions {
       this.client.messageStore.upsert(parentMessage);
     }
 
-    this.messagePaginator.mergeNewestPage(
-      thread.messagePaginator.state.getLatestValue().items ?? [],
-      options?.reconcile,
-    );
+    const incomingReplies = thread.messagePaginator.state.getLatestValue().items ?? [];
+
+    if (typeof this.messagePaginator.items === 'undefined') {
+      // Nothing loaded yet — the common case for a thread opened from a message, whose paginator
+      // has never held a window. `mergeNewestPage` deliberately no-ops there (it merges into an
+      // anchored head and leaves seeding to the query path), so hydrating through it would drop the
+      // replies this request just fetched and leave the panel empty until something else queried
+      // them. Seed instead, exactly as the constructor does for a thread response's `latest_replies`.
+      this.messagePaginator.setItems({
+        valueOrFactory: incomingReplies,
+        isFirstPage: true,
+        isLastPage: incomingReplies.length === replyCount,
+      });
+    } else {
+      this.messagePaginator.mergeNewestPage(incomingReplies, options?.reconcile);
+    }
     pendingReplies.forEach((reply) => this.messagePaginator.ingestItem(reply));
     // Carry the re-queried thread's last-activity floor so lastMessageAt stays fresh even when the
     // merged page does not include the newest reply. Monotonic, so an older value is a no-op.

--- a/test/unit/pagination/paginators/MessagePaginator.test.ts
+++ b/test/unit/pagination/paginators/MessagePaginator.test.ts
@@ -1938,6 +1938,58 @@ describe('MessagePaginator', () => {
       return { paginator, m1, m2, m3 };
     };
 
+    it('continues pagination after a hydrate instead of re-fetching the first page', async () => {
+      // `Thread.reload()` hydrates through `mergeNewestPage`, which records no query shape. The
+      // next `toTail()` therefore reads `_lastQueryShape === undefined`, and
+      // `shouldResetStateBeforeQuery` treats an undefined previous shape as a shape CHANGE — so the
+      // continuation is classified as a first page: the loaded window is blanked and page one is
+      // fetched again. Scrolling up in a freshly opened thread should paginate, not reload.
+      const { paginator, m1 } = setupLoadedHead({ isTail: false });
+      const m4 = m('m4', '04');
+      paginator.mergeNewestPage([m1, m('m2', '02'), m('m3', '03'), m4]);
+      // The older page the scroll asks for.
+      (channel.getReplies as ReturnType<typeof vi.fn>).mockResolvedValue({
+        messages: [
+          m('m0', '01', {
+            created_at: convertDateToTimestamp('2019-12-31T00:00:00.000Z'),
+          }),
+        ],
+      });
+
+      await paginator.toTail();
+
+      // The request itself is a correct continuation — older than the oldest loaded reply...
+      expect(channel.getReplies).toHaveBeenCalledWith(
+        expect.objectContaining({ id_lt: m1.id, parent_id: 'parent-1' }),
+      );
+      // ...but the page must be PREPENDED to the hydrated window, not replace it.
+      expect(paginator.items?.map((message) => message.id)).toEqual([
+        'm0',
+        'm1',
+        'm2',
+        'm3',
+        'm4',
+      ]);
+    });
+
+    it('keeps the hydrated window when the older page comes back empty', async () => {
+      // Scrolling to the top of a thread whose replies are all loaded: the tailward query returns
+      // nothing, which means "no older replies", not "no replies". The hydrate recorded no query
+      // shape, so `isFirstPageQuery` classifies this continuation as a first page and publishes
+      // `getStateBeforeFirstQuery()` (items undefined) before the request — with nothing in the
+      // response to rebuild from, the loaded window is lost.
+      const { paginator, m1 } = setupLoadedHead({ isTail: false });
+      paginator.mergeNewestPage([m1, m('m2', '02'), m('m3', '03')]);
+      (channel.getReplies as ReturnType<typeof vi.fn>).mockResolvedValue({
+        messages: [],
+      });
+
+      await paginator.toTail();
+
+      expect(paginator.items?.map((message) => message.id)).toEqual(['m1', 'm2', 'm3']);
+      expect(paginator.hasMoreTail).toBe(false);
+    });
+
     it('reconciles in-place edits and appends new messages without a query', () => {
       const { paginator, m1, m2 } = setupLoadedHead({ isTail: true });
       // While offline: m3 was edited and m4/m5 arrived; the hydrated newest window carries both.

--- a/test/unit/threads.test.ts
+++ b/test/unit/threads.test.ts
@@ -411,6 +411,35 @@ describe('Threads 2.0', () => {
           expect(() => thread.hydrateState(otherThread)).to.throw();
         });
 
+        it('seeds the reply window when the thread has never loaded one', () => {
+          // A thread opened from a message (channel + parentMessage, no server payload) has never
+          // held a reply window. `mergeNewestPage` deliberately no-ops in that state — it merges
+          // into an anchored head and leaves seeding to the query path — so hydrating through it
+          // dropped the replies `Thread.reload()` had just fetched, and the panel stayed empty
+          // until something else queried them separately.
+          const thread = createMinimalThread();
+          expect(thread.messagePaginator.state.getLatestValue().items).to.be.undefined;
+
+          const reply = generateMsg({
+            parent_id: parentMessageResponse.id,
+            created_at: convertDateToTimestamp('2020-01-01T00:00:00.000Z'),
+          }) as MessageResponse;
+          const hydrationThread = createTestThread({
+            latest_replies: [reply],
+            // The count that matters is the parent message's — the thread endpoint's top-level
+            // `reply_count` excludes soft-deleted replies, so the LLC reads the parent's.
+            parentMessageOverrides: { reply_count: 1 },
+            reply_count: 1,
+          });
+
+          thread.hydrateState(hydrationThread);
+
+          const paginatorState = thread.messagePaginator.state.getLatestValue();
+          expect(paginatorState.items?.map((item) => item.id)).to.deep.equal([reply.id]);
+          // Every reply is in hand, so there is nothing older to fetch.
+          expect(paginatorState.hasMoreTail).to.be.false;
+        });
+
         it('copies state of the instance with the same id', () => {
           const thread = createTestThread();
           const hydrationThread = createTestThread();


### PR DESCRIPTION
## Description

Two defects with one root cause: a paginator window can be filled either by a query or by hydration (`setItems`, `mergeNewestPage`), and the second path was mishandled in two different ways. Thread replies hit both, because `Thread.reload()` — the only public method that fetches replies — hydrates.

### 1. The first hydrate dropped its replies

A thread built from a message (rather than from `queryThreads`) has never held a reply window. `Thread.reload()` fetches replies via `GET /threads/:id?reply_limit=50` and hands them to `mergeNewestPage`, which deliberately no-ops in that state — it merges a newest page into an anchored head and leaves seeding to the query path:

```ts
if (!logicalHead || hasAnchoredHead || !page?.length) return;
```

So the replies arrived and were discarded, leaving `items` `undefined`.

This went unnoticed because the message list separately issued `GET /messages/:id/replies`, which seeded the window through `postQueryReconcile`. The thread request looked redundant while the reply request was the one doing the work. It surfaced when the React SDK suppressed that second request.

**Fix:** `hydrateState` seeds when there is no window and merges when there is, reusing the `setItems` call the constructor already makes for a thread response's `latest_replies`. Completeness is judged against the parent message's `reply_count` (which includes soft-deleted replies) rather than the payload's top-level count (which does not).

### 2. A hydrated window lost itself on the next pagination

`setItems` records the query shape its window corresponds to; `mergeNewestPage` did not. With `_lastQueryShape` left undefined, `shouldResetStateBeforeQuery` reads the next pagination as a shape *change* rather than a continuation, so `executeQuery` takes its first-page branch and publishes `getStateBeforeFirstQuery()` — `items: undefined` — before issuing the request.

A response carrying items rebuilds the window from the surviving intervals, so that case only churns. An empty response has nothing to rebuild from: scrolling to the top of a thread whose replies are all loaded emptied the list.

**Fix:** the shape recording in `setItems` is extracted to `recordLoadedWindowQueryShape()` and called from the hydrate path too. `mergeNewestPage` returns early in several places, so the public method is now a wrapper around the implementation and records on every exit.

## Scope

Not thread-specific. Any window filled by hydration is affected — a channel's messages restored after reconnect, then scrolled to the first message, hits defect 2 by the same mechanism. Threads are simply where both were found.

## Tests

- `threads.test.ts` — hydrating a thread built from `channel + parentMessage` seeds the replies and reports nothing older to fetch. Fails without the fix.
- `MessagePaginator.test.ts` — a hydrated window survives a continuation that returns no items. Fails without the fix.
- `MessagePaginator.test.ts` — a hydrated window paginates correctly when the continuation *does* return items. Passes before and after; included so the half that already worked can't be broken while fixing the other.

Full unit suite passes.

## Note for the React SDK

`stream-chat-react` has a companion change that stops the message list issuing `GET /messages/:id/replies` on thread open. That change depends on this one: without the seeding fix, suppressing the reply query leaves the thread panel empty. This should land and release first.