### PR TITLE
fix: keep query methods from hanging when a connection is closed during connect

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -393,6 +393,10 @@ export class StreamChat {
   wsConnection: StableWSConnection | null;
   wsFallback?: WSConnectionFallback;
   wsPromise: ConnectAPIResponse | null;
+  private _wsPromiseSettled = true;
+  private _wsConnectId = 0;
+  private _resolveWsPromise?: (value: Awaited<ConnectAPIResponse>) => void;
+  private _rejectWsPromise?: (reason?: unknown) => void;
   consecutiveFailures: number;
   insightMetrics: InsightMetrics;
   defaultWSTimeoutWithFallback: number;
@@ -852,9 +856,42 @@ export class StreamChat {
     }
 
     this.clientID = `${this.userID}--${randomId()}`;
-    this.wsPromise = this.connect();
+    this.wsPromise = this._bindWsPromise(this.connect());
     this._startCleaning();
     return this.wsPromise;
+  };
+
+  /**
+   * Keep a single pending `wsPromise` across close/reopen so callers that already
+   * `await this.wsPromise` are not stranded when `openConnection` starts a new connect.
+   */
+  private _bindWsPromise = (connectPromise: ConnectAPIResponse): ConnectAPIResponse => {
+    const connectId = ++this._wsConnectId;
+
+    let pending = this.wsPromise;
+    if (this._wsPromiseSettled || !pending) {
+      this._wsPromiseSettled = false;
+      pending = new Promise((resolve, reject) => {
+        this._resolveWsPromise = resolve;
+        this._rejectWsPromise = reject;
+      });
+      this.wsPromise = pending;
+    }
+
+    connectPromise.then(
+      (value) => {
+        if (connectId !== this._wsConnectId) return;
+        this._wsPromiseSettled = true;
+        this._resolveWsPromise?.(value);
+      },
+      (error) => {
+        if (connectId !== this._wsConnectId) return;
+        this._wsPromiseSettled = true;
+        this._rejectWsPromise?.(error);
+      },
+    );
+
+    return pending;
   };
 
   /**

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -265,6 +265,84 @@ describe('Client openConnection', () => {
 	});
 });
 
+describe('Client wsPromise close/reopen race', () => {
+	const timeout = (ms) =>
+		new Promise((resolve) => setTimeout(() => resolve('timeout'), ms));
+
+	const createClientWithHangingConnect = () => {
+		const connectResolvers = [];
+		const wsConnection = new StableWSConnection({});
+		wsConnection.isConnecting = false;
+		wsConnection.isHealthy = false;
+		wsConnection.disconnect = function () {
+			this.isConnecting = false;
+			this.isHealthy = false;
+			return Promise.resolve();
+		};
+		wsConnection.connect = function () {
+			this.isConnecting = true;
+			return new Promise((resolve) => {
+				connectResolvers.push((connection) => {
+					this.isConnecting = false;
+					this.isHealthy = true;
+					this.connectionID = connection.connection_id;
+					resolve(connection);
+				});
+			});
+		};
+
+		const client = new StreamChat('key', {
+			allowServerSideConnect: true,
+			wsConnection,
+		});
+		client.userID = 'user';
+		client._setUser({ id: 'user' });
+
+		return { client, connectResolvers };
+	};
+
+	it('should resolve queryChannels after closeConnection and openConnection during connect', async () => {
+		const { client, connectResolvers } = createClientWithHangingConnect();
+		const postStub = sinon.stub(client, 'post').resolves({ channels: [] });
+
+		client.openConnection();
+		const queryPromise = client.queryChannels().then(() => 'resolved');
+
+		await client.closeConnection();
+		client.openConnection();
+
+		expect(connectResolvers.length).to.equal(2);
+		connectResolvers[1]({ connection_id: 'conn-2' });
+
+		const outcome = await Promise.race([queryPromise, timeout(200)]);
+		expect(outcome).to.equal('resolved');
+		expect(postStub.calledOnce).to.be.true;
+
+		await client.closeConnection();
+		postStub.restore();
+	});
+
+	it('should reject queryChannels when connect is closed and the next connect fails', async () => {
+		const { client } = createClientWithHangingConnect();
+
+		client.openConnection();
+		const queryPromise = client.queryChannels().then(
+			() => 'resolved',
+			(error) => error.message,
+		);
+
+		await client.closeConnection();
+		client.wsConnection.connect = function () {
+			this.isConnecting = true;
+			return Promise.reject(new Error('connect failed'));
+		};
+		client.openConnection();
+
+		const outcome = await Promise.race([queryPromise, timeout(200)]);
+		expect(outcome).to.equal('connect failed');
+	});
+});
+
 describe('Client connectUser', () => {
 	let client;
 	beforeEach(() => {


### PR DESCRIPTION
## CLA

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] Code changes are tested

## Description of the changes, What, Why and How?

`openConnection` now binds each `connect()` attempt to a single pending `wsPromise`. If a previous connect has not settled, waiters keep that same promise. The latest connect is the one that resolves or rejects it. This is the behaviour the reporter asked for: keep waiting for an active connection rather than rejecting on close, without changing the public `wsPromise` field.

Fixes #1122.

`queryChannels`, `queryUsers`, `search`, `queryReactions`, and the channel `watch` / `query` / `search` paths all `await this.wsPromise` so they do not hit the API before the websocket handshake finishes. If `closeConnection()` ran during that handshake (React Native backgrounding is the reported case) and `openConnection()` later started a new connect, the original `wsPromise` was replaced. Callers still awaiting the old promise never settled, even after the new connection was healthy.

The handshake itself also never settles on close: `StableWSConnection.disconnect()` increments `wsID` before the socket closes, so `onclose` does not reject `connectionOpen`, and `_connect()` waits on that promise with no timeout. This change does not alter that internal handshake.

`connectAnonymousUser()` uses the same `openConnection` path.

`_bindWsPromise` reuses an unsettled `wsPromise` and ignores stale connect generations. Existing `await this.wsPromise` sites (client and channel) do not need to change.

The alternative to reusing the pending promise is the getter on `wsPromise` proposed on the issue, which constructs a new promise and resolves on `connection.changed` with `online: true`. A getter would break `if (!this.wsPromise)` in `userMuteStatus`, change the value `connectUser` / `openConnection` return, and break tests that assign `client.wsPromise = Promise.resolve()`. Reusing the pending promise is the same pattern `openConnection` already uses when `isConnecting` is true, extended across close/reopen.

Fine to switch to the getter if that public shape is preferred.

## Changelog

- Fix a race where `queryChannels` / `queryUsers` / `search` (and other `await this.wsPromise` callers) hung forever if the websocket was closed during connect and then reopened
